### PR TITLE
Enable building apps with in-browser DWNs and Web5.connect()

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tbd54566975/web5",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "SDK for accessing the features and capabilities of Web5",
   "type": "module",
   "main": "./dist/cjs/index.js",

--- a/src/connect.js
+++ b/src/connect.js
@@ -38,11 +38,6 @@ async function triggerProtocolHandler(url) {
   document.body.append(form);
   form.submit();
   form.remove();
-
-  // var iframe = document.createElement('iframe');
-  //     iframe.src = url;
-  //     document.body.appendChild(iframe);
-  //     setTimeout(() => iframe.remove(), 10);
 }
 
 async function decodePin(result, secretKey) {
@@ -96,7 +91,7 @@ async function connect(options = {}) {
     let json;
     try {
       json = JSON.parse(event.data);
-    } catch { }
+    } catch (e) { console.log(e); }
 
     switch (json?.type) {
     case 'connected':

--- a/src/connect.js
+++ b/src/connect.js
@@ -58,6 +58,7 @@ async function connect(options = {}) {
   let connection = getConnection();
   if (connection) {
     options?.onConnected?.(connection);
+    // Register DID on reconnection
     register({
       connected: true,
       did: connection.did,
@@ -102,6 +103,12 @@ async function connect(options = {}) {
       }
 
       localStorage.setItem('web5_connect', JSON.stringify(json.data));
+      // Register DID on initial connection
+      register({
+        connected: true,
+        did: json.data.did,
+        endpoint: `http://localhost:${json.data.port}/dwn`,
+      });
       options?.onConnected?.(json.data);
       break;
 

--- a/src/main.js
+++ b/src/main.js
@@ -3,6 +3,7 @@ import { DWeb, DWebNodeSDK, transports } from './dweb';
 import { connect } from './connect';
 
 const Web5 = {
+  connect: connect,
   did: DID,
   protocols: DWeb.protocols,
   records: DWeb.records,
@@ -11,7 +12,6 @@ const Web5 = {
 };
 
 export {
-  connect,
   DWebNodeSDK,
   Web5,
   DWeb

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,30 +1,25 @@
 import * as SDK from '@tbd54566975/dwn-sdk-js';
 
 /**
- * Set/detect the media type, encode the data, and return as a Blob.
+ * Set/detect the media type and return the data as bytes.
  */
-const encodeData = (data, dataFormat) => {
+const dataToBytes = (data, dataFormat) => {
   let dataBytes = data;
 
-  // Format was not provided so check for Object or String, and if neither, assume blob of raw data.
-  if (!dataFormat) {
-    const detectedType = toType(data);
-    if (detectedType === 'string') {
-      dataFormat = 'text/plain';
-      dataBytes = SDK.Encoder.stringToBytes(data);
-    }
-    else if (detectedType === 'object') {
-      dataFormat = 'application/json';
-      dataBytes = SDK.Encoder.objectToBytes(data);
-    } else {
-      dataFormat = 'application/octet-stream';
-    }
+  // Check for Object or String, and if neither, assume bytes.
+  const detectedType = toType(data);
+  if ((dataFormat === 'text/plain') || (detectedType === 'string')) {
+    dataFormat = 'text/plain';
+    dataBytes = SDK.Encoder.stringToBytes(data);
+  }
+  else if ((dataFormat === 'application/json') || (detectedType === 'object')) {
+    dataFormat = 'application/json';
+    dataBytes = SDK.Encoder.objectToBytes(data);
+  } else if (!dataFormat) {
+    dataFormat = 'application/octet-stream';
   }
 
-  // All data encapsulated in a Blob object that can be transported to a remote DWN and converted into a ReadableStream.
-  const encodedData = new Blob([dataBytes], { type: dataFormat });
-
-  return { encodedData, dataFormat };
+  return { dataBytes, dataFormat };
 };
 
 function memoryCache(options = {}) {
@@ -62,6 +57,6 @@ const toType = (obj) => {
 };
 
 export {
-  encodeData,
+  dataToBytes,
   memoryCache
 };

--- a/test-site/index.html
+++ b/test-site/index.html
@@ -208,7 +208,7 @@
 
 <script type="module">
 
-  import { connect, Web5 } from './browser.mjs';
+  import { Web5 } from './browser.mjs';
 
   window.Web5 = Web5;
   let myDid = '';
@@ -217,7 +217,7 @@
 
     event.preventDefault();
 
-    connect({
+    Web5.connect({
       onRequest(response) {
         security_code.textContent = response.pin;
       },

--- a/tests/utils.spec.js
+++ b/tests/utils.spec.js
@@ -3,11 +3,29 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 
 describe('Utils Tests', () => {
-  describe('encodeData', () => {
+  describe('dataToBytes', () => {
     it('sets dataFormat to text/plain if string is provided', () => {
-      const { dataFormat } = utils.encodeData('hello');
+      const { dataFormat } = utils.dataToBytes('hello');
 
       expect(dataFormat).to.equal('text/plain');
+    });
+
+    it('sets dataFormat to application/json if object is provided', () => {
+      const { dataFormat } = utils.dataToBytes({ hello: 'world' });
+
+      expect(dataFormat).to.equal('application/json');
+    });
+
+    it('sets dataFormat to `application/octet-stream` if data is not string or object and dataFormat not specified', () => {
+      const { dataFormat } = utils.dataToBytes(new Uint8Array([10, 11, 12]));
+
+      expect(dataFormat).to.equal('application/octet-stream');
+    });
+
+    it('does not change dataFormat if specified', () => {
+      const { dataFormat } = utils.dataToBytes(new Uint8Array([10, 11, 12]), 'image/png');
+
+      expect(dataFormat).to.equal('image/png');
     });
   });
 


### PR DESCRIPTION
**Features**
- Enable building apps with in-browser DWNs
  - Convert RecordsWrite string/object data to bytes before further processing
  - Remove now redundant data to bytes encoding in HTTP/S transport
  - Change `encodeData()` to `dataToBytes()` and change functionality to support before remote and in-memory DWNs

**Refactoring**
- `connect()` becomes `Web5.connect()`

**Bugs/Docs**
- Fix bug in `src/connect.js` that didn't register the DID after the initial connection.
- Fix code causing linter to fail in `src/connect.js`