### PR TITLE
Bump version to 0.6.3 to trigger NPM package publication

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tbd54566975/web5",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "SDK for accessing the features and capabilities of Web5",
   "type": "module",
   "main": "./dist/cjs/index.cjs",


### PR DESCRIPTION
This PR is bumping the version to `v0.6.3` but involves no other changes.

The only reason for this bump is to trigger the publication of a new version to NPMJS.com that resolves an issue with the `v0.6.2` push that has a corrupted `dist/` directory.