### PR TITLE
Add did:key methods

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@decentralized-identity/ion-tools": "1.0.6",
         "@tbd54566975/dwn-sdk-js": "0.0.26",
         "cross-fetch": "3.1.5",
+        "ed2curve": "0.3.0",
         "tweetnacl": "1.0.3"
       },
       "devDependencies": {
@@ -2416,6 +2417,14 @@
       },
       "funding": {
         "url": "https://bevry.me/fund"
+      }
+    },
+    "node_modules/ed2curve": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/ed2curve/-/ed2curve-0.3.0.tgz",
+      "integrity": "sha512-8w2fmmq3hv9rCrcI7g9hms2pMunQr1JINfcjwR9tAyZqhtyaMN991lF/ZfHfr5tzZQ8c7y7aBgZbjfbd0fjFwQ==",
+      "dependencies": {
+        "tweetnacl": "1.x.x"
       }
     },
     "node_modules/ee-first": {
@@ -9017,6 +9026,14 @@
       "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.22.0.tgz",
       "integrity": "sha512-IGBwjF7tNk3cwypFNH/7bfzBcgSCbaMOD3GsaY1AU/JRrnHnYgEM0+9kQt52iZxjNsjBtJYtao146V+f8jFZNw==",
       "dev": true
+    },
+    "ed2curve": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/ed2curve/-/ed2curve-0.3.0.tgz",
+      "integrity": "sha512-8w2fmmq3hv9rCrcI7g9hms2pMunQr1JINfcjwR9tAyZqhtyaMN991lF/ZfHfr5tzZQ8c7y7aBgZbjfbd0fjFwQ==",
+      "requires": {
+        "tweetnacl": "1.x.x"
+      }
     },
     "ee-first": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "@decentralized-identity/ion-tools": "1.0.6",
     "@tbd54566975/dwn-sdk-js": "0.0.26",
     "cross-fetch": "3.1.5",
+    "ed2curve": "0.3.0",
     "tweetnacl": "1.0.3"
   }
 }

--- a/src/Web5.js
+++ b/src/Web5.js
@@ -138,7 +138,7 @@ class Web5 extends EventTarget {
       }
     }
 
-    const encodedOrigin = this.#dwn.SDK.Encoder.bytesToBase64Url(location.origin);
+    const encodedOrigin = this.#dwn.SDK.Encoder.stringToBase64Url(location.origin);
     triggerProtocolHandler(`web5://connect/${this.#keys.encoded.publicKey}/${encodedOrigin}`);
 
     function destroySocket(socket) {

--- a/src/did/Web5DID.js
+++ b/src/did/Web5DID.js
@@ -29,8 +29,18 @@ class Web5DID {
     });
   }
 
