### PR TITLE
make `key` the default DID method when calling `web5.did.create()`

### DIFF
--- a/src/did/Web5DID.js
+++ b/src/did/Web5DID.js
@@ -15,7 +15,7 @@ class Web5DID {
     return this.#web5;
   }
 
-  async create(method, options = { }) {
+  async create(method = 'key', options = { }) {
     const api = await this.#getMethodAPI(method);
     return api.create(options);
   }


### PR DESCRIPTION
this will allow developers who just want to get a basic DID to do so without having to even know anything about what a DID method is

it still lets them "do better" by providing a DID method to get more features (e.g. endpoints)