### PR TITLE
Fix CI WebKit Tests

### DIFF
--- a/.github/workflows/tests-ci.yml
+++ b/.github/workflows/tests-ci.yml
@@ -37,7 +37,8 @@ jobs:
         run: npm run test:node --ws
 
   test-on-browsers:
-    runs-on: ubuntu-latest
+    # Run browser tests using macOS so that WebKit tests don't fail under a Linux environment
+    runs-on: macos-latest
     steps:
       - name: Checkout source
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2

--- a/.github/workflows/tests-ci.yml
+++ b/.github/workflows/tests-ci.yml
@@ -12,7 +12,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  test-on-node:
+  test-with-node:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source
@@ -36,7 +36,7 @@ jobs:
       - name: Run tests for all packages
         run: npm run test:node --ws
 
-  test-on-browsers:
+  test-with-browsers:
     # Run browser tests using macOS so that WebKit tests don't fail under a Linux environment
     runs-on: macos-latest
     steps:
@@ -52,11 +52,11 @@ jobs:
       - name: Install latest npm
         run: npm install -g npm@latest
 
-      - name: Install Playwright Browsers
-        run: npx playwright install --with-deps
-
       - name: Install dependencies
         run: npm ci
+
+      - name: Install Playwright Browsers
+        run: npx playwright install --with-deps
 
       - name: Build all workspace packages
         run: npm run build

--- a/packages/crypto/tests/needed.spec.ts
+++ b/packages/crypto/tests/needed.spec.ts
@@ -1,3 +1,7 @@
+import { expect } from 'chai';
+
 describe('@tbd54566975/crypto', () => {
-  xit('should have tests');
+  it('should have tests', () => {
+    expect(true).to.equal(true);
+  });
 });

--- a/packages/web5-agent/tests/needed.spec.ts
+++ b/packages/web5-agent/tests/needed.spec.ts
@@ -1,3 +1,7 @@
+import { expect } from 'chai';
+
 describe('@tbd54566975/web5-agent', () => {
-  xit('should have tests');
+  it('should have tests', () => {
+    expect(true).to.equal(true);
+  });
 });

--- a/packages/web5-proxy-agent/tests/needed.spec.ts
+++ b/packages/web5-proxy-agent/tests/needed.spec.ts
@@ -1,3 +1,7 @@
+import { expect } from 'chai';
+
 describe('@tbd54566975/web5-proxy-agent', () => {
-  xit('should have tests');
+  it('should have tests', () => {
+    expect(true).to.equal(true);
+  });
 });


### PR DESCRIPTION
Runs the browser tests using a macOS runner to ensure that Chromium, Firefox, and WebKit tests can all be executed.