### PR TITLE
Adds feature to enable transporting messages to one or more remote DWN endpoints

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tbd54566975/web5",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@tbd54566975/web5",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@decentralized-identity/ion-tools": "1.0.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tbd54566975/web5",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "SDK for accessing the features and capabilities of Web5",
   "type": "module",
   "main": "./dist/cjs/index.js",

--- a/src/transport/HTTPTransport.js
+++ b/src/transport/HTTPTransport.js
@@ -1,6 +1,20 @@
+import crossFetch from 'cross-fetch';
 import { Encoder } from '@tbd54566975/dwn-sdk-js';
 
 import { Transport } from './Transport.js';
+
+/**
+ * Supports fetch in: browser, browser extensions, Node, and React Native.
+ * In node, it uses node-fetch, and in a browser or React Native, it uses
+ * Github's whatwg-fetch.
+ * 
+ * WARNING for browser extension background service workers:
+ * 'cross-fetch' is a ponyfill that uses `XMLHTTPRequest` under the hood.
+ * `XMLHTTPRequest` cannot be used in browser extension background service
+ * workers.  Browser extensions get even more strict with `fetch` in that it
+ * cannot be referenced indirectly.
+ */
+const fetch = globalThis.fetch ?? crossFetch;
 
 class HTTPTransport extends Transport {
   ENCODED_MESSAGE_HEADER = 'DWN-MESSAGE';
@@ -27,7 +41,14 @@ class HTTPTransport extends Transport {
         'Content-Type': 'application/octet-stream',
       },
       body: request.data,
-    });
+    })
+      .then((response) => {
+        // Only resolve if response was successful (status of 200-299)
+        if (response.ok) { 
+          return response;
+        }
+        return Promise.reject(response); 
+      });
   }
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -83,40 +83,6 @@ async function triggerProtocolHandler(url) {
   form.remove();
 }
 