+  async sign(method, options = { }) {
+    const api = await this.#getMethodAPI(method);
+    return api.sign(options);
+  }
+
   async unregister(did) {
     await this.#registeredDIDs.delete(did);
+  }
+
+  async verify(method, options = { }) {
+    const api = await this.#getMethodAPI(method);
+    return api.verify(options);
   }
 
   async resolve(did, options = { }) {

--- a/src/did/methods/index.js
+++ b/src/did/methods/index.js
@@ -1,1 +1,2 @@
 export * as ion from './ion.js';
+export * as key from './key.js';

--- a/src/did/methods/key.js
+++ b/src/did/methods/key.js
@@ -1,6 +1,7 @@
 import { base64url } from 'multiformats/bases/base64';
 import { base58btc } from 'multiformats/bases/base58';
-import { convertKeyPair } from 'ed2curve';
+import ed2curve from 'ed2curve';
+const { convertKeyPair } = ed2curve;
 import nacl from 'tweetnacl';
 
 // See https://github.com/multiformats/multicodec/blob/master/table.csv

--- a/src/did/methods/key.js
+++ b/src/did/methods/key.js
@@ -1,0 +1,153 @@
+import { base64url } from 'multiformats/bases/base64';
+import { base58btc } from 'multiformats/bases/base58';
+import { convertKeyPair } from 'ed2curve';
+import nacl from 'tweetnacl';
+
+// See https://github.com/multiformats/multicodec/blob/master/table.csv
+// multicodec ed25519-pub header 0xed as varint
+const MULTICODEC_ED25519_PUB_HEADER = new Uint8Array([0xed, 0x01]);
+// multicodec ed25519-priv header 0x1300 as varint
+const MULTICODEC_ED25519_PRIV_HEADER = new Uint8Array([0x80, 0x26]);
+// multicodec x25519-pub header 0xec as varint
+const MULTICODEC_X25519_PUB_HEADER = new Uint8Array([0xec, 0x01]);
+// multicodec x25519-priv header 0x1302 as varint
+const MULTICODEC_X25519_PRIV_HEADER = new Uint8Array([0x82, 0x26]);
+
+async function create(options = { }) {
+  // Generate new sign key pair.
+  const verificationKeyPair = nacl.sign.keyPair();
+  const keyAgreementKeyPair = convertKeyPair(verificationKeyPair);
+
+  const verificationKeyId = await encodeMbBase58(MULTICODEC_ED25519_PUB_HEADER, verificationKeyPair.publicKey);
+  const keyAgreementKeyId = await encodeMbBase58(MULTICODEC_X25519_PUB_HEADER, keyAgreementKeyPair.publicKey);
+  
+  const id = `did:key:${verificationKeyId}`;
+
+  const verificationKey = await toJsonWebKey(id, verificationKeyId, 'Ed25519', verificationKeyPair.publicKey, verificationKeyPair.secretKey);
+  const keyAgreementKey = await toJsonWebKey(id, keyAgreementKeyId, 'X25519', keyAgreementKeyPair.publicKey, keyAgreementKeyPair.secretKey);
+  
+  return {
+    id,
+    internalId: id,
+    keys: [verificationKey, keyAgreementKey],
+  };
+}
+
+async function resolve() {
+  // TODO: Implement
+  throw new Error('did:key resolve() not implemented');
+}
+
+/**
+ * 
+ * @param {Object} params - Object containing the signing parameters
+ * @param {Uint8Array} params.data - The data to sign
+ * @param {Object} params.privateKeyJwk - Private key as JSON Web Key (JWK)
+ * @param {string} params.privateKeyJwk.crv - Cryptogrpahic curve
+ * @param {string} params.privateKeyJwk.d - Base64url encoded private key
+ * @param {string} params.privateKeyJwk.kid - Key ID
+ * @param {string} params.privateKeyJwk.kty - Key type
+ * @param {string} params.privateKeyJwk.x - Base64url encoded public key
+ * @returns {Uint8Array} Signature
+ */
+async function sign(params) {
+  const { data, privateKeyJwk } = params;
+  const privateKeyBytes = base64url.baseDecode(privateKeyJwk.d);
+
+  let signature, signedData;
+  switch (privateKeyJwk.crv) {
+  case 'Ed25519':
+    signedData = nacl.sign(data, privateKeyBytes);
+    signature = signedData.slice(0, nacl.sign.signatureLength);
+    break;
+  default:
+    throw new Error('Unsupported cryptographic type');
+  }
+
+  return signature;
+}
+
+/**
+ * 
+ * @param {Object} params - Object containing the verification parameters
+ * @param {Uint8Array} params.signature - The signature to verify
+ * @param {Uint8Array} params.data - The data to verify
+ * @param {Object} params.publicKeyJwk - Public key as JSON Web Key (JWK)
+ * @param {string} params.publicKeyJwk.crv - Cryptogrpahic curve
+ * @param {string} params.publicKeyJwk.kid - Key ID
+ * @param {string} params.publicKeyJwk.kty - Key type
+ * @param {string} params.publicKeyJwk.x - Base64url encoded public key
+ * @returns {boolean}
+ */
+async function verify(params) {
+  const { signature, data, publicKeyJwk } = params;
+  const publicKeyBytes = base64url.baseDecode(publicKeyJwk.x);
+
+  let signedData, result;
+  switch (publicKeyJwk.crv) {
+  case 'Ed25519':
+    signedData = new Uint8Array(signature.length + data.length);
+    signedData.set(signature);
+    signedData.set(data, signature.length);
+    result = nacl.sign.open(signedData, publicKeyBytes);
+    break;
+  default:
+    throw new Error('Unsupported cryptographic type');
+  }
+
+  return (result === null) ? false : true;
+}
+
+/**
+ * Given a DID, key ID, cryptographic curve, and key pair, return a JSON Web Key 2020 object.
+ * 
+ * @param {string} id 
+ * @param {string} kid 
+ * @param {string} crv 
+ * @param {Uint8Array} publicKey 
+ * @param {Uint8Array} privateKey 
+ * @returns {{ id: string, type: string, controller: string, keypair: Object}}
+ */
+async function toJsonWebKey(id, kid, crv, publicKey, privateKey) {
+  const jsonWebKey = {
+    id: `${id}#${kid}`,
+    type: 'JsonWebKey2020',
+    controller: id,
+    keypair: {},
+  };
+
+  const jwk = { crv, kid, kty: 'OKP' };
+
+  jsonWebKey.keypair.publicKeyJwk = { ...jwk };
+  jsonWebKey.keypair.publicKeyJwk.x = base64url.baseEncode(publicKey);
+  
+  jsonWebKey.keypair.privateKeyJwk = { ...jsonWebKey.keypair.publicKeyJwk };
+  jsonWebKey.keypair.privateKeyJwk.d = base64url.baseEncode(privateKey);
+  
+  return jsonWebKey;
+}
+
+/**
+ * Encode a Multibase base58-btc encoded value
+ * Concatenation of the Multicodec identifier for the key type and
+ * the raw bytes associated with the key format.
+ * 
+ * @param {Uint8Array} header Muticodec identifier
+ * @param {Uint8Array} key Raw bytes of the key
+ * @returns 
+ */
+async function encodeMbBase58(header, key) {
+  const multibaseKey = new Uint8Array(header.length + key.length);
+
+  multibaseKey.set(header);
+  multibaseKey.set(key, header.length);
+
+  return base58btc.encode(multibaseKey);
+}
+
+export {
+  create,
+  resolve,
+  sign,
+  verify,
+};


### PR DESCRIPTION
**Features**
- Add very basic support for `did:key`:
    - `create()`: Creates a new `did:key` by generating an `Ed25519` verification key pair and deriving a `X25519` key agreement key.  The Ed25519 key will be used for signing and verification, while the X25519 key will be used to establish a shared secret that can be used to encrypt data between two parties. This was added specifically to support the DIDConnect process between an agent and DWA using Web5 JS.
        - Method signature designed to be compatible with values returned by `Web5.did.create('ion')`.
    - `sign()`: Given data and a private key JWK, return the signature.
        - Method signature modeled after `@noble/ed25519`.
    - `verify()`: Given a signature, data, and a public key JWK, return a boolean with the result of the verification check.                    
        - Method signature modeled after `@noble/ed25519`.
    - **NOTE:** This and the `ion` method should eventually be replaced with the TBD [ssi-sdk](https://github.com/TBD54566975/ssi-sdk/) WASM bundle.

**Bugs/Fixes**
- `location.origin` is a string so should use `stringToBase64Url()` to encode its value