### PR TITLE
adding a release workflow - similar to dwn sdk

### DIFF
--- a/.github/workflows/npm-publish-stable.yml
+++ b/.github/workflows/npm-publish-stable.yml
@@ -1,0 +1,28 @@
+# This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
+# For more information see: https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages
+
+name: publish stable
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  publish-npm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18.8.0
+          registry-url: https://registry.npmjs.org/
+      - run: npm install
+      # builds all bundles
+      - run: npm run build
+      # Note - this is not required but it gives a clean failure prior to attempting a release if the GH workflow runner is not authenticated with npm.js
+      - run: npm whoami
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.npm_token}}
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.npm_token}}


### PR DESCRIPTION
cc @frankhinek @mistermoe - this is what DWN used which should work similarly for web5-js 