-/**
- * Runs promise-returning and async functions in series until the first one fulfills or all reject
- * 
- * Returns a Promise that is fulfilled when the first Promise is fulfilled or rejects if all of the
- * Promises reject. Rather than stopping when a Promise rejects, the next Promise in the input array
- * is executed. This continues until a Promise fulfills or the end of the array is reached.
- * 
- * This execution strategy is used for specific cases like attempting to write large data streams to
- * the DWN endpoints listed in a DID document. It would be inefficient to attempt to write data to
- * multiple endpoints in parallel until the first one completes. Instead, we only try the next DWN if
- * there is a failure.  Additionally, per the DWN Specification, implementers SHOULD select from the
- * Service Endpoint URIs in the nodes array in index order, so this function makes that approach easy.
- * 
- * @param {[Promise]} tasks
- * @returns Promise<any>
- */
-function promiseSeriesAny(tasks) {
-  let index = 0;
-
-  function tryNextTask() {
-    if (index >= tasks.length) {
-      return Promise.reject(new Error('All promises rejected.'));
-    }
-
-    const task = tasks[index++];
-
-    return task()
-      .then(result => { return result; })
-      .catch(_ => { return tryNextTask(); });
-  }
-
-  return tryNextTask();
-}
-
 async function decodePin(data, secretKey) {
   const { pin, nonce, publicKey } = data;
   const encryptedPinBytes = Encoder.base64UrlToBytes(pin);
@@ -133,6 +99,5 @@ export {
   isUnsignedMessage,
   parseJSON,
   parseURL,
-  promiseSeriesAny,
   triggerProtocolHandler,
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -52,6 +52,20 @@ const dataToBytes = (data, dataFormat) => {
 };
 
 /**
+ * Simplistic initial implementation to check whether messages that are being routed
+ * to process locally or be transported to a remote DWN are already signed.
+ * 
+ * TODO: Consider whether cryptographic signature verification is warranted or if
+ *       the naive check is sufficient given that DWNs already verify authenticity
+ *       and integrity of every message.
+ * @param {{}} message 
+ * @returns boolean
+ */
+function isUnsignedMessage(message) {
+  return message?.message?.authorization ? false : true;
+}
+
+/**
  * Credit for toType() function:
  *   Angus Croll
  *   https://github.com/angus-c
@@ -82,6 +96,7 @@ export {
   createWeakSingletonAccessor,
   dataToBytes,
   decodePin,
+  isUnsignedMessage,
   parseJSON,
   parseURL,
   triggerProtocolHandler,

--- a/src/utils.js
+++ b/src/utils.js
@@ -83,6 +83,40 @@ async function triggerProtocolHandler(url) {
   form.remove();
 }
 
+/**
+ * Runs promise-returning and async functions in series until the first one fulfills or all reject
+ * 
+ * Returns a Promise that is fulfilled when the first Promise is fulfilled or rejects if all of the
+ * Promises reject. Rather than stopping when a Promise rejects, the next Promise in the input array
+ * is executed. This continues until a Promise fulfills or the end of the array is reached.
+ * 
+ * This execution strategy is used for specific cases like attempting to write large data streams to
+ * the DWN endpoints listed in a DID document. It would be inefficient to attempt to write data to
+ * multiple endpoints in parallel until the first one completes. Instead, we only try the next DWN if
+ * there is a failure.  Additionally, per the DWN Specification, implementers SHOULD select from the
+ * Service Endpoint URIs in the nodes array in index order, so this function makes that approach easy.
+ * 
+ * @param {[Promise]} tasks
+ * @returns Promise<any>
+ */
+function promiseSeriesAny(tasks) {
+  let index = 0;
+
+  function tryNextTask() {
+    if (index >= tasks.length) {
+      return Promise.reject(new Error('All promises rejected.'));
+    }
+
+    const task = tasks[index++];
+
+    return task()
+      .then(result => { return result; })
+      .catch(_ => { return tryNextTask(); });
+  }
+
+  return tryNextTask();
+}
+
 async function decodePin(data, secretKey) {
   const { pin, nonce, publicKey } = data;
   const encryptedPinBytes = Encoder.base64UrlToBytes(pin);
@@ -99,5 +133,6 @@ export {
   isUnsignedMessage,
   parseJSON,
   parseURL,
+  promiseSeriesAny,
   triggerProtocolHandler,
 };

--- a/test-site/index.html
+++ b/test-site/index.html
@@ -204,6 +204,13 @@
     </div>
   </div>
 
+    <div class="box">
+      <div class="row">
+        <span>Query data authored by Alice's DID to Bob's DWN withOUT local key chain</span>
+        <button type="button" id="query_alice_to_bob_remote_btn">Send</button>
+      </div>
+    </div>
+  </div>
 </body>
 
 <script type="module">
@@ -428,7 +435,28 @@
    * NEW TESTS
    */
 
-  const bobDid = 'did:ion:bob1234';
+  /** ION DID that resolves to a DID Document containing:
+   *  "service": [
+   *     {
+   *       "id": "#dwn",
+   *       "type": "DecentralizedWebNode",
+   *       "serviceEndpoint": {
+   *         "nodes": [
+   *           "http://localhost:8085/dwn"
+   *         ],
+   *         "origins": []
+   *       }
+   *     }
+   *   ],
+   * 
+   * Must run a DWN addressable at http://localhost:8085/dwn to execute the tests below.
+   */
+  
+  // this one can be used to simulate a case where all endpoints are offline since the service endpoints in the resolved
+  // DID Document are http://localhost:8085 instead of http://localhost:8085/dwn
+
+  // const bobDid = 'did:ion:EiDPUAG_o_sameoRdJQ48M8A-j9WfrSr8GXbWlSQ01m-MQ:eyJkZWx0YSI6eyJwYXRjaGVzIjpbeyJhY3Rpb24iOiJyZXBsYWNlIiwiZG9jdW1lbnQiOnsicHVibGljS2V5cyI6W3siaWQiOiJrZXktMSIsInB1YmxpY0tleUp3ayI6eyJjcnYiOiJzZWNwMjU2azEiLCJrdHkiOiJFQyIsIngiOiJyZ2RDNkhmbWt6aFNBUE45RkRkb3VvVTFQdnM4TjUyQmNHVkZFSVA5M2E0IiwieSI6Imc2UGtwX3V3M3ljTnJHVzl4b2ZOMXRZU2ZLUlY3MzlodW1DMXg3UzJjaWcifSwicHVycG9zZXMiOlsiYXV0aGVudGljYXRpb24iXSwidHlwZSI6Ikpzb25XZWJLZXkyMDIwIn1dLCJzZXJ2aWNlcyI6W3siaWQiOiJkd24iLCJzZXJ2aWNlRW5kcG9pbnQiOnsibm9kZXMiOlsiaHR0cDovL2xvY2FsaG9zdDo4MDg1IiwiaHR0cDovL2xvY2FsaG9zdDo4MDg2IiwiaHR0cDovL2xvY2FsaG9zdDo4MDg3Il19LCJ0eXBlIjoiRGVjZW50cmFsaXplZFdlYk5vZGUifV19fV0sInVwZGF0ZUNvbW1pdG1lbnQiOiJFaUF6MUdlRE9fRUJKMXdWWmtHaUFJYmZPWGZrQW9BSWZlR083WGtmb0V5UjdnIn0sInN1ZmZpeERhdGEiOnsiZGVsdGFIYXNoIjoiRWlCcTlzcTE5U1hEZ0hwdE1FVWRMZV9ta0d1dmluc0NmMUxNYndfek1rU0xrQSIsInJlY292ZXJ5Q29tbWl0bWVudCI6IkVpQjVscHZ2ZWZiUlIwZU9HTU94Uk52aUdYdmhzaVQxQWRiN19odWQ2QWdKQVEifX0';
+  const bobDid = 'did:ion:EiAa0ZGOuDaAz0IP9dtzfgcr9dqoVLMVjjce3qJVCeAE4g:eyJkZWx0YSI6eyJwYXRjaGVzIjpbeyJhY3Rpb24iOiJyZXBsYWNlIiwiZG9jdW1lbnQiOnsicHVibGljS2V5cyI6W3siaWQiOiJrZXktMSIsInB1YmxpY0tleUp3ayI6eyJjcnYiOiJzZWNwMjU2azEiLCJrdHkiOiJFQyIsIngiOiJPMzhYcDIzR3lNSHBMWTl0SXFFR1dla2MtYU8tYk5pUzQ3VFYtend5ZGMwIiwieSI6Il9OeG0tQ05zWHB3a2NiQ05pT0ZxWnFtUUpDQ2VQbnI3a3JrbklPc1hNd2MifSwicHVycG9zZXMiOlsiYXV0aGVudGljYXRpb24iXSwidHlwZSI6Ikpzb25XZWJLZXkyMDIwIn1dLCJzZXJ2aWNlcyI6W3siaWQiOiJkd24iLCJzZXJ2aWNlRW5kcG9pbnQiOnsibm9kZXMiOlsiaHR0cDovL2xvY2FsaG9zdDo4MDg1L2R3biIsImh0dHA6Ly9sb2NhbGhvc3Q6ODA4Ni9kd24iLCJodHRwOi8vbG9jYWxob3N0OjgwODcvZHduIl19LCJ0eXBlIjoiRGVjZW50cmFsaXplZFdlYk5vZGUifV19fV0sInVwZGF0ZUNvbW1pdG1lbnQiOiJFaURtQ3Utcmo2V2J6QURLcjhoc2FfSnZzd2QwaGdOYzNPVmo0NFkzZzJvUzVnIn0sInN1ZmZpeERhdGEiOnsiZGVsdGFIYXNoIjoiRWlBU3NvZlJ3VGtmOGZNa0RwRTJlZUJiTHZyVkNQT1VXUmdaY3lKQ3laamJSQSIsInJlY292ZXJ5Q29tbWl0bWVudCI6IkVpQ05NVHNrZDRScWZvcmY0QTRwdTZCbmtpUTBPVDA4WWpVM2hSY0VWRjBFOVEifX0';
 
   write_alice_to_alice_local_btn.addEventListener('click', async event => {
     if (!agentConnected()) return;
@@ -474,11 +502,25 @@
       author: myDid,
       data: 'test',
       message: {
-        schema: 'foo/bar',
+        protocol: 'test',
+        schema: 'test/post'
       }
     });
     logConsole(response);
-    alert('TEST PARTIALLY IMPLEMENTED.\n\nHandling for unknown target DIDs not implemented yet.')
+  });
+
+  query_alice_to_bob_remote_btn.addEventListener('click', async event => {
+    if (!agentConnected()) return;
+    const response = await web5.dwn.records.query(bobDid, {
+      author: myDid,
+      message: {
+        filter: {
+          protocol: 'test',
+          schema: 'test/post',
+        }
+      }
+    });
+    logConsole(response);
   });
 
 </script>

--- a/tests/utils.spec.js
+++ b/tests/utils.spec.js
@@ -40,12 +40,12 @@ describe('Utils Tests', () => {
 
     
     it('should return true is message is missing authorization', () => {
-      const result = utils.isMessageUnsigned(unsignedMessage);
+      const result = utils.isUnsignedMessage(unsignedMessage);
       expect(result).to.be.true;
     });
 
     it('should return false is message contains authorization', () => {
-      const result = utils.isMessageUnsigned(signedMessage);
+      const result = utils.isUnsignedMessage(signedMessage);
       expect(result).to.be.false;
     });
   });

--- a/tests/utils.spec.js
+++ b/tests/utils.spec.js
@@ -28,4 +28,25 @@ describe('Utils Tests', () => {
       expect(dataFormat).to.equal('image/png');
     });
   });
+
+  describe('isUnsignedMessage', () => {
+    const signedMessage = {
+      message: { authorization: 'value' },
+    };
+
+    const unsignedMessage = {
+      message: { descriptor: { schema: 'foo/bar' } },
+    };
+
+    
+    it('should return true is message is missing authorization', () => {
+      const result = utils.isMessageUnsigned(unsignedMessage);
+      expect(result).to.be.true;
+    });
+
+    it('should return false is message contains authorization', () => {
+      const result = utils.isMessageUnsigned(signedMessage);
+      expect(result).to.be.false;
+    });
+  });
 });


### PR DESCRIPTION
## Goals

### Features Introduced
- Enables apps built with this library (browser, agent, cloud instance) to send messages to remote DWNs via any supported transport method.
- Previously messages could only be sent to a single DWN, even if there were multiple endpoints available (e.g., `service` endpoints in DID document).  The `Web5.send()` method was modified to serially attempt to send messages to each DWN endpoint using the approach recommended by the [DWN](https://identity.foundation/decentralized-web-node/spec/#resolution).  If only a single endpoint is targeted, then the behavior is no different than before.

    > Parse the DecentralizedWebNode Service Endpoint object and select the first URI present in the serviceEndpoint objects nodes array. NOTE: implementers SHOULD select from the URIs in the nodes array in index order.
- Enables polymorphic access to fetch across browsers, browser extensions, node, and React Native environments.
    - Why cross-fetch?  It was already a `web5-js` project dependency and is also [used in the `dwn-sdk-js`](https://github.com/TBD54566975/dwn-sdk-js/blob/8780cd8eaf67d0764d102ef4682507f3a61e4dbd/src/did/did-ion-resolver.ts#L3-L10) so there is familiarity on the team and one less "new" library to track as a dependency.
- A simple/naive method to check for unsigned messages and skip any signing logic for signed messages.  Includes tests and a note in the code that this could be enhanced in the future, if necessary.  The premise for the moment is that the `dwn-sdk-js` implementation already checks message authenticity and integrity, so messages that have been tampered with/corrupted would be rejected anyways once `processMessage()` is called.


## Non-Goals

- Automatically write the message to both a local/in-memory DWN and the remote DWN in the case of protocols that depend on the presence of a RecordsWrite to permit actors to perform certain actions.  This is being tracked in Issue #17.
- Resolve DID URIs defined in DID document service endpoint `nodes` array.  This is being tracked in Issue #18.