### PR TITLE
Add support for encrypting records using web5.dwn.records.create()

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ console.log(records); // an array of record entries from Bob's DWeb Nodes
 
 The query `request` contains the following properties:
 
-- **`from`** - _`DID string`_ (_optional_): the decentralized identifier of the DID of the DWeb Node the query will fetch results from.
+- **`from`** - _`DID string`_ (_optional_): the decentralized identifier of the DWeb Node the query will fetch results from.
 - **`message`** - _`object`_: the properties of the DWeb Node Message Descriptor that will be used to construct a valid record query:
   - **`filter`** - _`object`_: properties against which results of the query will be filtered:
     - **`protocol`** - _`URI string`_ (_optional_): the URI of the protocol bucket in which to query.
@@ -340,7 +340,7 @@ console.log(protocols); // logs an array of protocol configurations installed on
 
 The query `request` must contain the following:
 
-- **`from`** - _`DID string`_ (_optional_): the decentralized identifier of the DID of the DWeb Node the query will fetch results from.
+- **`from`** - _`DID string`_ (_optional_): the decentralized identifier of the DWeb Node the query will fetch results from.
 - **`message`** - _`object`_: The properties of the DWeb Node Message Descriptor that will be used to construct a valid record query:
   - **`filter`** - _`object`_: properties against which results of the query will be filtered:
     - **`protocol`** - _`URI string`_ (_optional_): the URI of the protocol bucket in which to query.

--- a/README.md
+++ b/README.md
@@ -164,7 +164,8 @@ const { status } = await record.send("did:example:bob"); // send the newly gener
 The `create` request object is composed as follows:
 
 - **`store`** - _`boolean`_: tells the create function whether or not to store the record in the user's local DWeb Node. (you might pass `false` if you didn't want to retain a copy of the record for yourself)
-- **`data`** - _`text|object|file|blob`_: The data payload of the record.
+- **`data`** - _`text|object|file|blob`_: the data payload of the record.
+- **`encrypt`** - _`boolean|object` (optional)_: whether to encrypt the record. A value of `true` encrypts the record using the local active DID's public key such that only they can decrypt. To encrypt a record using someone else's public key, specify their DID with a value of `{ for: 'did:example:bob'}`.
 - **`message`** - _`object`_: The properties of the DWeb Node Message Descriptor that will be used to construct a valid record query:
   - **`protocol`** - _`URI string`_ (_optional_): the URI of the protocol under which the record will be bucketed.
   - **`schema`** - _`URI string`_ (_optional_): the URI of the schema under which the record will be bucketed.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7602,6 +7602,7 @@
             "version": "0.1.3",
             "license": "Apache-2.0",
             "dependencies": {
+                "@noble/secp256k1": "1.7.1",
                 "ed2curve": "0.3.0",
                 "multiformats": "11.0.2"
             },
@@ -7632,6 +7633,17 @@
             "engines": {
                 "node": ">=18.0.0"
             }
+        },
+        "packages/crypto/node_modules/@noble/secp256k1": {
+            "version": "1.7.1",
+            "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.1.tgz",
+            "integrity": "sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://paulmillr.com/funding/"
+                }
+            ]
         },
         "packages/dids": {
             "name": "@tbd54566975/dids",
@@ -9235,6 +9247,7 @@
         "@tbd54566975/crypto": {
             "version": "file:packages/crypto",
             "requires": {
+                "@noble/secp256k1": "1.7.1",
                 "@types/chai": "4.3.0",
                 "@types/ed2curve": "0.2.2",
                 "@types/eslint": "8.37.0",
@@ -9259,6 +9272,13 @@
                 "playwright": "1.31.2",
                 "rimraf": "4.4.0",
                 "typescript": "5.0.4"
+            },
+            "dependencies": {
+                "@noble/secp256k1": {
+                    "version": "1.7.1",
+                    "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.1.tgz",
+                    "integrity": "sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw=="
+                }
             }
         },
         "@tbd54566975/dids": {

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -74,6 +74,7 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
+    "@noble/secp256k1": "1.7.1",
     "ed2curve": "0.3.0",
     "multiformats": "11.0.2"
   },

--- a/packages/crypto/src/utils.ts
+++ b/packages/crypto/src/utils.ts
@@ -1,5 +1,6 @@
 import { base64url } from 'multiformats/bases/base64';
 import { base58btc } from 'multiformats/bases/base58';
+import * as secp256k1 from '@noble/secp256k1';
 
 
 // See https://github.com/multiformats/multicodec/blob/master/table.csv
@@ -15,11 +16,6 @@ export const MULTICODEC_HEADERS = {
   NOOP: new Uint8Array([])
 };
 
-
-export function bytesToBase64Url(bytes: Uint8Array): string {
-  return base64url.baseEncode(bytes);
-}
-
 export function base64UrlToBytes(base64urlString: string): Uint8Array {
   return base64url.baseDecode(base64urlString);
 }
@@ -30,4 +26,12 @@ export function bytesToBase58btcMultibase(header: Uint8Array, bytes: Uint8Array)
   multibaseBytes.set(bytes);
 
   return base58btc.encode(multibaseBytes);
+}
+
+export function bytesToBase64Url(bytes: Uint8Array): string {
+  return base64url.baseEncode(bytes);
+}
+
+export function randomBytes(bytesLength: number): Uint8Array {
+  return secp256k1.utils.randomBytes(bytesLength);
 }

--- a/packages/dids/.vscode/launch.json
+++ b/packages/dids/.vscode/launch.json
@@ -1,0 +1,22 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "test:node",
+      "runtimeExecutable": "${workspaceFolder:root}/node_modules/.bin/mocha",
+      "runtimeArgs": [
+        "${workspaceFolder:dids}/__tests__/**/*.spec.js"
+      ],
+      "console": "internalConsole",
+      "preLaunchTask": "tsc: build - tsconfig.test.json",
+      "outFiles": [
+        "${workspaceFolder:dids}/__tests__/**/*.js"
+      ],
+    }
+  ]
+}

--- a/packages/dids/.vscode/tasks.json
+++ b/packages/dids/.vscode/tasks.json
@@ -1,0 +1,45 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"label": "npm run build",
+			"type": "npm",
+			"script": "build",
+			"problemMatcher": [],
+			"group": {
+				"kind": "build",
+				"isDefault": true
+			}
+		},
+		{
+			"label": "tsc: build - tsconfig.json",
+			"type": "typescript",
+			"tsconfig": "tsconfig.json",
+			"problemMatcher": [
+				"$tsc"
+			],
+			"group": {
+				"kind": "build",
+				"isDefault": false
+			},
+			"options": {
+				"cwd": "${workspaceFolder:root}"
+			}
+		},
+		{
+			"label": "tsc: build - tsconfig.test.json",
+			"type": "typescript",
+			"tsconfig": "tsconfig.test.json",
+			"problemMatcher": [
+				"$tsc"
+			],
+			"group": {
+				"kind": "build",
+				"isDefault": false
+			},
+			"options": {
+				"cwd": "${workspaceFolder:root}"
+			}
+		},
+	]
+}

--- a/packages/dids/src/did-ion.ts
+++ b/packages/dids/src/did-ion.ts
@@ -155,9 +155,9 @@ export class DidIonApi implements DidMethodResolver, DidMethodCreator {
   }
 
   /**
-   * generates three key pairs used for attestation, authorization and encryption purposes
-   * when interfacing with DWNs. the ids of these keys are referenced in the service object
-   *  that includes the dwnUrls provided.
+   * Generates two key pairs used for authorization and encryption purposes
+   * when interfacing with DWNs. The IDs of these keys are referenced in the
+   * service object that includes the dwnUrls provided.
    */
   static async generateDwnConfiguration(dwnUrls: string[]): Promise<DidIonCreateOptions> {
     const keys = [{

--- a/packages/dids/src/utils.ts
+++ b/packages/dids/src/utils.ts
@@ -1,5 +1,17 @@
 import type { KeyPairJwk } from '@tbd54566975/crypto';
-import type { DidDocument, VerificationMethodWithPrivateKeyJwk, ServiceEndpoint } from './types.js';
+import type { DidDocument, VerificationMethod, VerificationMethodWithPrivateKeyJwk, ServiceEndpoint } from './types.js';
+
+export function createVerificationMethodWithPrivateKeyJwk(id: string, keyPairJwk: KeyPairJwk): VerificationMethodWithPrivateKeyJwk {
+  const { publicKeyJwk, privateKeyJwk } = keyPairJwk;
+
+  return {
+    id         : `${id}#${keyPairJwk.publicKeyJwk.kid}`,
+    type       : 'JsonWebKey2020',
+    controller : id,
+    publicKeyJwk,
+    privateKeyJwk
+  };
+}
 
 export type ParsedDid = {
   method: string;
@@ -17,16 +29,67 @@ export function parseDid(did: string): ParsedDid {
   return { method, id };
 }
 
-export function createVerificationMethodWithPrivateKeyJwk(id: string, keyPairJwk: KeyPairJwk): VerificationMethodWithPrivateKeyJwk {
-  const { publicKeyJwk, privateKeyJwk } = keyPairJwk;
+export type FindVerificationMethodsOptions = {
+  id?: string;
+  purpose?: string;
+};
 
-  return {
-    id         : `${id}#${keyPairJwk.publicKeyJwk.kid}`,
-    type       : 'JsonWebKey2020',
-    controller : id,
-    publicKeyJwk,
-    privateKeyJwk
-  };
+/**
+ *
+ * @param {object} options Object containing search parameters
+ * @param {string} options.id Method ID to search by
+ * @param {string} options.purpose Purpose to search by
+ * @returns {VerificationMethod[] | null}
+ */
+export function findVerificationMethods(didDocument: DidDocument, options?: FindVerificationMethodsOptions): VerificationMethod[] | null {
+  if (!didDocument?.verificationMethod) throw new Error('DID Document with `verificationMethod` is a required argument');
+  if (options?.purpose && options?.id) throw new Error('Specify method ID or purpose but not both');
+
+  function findMethodById(methodId?: string): VerificationMethod[] {
+    let results = [];
+
+    // First try to find the ID in the verification methods array
+    const verificationMethodsResult = didDocument?.verificationMethod?.filter(method => {
+      if (methodId && method.id !== methodId) return false;
+      return true;
+    });
+    if (verificationMethodsResult) results.push(...verificationMethodsResult);
+
+    // If the ID wasn't found, search in each of the verification relationships / purposes
+    DID_VERIFICATION_RELATIONSHIPS.forEach(purpose => {
+      if (Array.isArray(didDocument[purpose])) {
+        const verificationRelationshipsResult = didDocument[purpose].filter(method => {
+          if (methodId && method.id !== methodId) return false; // If methodId specified, match on `id` value
+          if (typeof method === 'string') return false; // Ignore verification method references
+          return true;
+        });
+        if (verificationRelationshipsResult) results.push(...verificationRelationshipsResult);
+      }
+    });
+    return results;
+  }
+
+  // Find by verification method ID
+  if (options?.purpose === undefined) {
+    const results = findMethodById(options?.id);
+    return (results.length > 0) ? results : null;
+  }
+
+  // Find by verification relationship / purpose (e.g., authentication, keyAgreement, etc.)
+  if (options?.purpose !== undefined) {
+    let results = [];
+    const methods = didDocument[options.purpose] || [];
+    methods.forEach(method => {
+      if (typeof method === 'string') {
+        // Find full description for referenced verification methods
+        const result = findMethodById(method);
+        if (result) results.push(...result);
+      } else {
+        results.push(method);
+      }
+    });
+    return (results.length > 0) ? results : null;
+  }
 }
 
 export type GetServicesOptions = {
@@ -49,3 +112,11 @@ export function getServices(didDocument: DidDocument, options: GetServicesOption
 }
 
 export const DID_REGEX = /^did:([a-z0-9]+):((?:(?:[a-zA-Z0-9._-]|(?:%[0-9a-fA-F]{2}))*:)*((?:[a-zA-Z0-9._-]|(?:%[0-9a-fA-F]{2}))+))((;[a-zA-Z0-9_.:%-]+=[a-zA-Z0-9_.:%-]*)*)(\/[^#?]*)?([?][^#]*)?(#.*)?$/;
+
+export const DID_VERIFICATION_RELATIONSHIPS = [
+  'assertionMethod',
+  'authentication',
+  'capabilityDelegation',
+  'capabilityInvocation',
+  'keyAgreement',
+];

--- a/packages/dids/tests/fixtures/did-documents.ts
+++ b/packages/dids/tests/fixtures/did-documents.ts
@@ -1,0 +1,456 @@
+export const ion = {
+  notFound: {
+    didDocument           : null,
+    didDocumentMetadata   : {},
+    didResolutionMetadata : {
+      error: 'unable to resolve did:ion:invalid, got http status 404',
+    },
+  },
+
+  noKeys: {
+    didDocument: {
+      '@context' : ['https://www.w3.org/ns/did/v1'],
+      id         : 'did:ion:abcd1234',
+    },
+  },
+
+  noServices: {
+    didDocument: {
+      '@context' : ['https://www.w3.org/ns/did/v1'],
+      id         : 'did:ion:abcd1234',
+    },
+  },
+
+  oneVerificationMethodJwk: {
+    didDocument: {
+      '@context'         : ['https://www.w3.org/ns/did/v1'],
+      id                 : 'did:ion:EiDnouH_Q0pwfFJom6v1BLbVzKp9b6qSx6-Dbox6kD-vnA:eyJkZWx0YSI6eyJwYXRjaGVzIjpbeyJhY3Rpb24iOiJyZXBsYWNlIiwiZG9jdW1lbnQiOnsicHVibGljS2V5cyI6W3siaWQiOiJrZXktMSIsInB1YmxpY0tleUp3ayI6eyJjcnYiOiJzZWNwMjU2azEiLCJrdHkiOiJFQyIsIngiOiJ4c2ZFTi1iN0REdFBJTEpKTXhYeHlONVgwYmc1S011eFFwZjRVYnpFbE4wIiwieSI6Ik1DT3RMMmx3TkJfejQwX2hhYnBNcUxqRTVEMjNDUjJDS3JfNG5DRElCTEEifSwicHVycG9zZXMiOlsiYXV0aGVudGljYXRpb24iXSwidHlwZSI6Ikpzb25XZWJLZXkyMDIwIn1dLCJzZXJ2aWNlcyI6W3siaWQiOiJkd24iLCJzZXJ2aWNlRW5kcG9pbnQiOnsibm9kZXMiOlsiaHR0cDovL2xvY2FsaG9zdDo4MDg1L2R3biJdfSwidHlwZSI6IkRlY2VudHJhbGl6ZWRXZWJOb2RlIn1dfX1dLCJ1cGRhdGVDb21taXRtZW50IjoiRWlBc0Q0YVBnRlNKV25VNWExcGhpRnRTTHJZNF9uSnc5SnpFTWtNWjZab2VXQSJ9LCJzdWZmaXhEYXRhIjp7ImRlbHRhSGFzaCI6IkVpQTVuU2tPaWJ0blBjNHBnbVA4djZuRDdjc28zTzlsbE5oSjhoYTVwSVZxeHciLCJyZWNvdmVyeUNvbW1pdG1lbnQiOiJFaUJ3SFU2WEFsRkt0V3R6dk0wVmdHTlJVbHl4cFR5dlFBaEM0RFVyXzMzc2VnIn19',
+      verificationMethod : [
+        {
+          id           : '#someKeyId',
+          controller   : 'did:ion:EiClkZMDxPKqC9c-umQfTkR8vvZ9JPhl_xLDI9Nfk38w5w',
+          type         : 'EcdsaSecp256k1VerificationKey2019',
+          publicKeyJwk : {
+            kty : 'EC',
+            crv : 'secp256k1',
+            x   : 'WfY7Px6AgH6x-_dgAoRbg8weYRJA36ON-gQiFnETrqw',
+            y   : 'IzFx3BUGztK0cyDStiunXbrZYYTtKbOUzx16SUK0sAY',
+          },
+        },
+      ],
+    },
+  },
+
+  oneService: {
+    didDocument: {
+      '@context' : ['https://www.w3.org/ns/did/v1'],
+      id         : 'did:ion:EiDnouH_Q0pwfFJom6v1BLbVzKp9b6qSx6-Dbox6kD-vnA:eyJkZWx0YSI6eyJwYXRjaGVzIjpbeyJhY3Rpb24iOiJyZXBsYWNlIiwiZG9jdW1lbnQiOnsicHVibGljS2V5cyI6W3siaWQiOiJrZXktMSIsInB1YmxpY0tleUp3ayI6eyJjcnYiOiJzZWNwMjU2azEiLCJrdHkiOiJFQyIsIngiOiJ4c2ZFTi1iN0REdFBJTEpKTXhYeHlONVgwYmc1S011eFFwZjRVYnpFbE4wIiwieSI6Ik1DT3RMMmx3TkJfejQwX2hhYnBNcUxqRTVEMjNDUjJDS3JfNG5DRElCTEEifSwicHVycG9zZXMiOlsiYXV0aGVudGljYXRpb24iXSwidHlwZSI6Ikpzb25XZWJLZXkyMDIwIn1dLCJzZXJ2aWNlcyI6W3siaWQiOiJkd24iLCJzZXJ2aWNlRW5kcG9pbnQiOnsibm9kZXMiOlsiaHR0cDovL2xvY2FsaG9zdDo4MDg1L2R3biJdfSwidHlwZSI6IkRlY2VudHJhbGl6ZWRXZWJOb2RlIn1dfX1dLCJ1cGRhdGVDb21taXRtZW50IjoiRWlBc0Q0YVBnRlNKV25VNWExcGhpRnRTTHJZNF9uSnc5SnpFTWtNWjZab2VXQSJ9LCJzdWZmaXhEYXRhIjp7ImRlbHRhSGFzaCI6IkVpQTVuU2tPaWJ0blBjNHBnbVA4djZuRDdjc28zTzlsbE5oSjhoYTVwSVZxeHciLCJyZWNvdmVyeUNvbW1pdG1lbnQiOiJFaUJ3SFU2WEFsRkt0V3R6dk0wVmdHTlJVbHl4cFR5dlFBaEM0RFVyXzMzc2VnIn19',
+      service    : [
+        {
+          id              : '#dwn',
+          type            : 'DecentralizedWebNode',
+          serviceEndpoint : {
+            nodes   : ['http://localhost:8080/dwn'],
+            origins : [],
+          },
+        },
+      ],
+    },
+  },
+
+  dwnService: {
+    twoAuthenticationReferencedKeysJwk: {
+      didDocument: {
+        '@context' : ['https://www.w3.org/ns/did/v1'],
+        id         : 'did:ion:EiAp_JjfvetzRV033JTaIiBIzh7UxP0Q6bGosMuPpo_4xQ:eyJkZWx0YSI6eyJwYXRjaGVzIjpbeyJhY3Rpb24iOiJyZXBsYWNlIiwiZG9jdW1lbnQiOnsicHVibGljS2V5cyI6W3siaWQiOiJhdXRoeiIsInB1YmxpY0tleUp3ayI6eyJjcnYiOiJzZWNwMjU2azEiLCJrdHkiOiJFQyIsIngiOiJRMl9RSUR5NERxRHJ6SVFESDFnWmZyQlo5OHYtV2JQWXNoXzBJVWZzVGpRIiwieSI6IlVvNlNDTHNDeGFRVGlsa1dSeDZNUUY1TzByRS1qWnlwb2dtR01nb0NkY2cifSwicHVycG9zZXMiOlsiYXV0aGVudGljYXRpb24iXSwidHlwZSI6Ikpzb25XZWJLZXkyMDIwIn0seyJpZCI6ImVuYyIsInB1YmxpY0tleUp3ayI6eyJjcnYiOiJzZWNwMjU2azEiLCJrdHkiOiJFQyIsIngiOiJmU25ZWmVwa1NNWXhFRmFGM3Z4TWZIaWw3SWhxWTRKNkpkejdxUUNlRFI4IiwieSI6InVmNkNwZ1VCdWRyTkFCVmtUTExPRlE1SWFTQ3pFZGlUMkREYjVXdnRCcEEifSwicHVycG9zZXMiOlsia2V5QWdyZWVtZW50Il0sInR5cGUiOiJKc29uV2ViS2V5MjAyMCJ9XSwic2VydmljZXMiOlt7ImlkIjoiZHduIiwic2VydmljZUVuZHBvaW50Ijp7Im1lc3NhZ2VBdXRob3JpemF0aW9uS2V5cyI6WyIjYXV0aHoiXSwibm9kZXMiOlsiaHR0cHM6Ly9kd24taG9zdC5jb20iXSwicmVjb3JkRW5jcnlwdGlvbktleXMiOlsiI3dyb25nIl19LCJ0eXBlIjoiRGVjZW50cmFsaXplZFdlYk5vZGUifV19fV0sInVwZGF0ZUNvbW1pdG1lbnQiOiJFaUNiM2Y1bW4zaWl5S0lIZHVTZzJ4d2hDRURKejRKQ0tjT0JLYWNpNzN4dGt3In0sInN1ZmZpeERhdGEiOnsiZGVsdGFIYXNoIjoiRWlDZmVhTWNZRUhSRHdhb3BzbVE5aWxTWkQ3S3hXeHJScVVrUGRYa2c3VWh6QSIsInJlY292ZXJ5Q29tbWl0bWVudCI6IkVpQ3M5TXFQVng3X1NkZU5Lb2ZjaVF1WVdPcTc3MHJKSG1FeFpkMzFoZXpuREEifX0',
+        service    : [
+          {
+            id              : '#dwn',
+            type            : 'DecentralizedWebNode',
+            serviceEndpoint : {
+              messageAuthorizationKeys: [
+                '#authz'
+              ],
+              nodes: [
+                'https://dwn-host.com'
+              ],
+              recordEncryptionKeys: [
+                '#enc'
+              ]
+            }
+          }
+        ],
+        verificationMethod: [
+          {
+            id           : '#authz',
+            controller   : 'did:ion:EiAp_JjfvetzRV033JTaIiBIzh7UxP0Q6bGosMuPpo_4xQ:eyJkZWx0YSI6eyJwYXRjaGVzIjpbeyJhY3Rpb24iOiJyZXBsYWNlIiwiZG9jdW1lbnQiOnsicHVibGljS2V5cyI6W3siaWQiOiJhdXRoeiIsInB1YmxpY0tleUp3ayI6eyJjcnYiOiJzZWNwMjU2azEiLCJrdHkiOiJFQyIsIngiOiJRMl9RSUR5NERxRHJ6SVFESDFnWmZyQlo5OHYtV2JQWXNoXzBJVWZzVGpRIiwieSI6IlVvNlNDTHNDeGFRVGlsa1dSeDZNUUY1TzByRS1qWnlwb2dtR01nb0NkY2cifSwicHVycG9zZXMiOlsiYXV0aGVudGljYXRpb24iXSwidHlwZSI6Ikpzb25XZWJLZXkyMDIwIn0seyJpZCI6ImVuYyIsInB1YmxpY0tleUp3ayI6eyJjcnYiOiJzZWNwMjU2azEiLCJrdHkiOiJFQyIsIngiOiJmU25ZWmVwa1NNWXhFRmFGM3Z4TWZIaWw3SWhxWTRKNkpkejdxUUNlRFI4IiwieSI6InVmNkNwZ1VCdWRyTkFCVmtUTExPRlE1SWFTQ3pFZGlUMkREYjVXdnRCcEEifSwicHVycG9zZXMiOlsia2V5QWdyZWVtZW50Il0sInR5cGUiOiJKc29uV2ViS2V5MjAyMCJ9XSwic2VydmljZXMiOlt7ImlkIjoiZHduIiwic2VydmljZUVuZHBvaW50Ijp7Im1lc3NhZ2VBdXRob3JpemF0aW9uS2V5cyI6WyIjYXV0aHoiXSwibm9kZXMiOlsiaHR0cHM6Ly9kd24taG9zdC5jb20iXSwicmVjb3JkRW5jcnlwdGlvbktleXMiOlsiI3dyb25nIl19LCJ0eXBlIjoiRGVjZW50cmFsaXplZFdlYk5vZGUifV19fV0sInVwZGF0ZUNvbW1pdG1lbnQiOiJFaUNiM2Y1bW4zaWl5S0lIZHVTZzJ4d2hDRURKejRKQ0tjT0JLYWNpNzN4dGt3In0sInN1ZmZpeERhdGEiOnsiZGVsdGFIYXNoIjoiRWlDZmVhTWNZRUhSRHdhb3BzbVE5aWxTWkQ3S3hXeHJScVVrUGRYa2c3VWh6QSIsInJlY292ZXJ5Q29tbWl0bWVudCI6IkVpQ3M5TXFQVng3X1NkZU5Lb2ZjaVF1WVdPcTc3MHJKSG1FeFpkMzFoZXpuREEifX0',
+            type         : 'JsonWebKey2020',
+            publicKeyJwk : {
+              crv : 'secp256k1',
+              kty : 'EC',
+              x   : 'Q2_QIDy4DqDrzIQDH1gZfrBZ98v-WbPYsh_0IUfsTjQ',
+              y   : 'Uo6SCLsCxaQTilkWRx6MQF5O0rE-jZypogmGMgoCdcg'
+            }
+          },
+          {
+            id           : '#enc',
+            controller   : 'did:ion:EiAp_JjfvetzRV033JTaIiBIzh7UxP0Q6bGosMuPpo_4xQ:eyJkZWx0YSI6eyJwYXRjaGVzIjpbeyJhY3Rpb24iOiJyZXBsYWNlIiwiZG9jdW1lbnQiOnsicHVibGljS2V5cyI6W3siaWQiOiJhdXRoeiIsInB1YmxpY0tleUp3ayI6eyJjcnYiOiJzZWNwMjU2azEiLCJrdHkiOiJFQyIsIngiOiJRMl9RSUR5NERxRHJ6SVFESDFnWmZyQlo5OHYtV2JQWXNoXzBJVWZzVGpRIiwieSI6IlVvNlNDTHNDeGFRVGlsa1dSeDZNUUY1TzByRS1qWnlwb2dtR01nb0NkY2cifSwicHVycG9zZXMiOlsiYXV0aGVudGljYXRpb24iXSwidHlwZSI6Ikpzb25XZWJLZXkyMDIwIn0seyJpZCI6ImVuYyIsInB1YmxpY0tleUp3ayI6eyJjcnYiOiJzZWNwMjU2azEiLCJrdHkiOiJFQyIsIngiOiJmU25ZWmVwa1NNWXhFRmFGM3Z4TWZIaWw3SWhxWTRKNkpkejdxUUNlRFI4IiwieSI6InVmNkNwZ1VCdWRyTkFCVmtUTExPRlE1SWFTQ3pFZGlUMkREYjVXdnRCcEEifSwicHVycG9zZXMiOlsia2V5QWdyZWVtZW50Il0sInR5cGUiOiJKc29uV2ViS2V5MjAyMCJ9XSwic2VydmljZXMiOlt7ImlkIjoiZHduIiwic2VydmljZUVuZHBvaW50Ijp7Im1lc3NhZ2VBdXRob3JpemF0aW9uS2V5cyI6WyIjYXV0aHoiXSwibm9kZXMiOlsiaHR0cHM6Ly9kd24taG9zdC5jb20iXSwicmVjb3JkRW5jcnlwdGlvbktleXMiOlsiI3dyb25nIl19LCJ0eXBlIjoiRGVjZW50cmFsaXplZFdlYk5vZGUifV19fV0sInVwZGF0ZUNvbW1pdG1lbnQiOiJFaUNiM2Y1bW4zaWl5S0lIZHVTZzJ4d2hDRURKejRKQ0tjT0JLYWNpNzN4dGt3In0sInN1ZmZpeERhdGEiOnsiZGVsdGFIYXNoIjoiRWlDZmVhTWNZRUhSRHdhb3BzbVE5aWxTWkQ3S3hXeHJScVVrUGRYa2c3VWh6QSIsInJlY292ZXJ5Q29tbWl0bWVudCI6IkVpQ3M5TXFQVng3X1NkZU5Lb2ZjaVF1WVdPcTc3MHJKSG1FeFpkMzFoZXpuREEifX0',
+            type         : 'JsonWebKey2020',
+            publicKeyJwk : {
+              crv : 'secp256k1',
+              kty : 'EC',
+              x   : 'fSnYZepkSMYxEFaF3vxMfHil7IhqY4J6Jdz7qQCeDR8',
+              y   : 'uf6CpgUBudrNABVkTLLOFQ5IaSCzEdiT2DDb5WvtBpA'
+            }
+          }
+        ],
+        authentication: [
+          '#authz'
+        ],
+        keyAgreement: [
+          '#enc'
+        ]
+      }
+    },
+
+    twoAuthenticationReferencedKeysJwkKeyIdMismatch: {
+      didDocument: {
+        '@context' : ['https://www.w3.org/ns/did/v1'],
+        id         : 'did:ion:EiAp_JjfvetzRV033JTaIiBIzh7UxP0Q6bGosMuPpo_4xQ:eyJkZWx0YSI6eyJwYXRjaGVzIjpbeyJhY3Rpb24iOiJyZXBsYWNlIiwiZG9jdW1lbnQiOnsicHVibGljS2V5cyI6W3siaWQiOiJhdXRoeiIsInB1YmxpY0tleUp3ayI6eyJjcnYiOiJzZWNwMjU2azEiLCJrdHkiOiJFQyIsIngiOiJRMl9RSUR5NERxRHJ6SVFESDFnWmZyQlo5OHYtV2JQWXNoXzBJVWZzVGpRIiwieSI6IlVvNlNDTHNDeGFRVGlsa1dSeDZNUUY1TzByRS1qWnlwb2dtR01nb0NkY2cifSwicHVycG9zZXMiOlsiYXV0aGVudGljYXRpb24iXSwidHlwZSI6Ikpzb25XZWJLZXkyMDIwIn0seyJpZCI6ImVuYyIsInB1YmxpY0tleUp3ayI6eyJjcnYiOiJzZWNwMjU2azEiLCJrdHkiOiJFQyIsIngiOiJmU25ZWmVwa1NNWXhFRmFGM3Z4TWZIaWw3SWhxWTRKNkpkejdxUUNlRFI4IiwieSI6InVmNkNwZ1VCdWRyTkFCVmtUTExPRlE1SWFTQ3pFZGlUMkREYjVXdnRCcEEifSwicHVycG9zZXMiOlsia2V5QWdyZWVtZW50Il0sInR5cGUiOiJKc29uV2ViS2V5MjAyMCJ9XSwic2VydmljZXMiOlt7ImlkIjoiZHduIiwic2VydmljZUVuZHBvaW50Ijp7Im1lc3NhZ2VBdXRob3JpemF0aW9uS2V5cyI6WyIjYXV0aHoiXSwibm9kZXMiOlsiaHR0cHM6Ly9kd24taG9zdC5jb20iXSwicmVjb3JkRW5jcnlwdGlvbktleXMiOlsiI3dyb25nIl19LCJ0eXBlIjoiRGVjZW50cmFsaXplZFdlYk5vZGUifV19fV0sInVwZGF0ZUNvbW1pdG1lbnQiOiJFaUNiM2Y1bW4zaWl5S0lIZHVTZzJ4d2hDRURKejRKQ0tjT0JLYWNpNzN4dGt3In0sInN1ZmZpeERhdGEiOnsiZGVsdGFIYXNoIjoiRWlDZmVhTWNZRUhSRHdhb3BzbVE5aWxTWkQ3S3hXeHJScVVrUGRYa2c3VWh6QSIsInJlY292ZXJ5Q29tbWl0bWVudCI6IkVpQ3M5TXFQVng3X1NkZU5Lb2ZjaVF1WVdPcTc3MHJKSG1FeFpkMzFoZXpuREEifX0',
+        service    : [
+          {
+            id              : '#dwn',
+            type            : 'DecentralizedWebNode',
+            serviceEndpoint : {
+              messageAuthorizationKeys: [
+                '#authz'
+              ],
+              nodes: [
+                'https://dwn-host.com'
+              ],
+              recordEncryptionKeys: [
+                '#wrong'
+              ]
+            }
+          }
+        ],
+        verificationMethod: [
+          {
+            id           : '#authz',
+            controller   : 'did:ion:EiAp_JjfvetzRV033JTaIiBIzh7UxP0Q6bGosMuPpo_4xQ:eyJkZWx0YSI6eyJwYXRjaGVzIjpbeyJhY3Rpb24iOiJyZXBsYWNlIiwiZG9jdW1lbnQiOnsicHVibGljS2V5cyI6W3siaWQiOiJhdXRoeiIsInB1YmxpY0tleUp3ayI6eyJjcnYiOiJzZWNwMjU2azEiLCJrdHkiOiJFQyIsIngiOiJRMl9RSUR5NERxRHJ6SVFESDFnWmZyQlo5OHYtV2JQWXNoXzBJVWZzVGpRIiwieSI6IlVvNlNDTHNDeGFRVGlsa1dSeDZNUUY1TzByRS1qWnlwb2dtR01nb0NkY2cifSwicHVycG9zZXMiOlsiYXV0aGVudGljYXRpb24iXSwidHlwZSI6Ikpzb25XZWJLZXkyMDIwIn0seyJpZCI6ImVuYyIsInB1YmxpY0tleUp3ayI6eyJjcnYiOiJzZWNwMjU2azEiLCJrdHkiOiJFQyIsIngiOiJmU25ZWmVwa1NNWXhFRmFGM3Z4TWZIaWw3SWhxWTRKNkpkejdxUUNlRFI4IiwieSI6InVmNkNwZ1VCdWRyTkFCVmtUTExPRlE1SWFTQ3pFZGlUMkREYjVXdnRCcEEifSwicHVycG9zZXMiOlsia2V5QWdyZWVtZW50Il0sInR5cGUiOiJKc29uV2ViS2V5MjAyMCJ9XSwic2VydmljZXMiOlt7ImlkIjoiZHduIiwic2VydmljZUVuZHBvaW50Ijp7Im1lc3NhZ2VBdXRob3JpemF0aW9uS2V5cyI6WyIjYXV0aHoiXSwibm9kZXMiOlsiaHR0cHM6Ly9kd24taG9zdC5jb20iXSwicmVjb3JkRW5jcnlwdGlvbktleXMiOlsiI3dyb25nIl19LCJ0eXBlIjoiRGVjZW50cmFsaXplZFdlYk5vZGUifV19fV0sInVwZGF0ZUNvbW1pdG1lbnQiOiJFaUNiM2Y1bW4zaWl5S0lIZHVTZzJ4d2hDRURKejRKQ0tjT0JLYWNpNzN4dGt3In0sInN1ZmZpeERhdGEiOnsiZGVsdGFIYXNoIjoiRWlDZmVhTWNZRUhSRHdhb3BzbVE5aWxTWkQ3S3hXeHJScVVrUGRYa2c3VWh6QSIsInJlY292ZXJ5Q29tbWl0bWVudCI6IkVpQ3M5TXFQVng3X1NkZU5Lb2ZjaVF1WVdPcTc3MHJKSG1FeFpkMzFoZXpuREEifX0',
+            type         : 'JsonWebKey2020',
+            publicKeyJwk : {
+              crv : 'secp256k1',
+              kty : 'EC',
+              x   : 'Q2_QIDy4DqDrzIQDH1gZfrBZ98v-WbPYsh_0IUfsTjQ',
+              y   : 'Uo6SCLsCxaQTilkWRx6MQF5O0rE-jZypogmGMgoCdcg'
+            }
+          },
+          {
+            id           : '#enc',
+            controller   : 'did:ion:EiAp_JjfvetzRV033JTaIiBIzh7UxP0Q6bGosMuPpo_4xQ:eyJkZWx0YSI6eyJwYXRjaGVzIjpbeyJhY3Rpb24iOiJyZXBsYWNlIiwiZG9jdW1lbnQiOnsicHVibGljS2V5cyI6W3siaWQiOiJhdXRoeiIsInB1YmxpY0tleUp3ayI6eyJjcnYiOiJzZWNwMjU2azEiLCJrdHkiOiJFQyIsIngiOiJRMl9RSUR5NERxRHJ6SVFESDFnWmZyQlo5OHYtV2JQWXNoXzBJVWZzVGpRIiwieSI6IlVvNlNDTHNDeGFRVGlsa1dSeDZNUUY1TzByRS1qWnlwb2dtR01nb0NkY2cifSwicHVycG9zZXMiOlsiYXV0aGVudGljYXRpb24iXSwidHlwZSI6Ikpzb25XZWJLZXkyMDIwIn0seyJpZCI6ImVuYyIsInB1YmxpY0tleUp3ayI6eyJjcnYiOiJzZWNwMjU2azEiLCJrdHkiOiJFQyIsIngiOiJmU25ZWmVwa1NNWXhFRmFGM3Z4TWZIaWw3SWhxWTRKNkpkejdxUUNlRFI4IiwieSI6InVmNkNwZ1VCdWRyTkFCVmtUTExPRlE1SWFTQ3pFZGlUMkREYjVXdnRCcEEifSwicHVycG9zZXMiOlsia2V5QWdyZWVtZW50Il0sInR5cGUiOiJKc29uV2ViS2V5MjAyMCJ9XSwic2VydmljZXMiOlt7ImlkIjoiZHduIiwic2VydmljZUVuZHBvaW50Ijp7Im1lc3NhZ2VBdXRob3JpemF0aW9uS2V5cyI6WyIjYXV0aHoiXSwibm9kZXMiOlsiaHR0cHM6Ly9kd24taG9zdC5jb20iXSwicmVjb3JkRW5jcnlwdGlvbktleXMiOlsiI3dyb25nIl19LCJ0eXBlIjoiRGVjZW50cmFsaXplZFdlYk5vZGUifV19fV0sInVwZGF0ZUNvbW1pdG1lbnQiOiJFaUNiM2Y1bW4zaWl5S0lIZHVTZzJ4d2hDRURKejRKQ0tjT0JLYWNpNzN4dGt3In0sInN1ZmZpeERhdGEiOnsiZGVsdGFIYXNoIjoiRWlDZmVhTWNZRUhSRHdhb3BzbVE5aWxTWkQ3S3hXeHJScVVrUGRYa2c3VWh6QSIsInJlY292ZXJ5Q29tbWl0bWVudCI6IkVpQ3M5TXFQVng3X1NkZU5Lb2ZjaVF1WVdPcTc3MHJKSG1FeFpkMzFoZXpuREEifX0',
+            type         : 'JsonWebKey2020',
+            publicKeyJwk : {
+              crv : 'secp256k1',
+              kty : 'EC',
+              x   : 'fSnYZepkSMYxEFaF3vxMfHil7IhqY4J6Jdz7qQCeDR8',
+              y   : 'uf6CpgUBudrNABVkTLLOFQ5IaSCzEdiT2DDb5WvtBpA'
+            }
+          }
+        ],
+        authentication: [
+          '#authz'
+        ],
+        keyAgreement: [
+          '#enc'
+        ]
+      }
+    },
+  }
+};
+
+export const key = {
+  notFound: {
+    didDocument           : null,
+    didDocumentMetadata   : {},
+    didResolutionMetadata : {
+      error: 'invalidDid',
+    },
+  },
+
+  malformed: {
+    didDocument: {
+      id: 'did:key:z6MkhvthBZDxVvLUswRey729CquxMiaoYXrT5SYbCAATc8V9',
+    },
+  },
+
+  noVerificationMethods: {
+    didDocument: {
+      '@context': [
+        'https://www.w3.org/ns/did/v1',
+        'https://w3id.org/security/suites/jws-2020/v1',
+        'https://w3id.org/security/suites/ed25519-2020/v1',
+      ],
+      id                 : 'did:ion:z6MkhvthBZDxVvLUswRey729CquxMiaoYXrT5SYbCAATc8V9',
+      verificationMethod : [],
+    },
+  },
+
+  oneVerificationMethodJwk: {
+    didDocument: {
+      '@context': [
+        'https://www.w3.org/ns/did/v1',
+        'https://w3id.org/security/suites/jws-2020/v1',
+        'https://w3id.org/security/suites/ed25519-2020/v1',
+      ],
+      id                 : 'did:key:z6MkhvthBZDxVvLUswRey729CquxMiaoYXrT5SYbCAATc8V9',
+      verificationMethod : [
+        {
+          id           : 'did:key:z6MkhvthBZDxVvLUswRey729CquxMiaoYXrT5SYbCAATc8V9#z6MkhvthBZDxVvLUswRey729CquxMiaoYXrT5SYbCAATc8V9',
+          type         : 'JsonWebKey2020',
+          controller   : 'did:key:z6MkhvthBZDxVvLUswRey729CquxMiaoYXrT5SYbCAATc8V9',
+          publicKeyJwk : {
+            alg : 'EdDSA',
+            kty : 'OKP',
+            crv : 'Ed25519',
+            x   : 'M6cuSLXzNrcydvtfswnRxDhnictOvjyzXne6ljRVw9Q',
+          },
+        },
+      ],
+    },
+  },
+
+  oneVerificationMethodMultibase: {
+    didDocument: {
+      '@context': [
+        'https://www.w3.org/ns/did/v1',
+        'https://w3id.org/security/suites/ed25519-2020/v1',
+      ],
+      id                 : 'did:key:z6MkhvthBZDxVvLUswRey729CquxMiaoYXrT5SYbCAATc8V9',
+      verificationMethod : [
+        {
+          id                 : 'did:key:z6MkhvthBZDxVvLUswRey729CquxMiaoYXrT5SYbCAATc8V9#z6MkhvthBZDxVvLUswRey729CquxMiaoYXrT5SYbCAATc8V9',
+          type               : 'Ed25519VerificationKey2020',
+          controller         : 'did:key:z6MkhvthBZDxVvLUswRey729CquxMiaoYXrT5SYbCAATc8V9',
+          publicKeyMultibase : 'zH3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV',
+        },
+      ],
+    },
+  },
+
+  twoAuthenticationReferencedKeysJwk: {
+    didDocument: {
+      '@context': [
+        'https://www.w3.org/ns/did/v1',
+        'https://w3id.org/security/suites/jws-2020/v1',
+        'https://w3id.org/security/suites/ed25519-2020/v1',
+      ],
+      id                 : 'did:key:z6MkhvthBZDxVvLUswRey729CquxMiaoYXrT5SYbCAATc8V9',
+      verificationMethod : [
+        {
+          id           : 'did:key:z6MkhvthBZDxVvLUswRey729CquxMiaoYXrT5SYbCAATc8V9#key-1',
+          type         : 'JsonWebKey2020',
+          controller   : 'did:key:z6MkhvthBZDxVvLUswRey729CquxMiaoYXrT5SYbCAATc8V9',
+          publicKeyJwk : {
+            alg : 'EdDSA',
+            kty : 'OKP',
+            crv : 'Ed25519',
+            x   : 'M6cuSLXzNrcydvtfswnRxDhnictOvjyzXne6ljRVw9Q',
+          },
+        },
+        {
+          id           : 'did:key:z6MkhvthBZDxVvLUswRey729CquxMiaoYXrT5SYbCAATc8V9#key-2',
+          type         : 'JsonWebKey2020',
+          controller   : 'did:key:z6MkhvthBZDxVvLUswRey729CquxMiaoYXrT5SYbCAATc8V9',
+          publicKeyJwk : {
+            alg : 'EdDSA',
+            kty : 'OKP',
+            crv : 'Ed25519',
+            x   : 'M6cuSLXzNrcydvtfswnRxDhnictOvjyzXne6ljRVw9Q',
+          },
+        },
+      ],
+      'authentication': [
+        'did:key:z6MkhvthBZDxVvLUswRey729CquxMiaoYXrT5SYbCAATc8V9#key-1',
+        'did:key:z6MkhvthBZDxVvLUswRey729CquxMiaoYXrT5SYbCAATc8V9#key-2',
+      ],
+    },
+  },
+
+  manyVerificationMethodsJwk: {
+    didDocument: {
+      '@context': [
+        'https://www.w3.org/ns/did/v1',
+        'https://w3id.org/security/suites/jws-2020/v1',
+        'https://w3id.org/security/suites/ed25519-2020/v1',
+      ],
+      id                 : 'did:key:z6MkhvthBZDxVvLUswRey729CquxMiaoYXrT5SYbCAATc8V9',
+      verificationMethod : [
+        {
+          id           : 'did:key:z6MkhvthBZDxVvLUswRey729CquxMiaoYXrT5SYbCAATc8V9#key-1',
+          type         : 'JsonWebKey2020',
+          controller   : 'did:key:z6MkhvthBZDxVvLUswRey729CquxMiaoYXrT5SYbCAATc8V9',
+          publicKeyJwk : {
+            alg : 'EdDSA',
+            kty : 'OKP',
+            crv : 'Ed25519',
+            x   : 'M6cuSLXzNrcydvtfswnRxDhnictOvjyzXne6ljRVw9Q',
+          },
+        },
+        {
+          id           : 'did:key:z6MkhvthBZDxVvLUswRey729CquxMiaoYXrT5SYbCAATc8V9#key-2',
+          type         : 'JsonWebKey2020',
+          controller   : 'did:key:z6MkhvthBZDxVvLUswRey729CquxMiaoYXrT5SYbCAATc8V9',
+          publicKeyJwk : {
+            alg : 'EdDSA',
+            kty : 'OKP',
+            crv : 'Ed25519',
+            x   : 'M6cuSLXzNrcydvtfswnRxDhnictOvjyzXne6ljRVw9Q',
+          },
+        },
+      ],
+      'authentication': [
+        'did:key:z6MkhvthBZDxVvLUswRey729CquxMiaoYXrT5SYbCAATc8V9#key-1',
+        {
+          id           : 'did:key:z6MkhvthBZDxVvLUswRey729CquxMiaoYXrT5SYbCAATc8V9#key-3',
+          type         : 'Ed25519VerificationKey2020',
+          controller   : 'did:key:z6MkhvthBZDxVvLUswRey729CquxMiaoYXrT5SYbCAATc8V9',
+          publicKeyJwk : {
+            alg : 'EdDSA',
+            kty : 'OKP',
+            crv : 'Ed25519',
+            x   : 'M6cuSLXzNrcydvtfswnRxDhnictOvjyzXne6ljRVw9Q',
+          },
+        },
+        {
+          id           : 'did:key:z6MkhvthBZDxVvLUswRey729CquxMiaoYXrT5SYbCAATc8V9#key-4',
+          type         : 'Ed25519VerificationKey2020',
+          controller   : 'did:key:z6MkhvthBZDxVvLUswRey729CquxMiaoYXrT5SYbCAATc8V9',
+          publicKeyJwk : {
+            alg : 'EdDSA',
+            kty : 'OKP',
+            crv : 'Ed25519',
+            x   : 'M6cuSLXzNrcydvtfswnRxDhnictOvjyzXne6ljRVw9Q',
+          },
+        },
+      ],
+      'keyAgreement': [
+        {
+          id           : 'did:key:z6MkhvthBZDxVvLUswRey729CquxMiaoYXrT5SYbCAATc8V9#key-5',
+          type         : 'X25519KeyAgreementKey2020',
+          controller   : 'did:key:z6MkhvthBZDxVvLUswRey729CquxMiaoYXrT5SYbCAATc8V9',
+          publicKeyJwk : {
+            alg : 'EdDSA',
+            kty : 'OKP',
+            crv : 'Ed25519',
+            x   : 'M6cuSLXzNrcydvtfswnRxDhnictOvjyzXne6ljRVw9Q',
+          },
+        },
+        {
+          id           : 'did:key:z6MkhvthBZDxVvLUswRey729CquxMiaoYXrT5SYbCAATc8V9#key-6',
+          type         : 'X25519KeyAgreementKey2020',
+          controller   : 'did:key:z6MkhvthBZDxVvLUswRey729CquxMiaoYXrT5SYbCAATc8V9',
+          publicKeyJwk : {
+            alg : 'EdDSA',
+            kty : 'OKP',
+            crv : 'Ed25519',
+            x   : 'M6cuSLXzNrcydvtfswnRxDhnictOvjyzXne6ljRVw9Q',
+          },
+        },
+      ],
+      'assertionMethod': [
+        'did:key:z6MkhvthBZDxVvLUswRey729CquxMiaoYXrT5SYbCAATc8V9#key-2',
+        {
+          id           : 'did:key:z6MkhvthBZDxVvLUswRey729CquxMiaoYXrT5SYbCAATc8V9#key-7',
+          type         : 'Ed25519VerificationKey2020',
+          controller   : 'did:key:z6MkhvthBZDxVvLUswRey729CquxMiaoYXrT5SYbCAATc8V9',
+          publicKeyJwk : {
+            alg : 'EdDSA',
+            kty : 'OKP',
+            crv : 'Ed25519',
+            x   : 'M6cuSLXzNrcydvtfswnRxDhnictOvjyzXne6ljRVw9Q',
+          },
+        },
+        {
+          id           : 'did:key:z6MkhvthBZDxVvLUswRey729CquxMiaoYXrT5SYbCAATc8V9#key-8',
+          type         : 'Ed25519VerificationKey2020',
+          controller   : 'did:key:z6MkhvthBZDxVvLUswRey729CquxMiaoYXrT5SYbCAATc8V9',
+          publicKeyJwk : {
+            alg : 'EdDSA',
+            kty : 'OKP',
+            crv : 'Ed25519',
+            x   : 'M6cuSLXzNrcydvtfswnRxDhnictOvjyzXne6ljRVw9Q',
+          },
+        },
+      ],
+    },
+  },
+
+  manyVerificationMethodsMultibase: {
+    didDocument: {
+      '@context': [
+        'https://www.w3.org/ns/did/v1',
+        'https://w3id.org/security/suites/ed25519-2020/v1',
+      ],
+      id                 : 'did:key:z6MkhvthBZDxVvLUswRey729CquxMiaoYXrT5SYbCAATc8V9',
+      verificationMethod : [
+        {
+          id                 : 'did:key:z6MkhvthBZDxVvLUswRey729CquxMiaoYXrT5SYbCAATc8V9#key-1',
+          type               : 'Ed25519VerificationKey2020',
+          controller         : 'did:key:z6MkhvthBZDxVvLUswRey729CquxMiaoYXrT5SYbCAATc8V9',
+          publicKeyMultibase : 'zH3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV',
+        },
+        {
+          id                 : 'did:key:z6MkhvthBZDxVvLUswRey729CquxMiaoYXrT5SYbCAATc8V9#key-2',
+          type               : 'Ed25519VerificationKey2020',
+          controller         : 'did:key:z6MkhvthBZDxVvLUswRey729CquxMiaoYXrT5SYbCAATc8V9',
+          publicKeyMultibase : 'zH3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV',
+        },
+      ],
+      'authentication': [
+        'did:key:z6MkhvthBZDxVvLUswRey729CquxMiaoYXrT5SYbCAATc8V9#key-1',
+        {
+          id                 : 'did:key:z6MkhvthBZDxVvLUswRey729CquxMiaoYXrT5SYbCAATc8V9#key-3',
+          type               : 'Ed25519VerificationKey2020',
+          controller         : 'did:key:z6MkhvthBZDxVvLUswRey729CquxMiaoYXrT5SYbCAATc8V9',
+          publicKeyMultibase : 'zH3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV',
+        },
+        {
+          id                 : 'did:key:z6MkhvthBZDxVvLUswRey729CquxMiaoYXrT5SYbCAATc8V9#key-4',
+          type               : 'Ed25519VerificationKey2020',
+          controller         : 'did:key:z6MkhvthBZDxVvLUswRey729CquxMiaoYXrT5SYbCAATc8V9',
+          publicKeyMultibase : 'zH3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV',
+        },
+      ],
+      'keyAgreement': [
+        {
+          id                 : 'did:key:z6MkhvthBZDxVvLUswRey729CquxMiaoYXrT5SYbCAATc8V9#key-5',
+          type               : 'X25519KeyAgreementKey2020',
+          controller         : 'did:key:z6MkhvthBZDxVvLUswRey729CquxMiaoYXrT5SYbCAATc8V9',
+          publicKeyMultibase : 'zH3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV',
+        },
+        {
+          id                 : 'did:key:z6MkhvthBZDxVvLUswRey729CquxMiaoYXrT5SYbCAATc8V9#key-6',
+          type               : 'X25519KeyAgreementKey2020',
+          controller         : 'did:key:z6MkhvthBZDxVvLUswRey729CquxMiaoYXrT5SYbCAATc8V9',
+          publicKeyMultibase : 'zH3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV',
+        },
+      ],
+      'assertionMethod': [
+        'did:key:z6MkhvthBZDxVvLUswRey729CquxMiaoYXrT5SYbCAATc8V9#key-2',
+        {
+          id                 : 'did:key:z6MkhvthBZDxVvLUswRey729CquxMiaoYXrT5SYbCAATc8V9#key-7',
+          type               : 'Ed25519VerificationKey2020',
+          controller         : 'did:key:z6MkhvthBZDxVvLUswRey729CquxMiaoYXrT5SYbCAATc8V9',
+          publicKeyMultibase : 'zH3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV',
+        },
+        {
+          id                 : 'did:key:z6MkhvthBZDxVvLUswRey729CquxMiaoYXrT5SYbCAATc8V9#key-8',
+          type               : 'Ed25519VerificationKey2020',
+          controller         : 'did:key:z6MkhvthBZDxVvLUswRey729CquxMiaoYXrT5SYbCAATc8V9',
+          publicKeyMultibase : 'zH3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV',
+        },
+      ],
+    },
+  },
+};

--- a/packages/dids/tests/utils.spec.ts
+++ b/packages/dids/tests/utils.spec.ts
@@ -1,0 +1,161 @@
+import { DidDocument } from '../src/types.js';
+
+import { expect } from 'chai';
+
+import * as DidUtils from '../src/utils.js';
+import * as didDocuments from './fixtures/did-documents.js';
+
+describe('DID Utils', () => {
+  describe('findVerificationMethods()', () => {
+
+    it('throws an error if didDocument is missing', () => {
+      expect(() => DidUtils.findVerificationMethods({ id: 'did:key:abcd1234' })).to.throw('required argument');
+    });
+
+    it('should not throw an error if purpose and method ID are both missing', () => {
+      const didDocument = didDocuments.key.oneVerificationMethodJwk.didDocument;
+      expect(() => DidUtils.findVerificationMethods(didDocument)).to.not.throw();
+    });
+
+    it('should throw error if purpose and method ID are both specified', () => {
+      const didDocument = didDocuments.key.oneVerificationMethodJwk.didDocument;
+      expect(() => DidUtils.findVerificationMethods(didDocument, { id: ' ', purpose: ' ' })).to.throw('Specify method ID or purpose but not both');
+    });
+
+    describe('by method ID', () => {
+      it('should return single verification method when defined in single method DID document', () => {
+        const didDocument = didDocuments.key.oneVerificationMethodJwk.didDocument;
+        const id = didDocuments.key.oneVerificationMethodJwk.didDocument.verificationMethod[0].id;
+
+        const verificationMethods = DidUtils.findVerificationMethods(didDocument, { id });
+
+        if (verificationMethods === null) expect.fail();
+        expect(verificationMethods).to.be.an('Array');
+        expect(verificationMethods).to.have.lengthOf(1);
+        expect(verificationMethods[0]).to.be.an('object');
+        expect(verificationMethods[0]).to.have.property('id', id);
+      });
+
+      it('should return single verification method when defined in multi method DID document', () => {
+        const didDocument = didDocuments.key.manyVerificationMethodsJwk.didDocument as DidDocument;
+        const id = didDocuments.key.manyVerificationMethodsJwk.didDocument.verificationMethod[1].id;
+
+        const verificationMethods = DidUtils.findVerificationMethods(didDocument, { id });
+
+        if (verificationMethods === null) expect.fail();
+        expect(verificationMethods).to.be.an('Array');
+        expect(verificationMethods).to.have.lengthOf(1);
+        expect(verificationMethods[0]).to.be.an('object');
+        expect(verificationMethods[0]).to.have.property('id', id);
+      });
+
+      it('should return single verification method when embedded in purpose', () => {
+        const didDocument = didDocuments.key.manyVerificationMethodsJwk.didDocument as DidDocument;
+        const id = didDocuments.key.manyVerificationMethodsJwk.didDocument['keyAgreement'][1].id;
+
+        const verificationMethods = DidUtils.findVerificationMethods(didDocument, { id });
+
+        if (verificationMethods === null) expect.fail();
+        expect(verificationMethods).to.be.an('Array');
+        expect(verificationMethods).to.have.lengthOf(1);
+        expect(verificationMethods[0]).to.be.an('object');
+        expect(verificationMethods[0]).to.have.property('id', id);
+      });
+
+      it('should return null if verification method ID not found', () => {
+        const didDocument = didDocuments.key.oneVerificationMethodJwk.didDocument;
+        const verificationMethods = DidUtils.findVerificationMethods(didDocument, { id: 'did:key:abcd1234#def980' });
+        expect(verificationMethods).to.be.null;
+      });
+
+      it('should return one verification method when no method ID is specified in single method DID document', () => {
+        const didDocument = didDocuments.key.oneVerificationMethodJwk.didDocument as DidDocument;
+
+        const verificationMethods = DidUtils.findVerificationMethods(didDocument);
+
+        if (verificationMethods === null) expect.fail();
+        expect(verificationMethods).to.be.an('Array');
+        expect(verificationMethods).to.have.lengthOf(1);
+        expect(verificationMethods[0]).to.be.an('object');
+      });
+
+      it('should return all verification methods when no method ID is specified in single method DID document', () => {
+        const didDocument = didDocuments.key.manyVerificationMethodsJwk.didDocument as DidDocument;
+
+        const verificationMethods = DidUtils.findVerificationMethods(didDocument);
+
+        if (verificationMethods === null) expect.fail();
+        expect(verificationMethods).to.be.an('Array');
+        expect(verificationMethods).to.have.lengthOf(8);
+        expect(verificationMethods[0]).to.have.property('id');
+        expect(verificationMethods[1]).to.have.property('id');
+        expect(verificationMethods[2]).to.have.property('id');
+        expect(verificationMethods[3]).to.have.property('id');
+        expect(verificationMethods[4]).to.have.property('id');
+        expect(verificationMethods[5]).to.have.property('id');
+        expect(verificationMethods[6]).to.have.property('id');
+        expect(verificationMethods[7]).to.have.property('id');
+      });
+    });
+
+    describe('by purpose', () => {
+      it('should return an array of verification methods if multiple referenced methods are defined', () => {
+        const didDocument = didDocuments.key.twoAuthenticationReferencedKeysJwk.didDocument as DidDocument;
+        const purpose = 'authentication';
+
+        const verificationMethods = DidUtils.findVerificationMethods(didDocument, { purpose });
+
+        if (verificationMethods === null) expect.fail();
+        expect(verificationMethods).to.be.an('Array');
+        expect(verificationMethods).to.have.lengthOf(2);
+        const keyId1 = didDocuments.key.twoAuthenticationReferencedKeysJwk.didDocument.verificationMethod[0].id;
+        expect(verificationMethods[0]).to.have.property('id', keyId1);
+        const keyId2 = didDocuments.key.twoAuthenticationReferencedKeysJwk.didDocument.verificationMethod[1].id;
+        expect(verificationMethods[1]).to.have.property('id', keyId2);
+      });
+
+      it('should return an array of verification methods if multiple embedded methods are defined', () => {
+        const didDocument = didDocuments.key.manyVerificationMethodsJwk.didDocument as DidDocument;
+        const purpose = 'keyAgreement';
+
+        const verificationMethods = DidUtils.findVerificationMethods(didDocument, { purpose });
+
+        if (verificationMethods === null) expect.fail();
+        expect(verificationMethods).to.be.an('Array');
+        expect(verificationMethods).to.have.lengthOf(2);
+        const keyId1 = didDocuments.key.manyVerificationMethodsJwk.didDocument['keyAgreement'][0].id;
+        expect(verificationMethods[0]).to.have.property('id', keyId1);
+        const keyId2 = didDocuments.key.manyVerificationMethodsJwk.didDocument['keyAgreement'][1].id;
+        expect(verificationMethods[1]).to.have.property('id', keyId2);
+      });
+
+      it('should return an array of verification methods if referenced and embedded methods are defined', () => {
+        const didDocument = didDocuments.key.manyVerificationMethodsJwk.didDocument as DidDocument;
+        const purpose = 'authentication';
+
+        const verificationMethods = DidUtils.findVerificationMethods(didDocument, { purpose });
+
+        if (verificationMethods === null) expect.fail();
+        expect(verificationMethods).to.be.an('Array');
+        expect(verificationMethods).to.have.lengthOf(3);
+        const keyId1 = didDocuments.key.manyVerificationMethodsJwk.didDocument.verificationMethod[0].id;
+        expect(verificationMethods[0]).to.have.property('id', keyId1);
+        // @ts-expect-error because the id a verification method could be a string and not object.
+        const keyId2 = didDocuments.key.manyVerificationMethodsJwk.didDocument['authentication'][1].id;
+        expect(verificationMethods[1]).to.have.property('id', keyId2);
+        // @ts-expect-error because the id a verification method could be a string and not object.
+        const keyId3 = didDocuments.key.manyVerificationMethodsJwk.didDocument['authentication'][2].id;
+        expect(verificationMethods[2]).to.have.property('id', keyId3);
+      });
+
+      it('should return null if purpose not found', () => {
+        const didDocument = didDocuments.key.twoAuthenticationReferencedKeysJwk.didDocument as DidDocument;
+        const purpose = 'keyAgreement';
+
+        const verificationMethods = DidUtils.findVerificationMethods(didDocument, { purpose });
+
+        expect(verificationMethods).to.be.null;
+      });
+    });
+  });
+});

--- a/packages/web5-agent/src/web5-agent.ts
+++ b/packages/web5-agent/src/web5-agent.ts
@@ -2,16 +2,17 @@ import type { Readable } from 'readable-stream';
 
 import {
   MessageReply,
-  RecordsQueryMessage,
-  ProtocolsQueryMessage,
-  ProtocolsConfigureMessage,
   EventsGetMessage,
   MessagesGetMessage,
+  RecordsQueryMessage,
   RecordsWriteMessage,
-  RecordsDeleteMessage
+  RecordsDeleteMessage,
+  ProtocolsQueryMessage,
+  ProtocolsConfigureMessage,
 } from '@tbd54566975/dwn-sdk-js';
 
 import type { JsonRpcResponse } from './json-rpc.js';
+
 export interface Web5Agent {
   processDwnRequest(request: ProcessDwnRequest): Promise<DwnResponse>
   sendDwnRequest(request: SendDwnRequest): Promise<DwnResponse>;
@@ -35,11 +36,17 @@ export type DwnRequest = {
   messageType: string;
 }
 
+// TODO: De-duplicate and put in either `web5` or `web5-agent`.
+export type RecordEncryptionOptions = {
+  for?: string;
+}
+
 /**
  * TODO: add JSDoc
  */
 export type ProcessDwnRequest = DwnRequest & {
   dataStream?: Blob | ReadableStream | Readable;
+  encrypt?: boolean | RecordEncryptionOptions;
   messageOptions: unknown;
 };
 

--- a/packages/web5-user-agent/.vscode/launch.json
+++ b/packages/web5-user-agent/.vscode/launch.json
@@ -1,0 +1,22 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "test:node",
+      "runtimeExecutable": "${workspaceFolder:root}/node_modules/.bin/mocha",
+      "runtimeArgs": [
+        "${workspaceFolder:web5-user-agent}/__tests__/**/*.spec.js"
+      ],
+      "console": "internalConsole",
+      "preLaunchTask": "tsc: build - tsconfig.test.json",
+      "outFiles": [
+        "${workspaceFolder:web5-user-agent}/__tests__/**/*.js"
+      ],
+    }
+  ]
+}

--- a/packages/web5-user-agent/.vscode/tasks.json
+++ b/packages/web5-user-agent/.vscode/tasks.json
@@ -1,0 +1,45 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"label": "npm run build",
+			"type": "npm",
+			"script": "build",
+			"problemMatcher": [],
+			"group": {
+				"kind": "build",
+				"isDefault": true
+			}
+		},
+		{
+			"label": "tsc: build - tsconfig.json",
+			"type": "typescript",
+			"tsconfig": "tsconfig.json",
+			"problemMatcher": [
+				"$tsc"
+			],
+			"group": {
+				"kind": "build",
+				"isDefault": false
+			},
+			"options": {
+				"cwd": "${workspaceFolder:root}"
+			}
+		},
+		{
+			"label": "tsc: build - tsconfig.test.json",
+			"type": "typescript",
+			"tsconfig": "tsconfig.test.json",
+			"problemMatcher": [
+				"$tsc"
+			],
+			"group": {
+				"kind": "build",
+				"isDefault": false
+			},
+			"options": {
+				"cwd": "${workspaceFolder:root}"
+			}
+		},
+	]
+}

--- a/packages/web5-user-agent/src/utils.ts
+++ b/packages/web5-user-agent/src/utils.ts
@@ -1,10 +1,118 @@
-import type { Readable } from 'readable-stream';
+import type { PublicKeyJwk } from '@tbd54566975/crypto';
+import type { EncryptionInput } from '@tbd54566975/dwn-sdk-js';
+
+import { utils as cryptoUtils } from '@tbd54566975/crypto';
+import { PassThrough, Readable } from 'readable-stream';
+import { Encryption, KeyDerivationScheme } from '@tbd54566975/dwn-sdk-js';
 import { ReadableWebToNodeStream } from 'readable-web-to-node-stream';
+
+export type EncryptInputOptions = {
+  protocol?: string;
+  schema?: string;
+}
 
 export function blobToIsomorphicNodeReadable(blob: Blob): Readable {
   return webReadableToIsomorphicNodeReadable(blob.stream());
 }
 
+export function generateDwnEncryptionInput(publickKeyJwk: PublicKeyJwk, encryptionInputOptions: EncryptInputOptions): EncryptionInput {
+  // Generate random symmetric encryption key.
+  const symmetricKey = cryptoUtils.randomBytes(32);
+
+  // Generate random initialization vector.
+  const initializationVector = cryptoUtils.randomBytes(16);
+
+  const encryptionInput: EncryptionInput = {
+    initializationVector : initializationVector,
+    key                  : symmetricKey,
+    keyEncryptionInputs  : []
+  };
+
+  // Always add the DataFormats derivation scheme since `dataFormats` is a required record property.
+  encryptionInput.keyEncryptionInputs.push({
+    derivationScheme : KeyDerivationScheme.DataFormats,
+    publicKey        : publickKeyJwk
+  });
+
+  // Add Protocols derivation scheme only if `protocols` is defined.
+  if (encryptionInputOptions.protocol) {
+    encryptionInput.keyEncryptionInputs.push({
+      derivationScheme : KeyDerivationScheme.Protocols,
+      publicKey        : publickKeyJwk
+    });
+  }
+
+  // Add Schemas derivation scheme if `schema` is defined.
+  if (encryptionInputOptions.schema) {
+    encryptionInput.keyEncryptionInputs.push({
+      derivationScheme : KeyDerivationScheme.Schemas,
+      publicKey        : publickKeyJwk
+    });
+  }
+
+  return encryptionInput;
+}
+
+export async function encryptBlobToStream(encryptionInput: EncryptionInput, plaintextBlob: Blob): Promise<Readable> {
+  if (!(plaintextBlob instanceof Blob)) {
+    throw new TypeError('Argument plaintextBlob must be a Blob');
+  }
+
+  // Convert plaintext blob to Node Readable.
+  const plaintextStream = blobToIsomorphicNodeReadable(plaintextBlob);
+
+  // Encrypt the data stream.
+  const symmetricKey = encryptionInput.key;
+  const initializationVector = encryptionInput.initializationVector;
+  const cipherStream = await Encryption.aes256CtrEncrypt(symmetricKey, initializationVector, plaintextStream);
+
+  return cipherStream;
+}
+
+export async function encryptStream(encryptionInput: EncryptionInput, plaintextStream: Readable): Promise<Readable> {
+  if (isWebReadableStream(plaintextStream)) {
+    throw new TypeError('argument plaintextStream must be a Node.js Readable.');
+  }
+
+  // Encrypt the data stream.
+  const symmetricKey = encryptionInput.key;
+  const initializationVector = encryptionInput.initializationVector;
+  const cipherStream = await Encryption.aes256CtrEncrypt(symmetricKey, initializationVector, plaintextStream);
+
+  return cipherStream;
+}
+
+export function isNodeReadableStream (stream: Readable): boolean {
+  return stream &&
+    typeof stream === 'object' &&
+    typeof stream.pipe === 'function' &&
+    typeof stream.on === 'function';
+}
+
+export function isWebReadableStream (stream: Readable): boolean {
+  return stream && !isNodeReadableStream;
+}
+
+/**
+ * Converts a readable stream or iterable to Blob.
+ * Note: Reads entire stream contents into memory.
+ */
+export async function streamToBlob(stream: AsyncIterable<any>|ReadableStream|Readable): Promise<Blob> {
+  const chunks = [];
+  //@ts-expect-error that not all `stream` types have a '[Symbol.asyncIterator]()' method that returns an async iterator
+  for await (const chunk of stream)
+    chunks.push(chunk);
+  return new Blob(chunks);
+}
+
 export function webReadableToIsomorphicNodeReadable(webReadable: ReadableStream) {
   return new ReadableWebToNodeStream(webReadable);
+}
+
+export function teeNodeReadable(stream: Readable): [Readable, Readable] {
+  const pass1 = new PassThrough();
+  const pass2 = new PassThrough();
+  stream.pipe(pass1);
+  stream.pipe(pass2);
+  return [<unknown>pass1 as Readable, <unknown>pass2 as Readable];
 }

--- a/packages/web5-user-agent/src/web5-user-agent.ts
+++ b/packages/web5-user-agent/src/web5-user-agent.ts
@@ -230,13 +230,12 @@ export class Web5UserAgent implements Web5Agent {
   }
 
   async #constructDwnMessage(request: ProcessDwnRequest) {
-    // TODO: Show Henry the consequence of choosing Readable for the DWN SDK.
+    // TODO: Reconsider use of Node Readable for the DWN SDK and evaluate refactor to use Web ReadableStream.
 
     const dwnSignatureInput = await this.#getAuthorSignatureInput(request.author);
     let streamForProcessMessage: Readable;
 
-    // TODO: MOVE ALL THIS TO HTTP TRANSPORT LAND BECAUSE THATS WHY WE HAVE TO DO IT
-    // THANKS A LOT BROWSER NECKBEARDS
+    // TODO: Consider refactoring to move data transformations imposed by fetch() limitations to the HTTP transport-related methods.
     if (request.messageType === 'RecordsWrite') {
       const messageOptions = request.messageOptions as RecordsWriteOptions;
 
@@ -304,7 +303,7 @@ export class Web5UserAgent implements Web5Agent {
       }
     }
 
-    // TODO: if we ever find time, figure out how to narrow this type. may have figured something out in `web5.DidInterface`
+    // TODO: Figure out how to narrow this type. may have figured something out in `web5.DidInterface`
     const messageCreateInput = {
       ...<any>request.messageOptions,
       authorizationSignatureInput: dwnSignatureInput

--- a/packages/web5-user-agent/tests/common/web5-user-agent.spec.ts
+++ b/packages/web5-user-agent/tests/common/web5-user-agent.spec.ts
@@ -1,6 +1,14 @@
-import { expect } from 'chai';
-import { Encoder, RecordsWriteMessage, RecordsRead } from '@tbd54566975/dwn-sdk-js';
+import type { MessageReply, RecordsRead, RecordsWriteMessage } from '@tbd54566975/dwn-sdk-js';
+
+import chai, { expect } from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import { Encoder } from '@tbd54566975/dwn-sdk-js';
+
 import { TestAgent } from './utils/test-user-agent.js';
+import * as testProfile from '../fixtures/test-profiles.js';
+import messageProtocolDefinition from '../fixtures/protocol-definitions/message.json' assert { type: 'json' };
+
+chai.use(chaiAsPromised);
 
 let did: string;
 let dwnNodes: string[] = ['https://dwn.tbddev.org/dwn0'];
@@ -22,8 +30,204 @@ describe('Web5UserAgent', () => {
     await testAgent.closeStorage();
   });
 
+  describe('processDwnRequest', () => {
+    it('throws an error if DID doc is missing DWN service endoint', async () => {
+      const dataBlob = new Blob(['Hello, world!']);
+      const { did: aliceDid } = await testAgent.createProfile();
+
+      await expect(testAgent.agent.processDwnRequest({
+        author         : aliceDid,
+        dataStream     : dataBlob,
+        encrypt        : true,
+        messageOptions : { dataFormat: 'text/plain' },
+        messageType    : 'RecordsWrite',
+        target         : aliceDid
+      })).to.eventually.be.rejectedWith('service endpoint defined in DID document');
+    });
+
+    it('throws an error if DID doc is missing record encryption keys', async () => {
+      const dataBlob = new Blob(['Hello, world!']);
+      const testProfileOptions = await testProfile.ion.with.dwn.service.and.authorization.keys();
+      const { did: aliceDid } = await testAgent.createProfile(testProfileOptions);
+
+      await expect(testAgent.agent.processDwnRequest({
+        author         : aliceDid,
+        dataStream     : dataBlob,
+        encrypt        : true,
+        messageOptions : { dataFormat: 'text/plain' },
+        messageType    : 'RecordsWrite',
+        target         : aliceDid
+      })).to.eventually.be.rejectedWith(`no 'recordEncryptionKeys' defined`);
+    });
+
+    it('throws an error if record encryption key ID cannot be found in DID document', async () => {
+      const dataBlob = new Blob(['Hello, world!']);
+      const testProfileOptions = {
+        keys: [
+          await testProfile.keys.secp256k1.jwk.authorization(),
+          await testProfile.keys.secp256k1.jwk.encryption()
+        ],
+        services: [{
+          'id'              : 'dwn',
+          'type'            : 'DecentralizedWebNode',
+          'serviceEndpoint' : {
+            'nodes'                    : ['https://dwn-host.com'],
+            'messageAuthorizationKeys' : ['#authz'],
+            'recordEncryptionKeys'     : ['#wrong']
+          }
+        }]
+      };
+      const { did: aliceDid } = await testAgent.createProfile({
+        profileDidOptions: testProfileOptions
+      });
+
+      await expect(testAgent.agent.processDwnRequest({
+        author         : aliceDid,
+        dataStream     : dataBlob,
+        encrypt        : true,
+        messageOptions : { dataFormat: 'text/plain' },
+        messageType    : 'RecordsWrite',
+        target         : aliceDid
+      })).to.eventually.be.rejectedWith(`no '#wrong' verification method defined`);
+    });
+
+    describe('handles a RecordsWrite with encrypt: true', () => {
+      it('with DataFormats key derivation', async () => {
+        const dataBlob = new Blob(['Hello, world!']);
+        const testProfileOptions = await testProfile.ion.with.dwn.service.and.authorization.encryption.keys();
+        const { did: aliceDid } = await testAgent.createProfile(testProfileOptions);
+
+        const response = await testAgent.agent.processDwnRequest({
+          author         : aliceDid,
+          dataStream     : dataBlob,
+          encrypt        : true,
+          messageOptions : { dataFormat: 'text/plain' },
+          messageType    : 'RecordsWrite',
+          target         : aliceDid
+        });
+        const message = response.message as RecordsWriteMessage;
+        const status = response.reply.status as MessageReply['status'];
+
+        expect(status.code).to.equal(202);
+        expect(message.encryption).to.exist;
+        expect(message?.encryption?.keyEncryption).to.have.length(1);
+        expect(message?.encryption?.keyEncryption[0]).to.have.property('derivationScheme', 'dataFormats');
+      });
+
+      it('with DataFormats and Schemas key derivation', async () => {
+        const dataBlob = new Blob(['Hello, world!']);
+        const testProfileOptions = await testProfile.ion.with.dwn.service.and.authorization.encryption.keys();
+        const { did: aliceDid } = await testAgent.createProfile(testProfileOptions);
+
+        const response = await testAgent.agent.processDwnRequest({
+          author         : aliceDid,
+          dataStream     : dataBlob,
+          encrypt        : true,
+          messageOptions : {
+            dataFormat : 'text/plain',
+            schema     : 'https://protocols.xyz/schemas/music-playlist'
+          },
+          messageType : 'RecordsWrite',
+          target      : aliceDid
+        });
+
+        const message = response.message as RecordsWriteMessage;
+        const status = response.reply.status as MessageReply['status'];
+
+        expect(status.code).to.equal(202);
+        expect(message.encryption).to.exist;
+        expect(message?.encryption?.keyEncryption).to.have.length(2);
+        expect(message?.encryption?.keyEncryption[0]).to.have.property('derivationScheme', 'dataFormats');
+        expect(message?.encryption?.keyEncryption[1]).to.have.property('derivationScheme', 'schemas');
+      });
+
+      it('with DataFormats, Schemas, and Protocols key derivation', async () => {
+        // Create data to use to test encryption.
+        const dataBlob = new Blob(['Hello, world!']);
+        // Create an encryption subject to
+        const testProfileOptions = await testProfile.ion.with.dwn.service.and.authorization.encryption.keys();
+        const { did: aliceDid } = await testAgent.createProfile(testProfileOptions);
+
+        // First configure a protocol on the agent-connected DWN.
+        const protocolsConfigureResponse = await testAgent.agent.processDwnRequest({
+          author         : aliceDid,
+          messageOptions : { definition: messageProtocolDefinition },
+          messageType    : 'ProtocolsConfigure',
+          target         : aliceDid
+        });
+        expect(protocolsConfigureResponse.reply.status.code).to.equal(202);
+
+        // Then try to process the RecordsWrite.
+        const response = await testAgent.agent.processDwnRequest({
+          author         : aliceDid,
+          dataStream     : dataBlob,
+          encrypt        : true,
+          messageOptions : {
+            dataFormat   : 'text/plain',
+            protocol     : 'http://message-protocol.xyz',
+            protocolPath : 'message',
+            schema       : 'https://protocols.xyz/message/schema/message'
+          },
+          messageType : 'RecordsWrite',
+          target      : aliceDid
+        });
+
+        const message = response.message as RecordsWriteMessage;
+        const status = response.reply.status as MessageReply['status'];
+
+        expect(status.code).to.equal(202);
+        expect(message.encryption).to.exist;
+        expect(message?.encryption?.keyEncryption).to.have.length(3);
+        expect(message?.encryption?.keyEncryption[0]).to.have.property('derivationScheme', 'dataFormats');
+        expect(message?.encryption?.keyEncryption[1]).to.have.property('derivationScheme', 'protocols');
+        expect(message?.encryption?.keyEncryption[2]).to.have.property('derivationScheme', 'schemas');
+      });
+    });
+
+    describe('handles a RecordsWrite with encrypt: { for: did }', () => {
+      it('throws an error if `encrypt: { for: }` missing DID', async () => {
+        const dataBlob = new Blob(['Hello, world!']);
+        const testProfileOptions = await testProfile.ion.with.dwn.service.and.authorization.encryption.keys();
+        const { did: aliceDid } = await testAgent.createProfile(testProfileOptions);
+
+        await expect(testAgent.agent.processDwnRequest({
+          author         : aliceDid,
+          dataStream     : dataBlob,
+          encrypt        : { for: undefined },
+          messageOptions : { dataFormat: 'text/plain' },
+          messageType    : 'RecordsWrite',
+          target         : aliceDid
+        })).to.eventually.be.rejectedWith('DID to encrypt for not provided');
+      });
+
+      it('with DataFormats key derivation', async () => {
+        const dataBlob = new Blob(['Hello, world!']);
+        const testProfileOptions = await testProfile.ion.with.dwn.service.and.authorization.encryption.keys();
+        const { did: aliceDid } = await testAgent.createProfile(testProfileOptions);
+        const { did: bobDid } = await testAgent.createProfile(testProfileOptions);
+
+        const response = await testAgent.agent.processDwnRequest({
+          author         : aliceDid,
+          dataStream     : dataBlob,
+          encrypt        : { for: bobDid },
+          messageOptions : { dataFormat: 'text/plain' },
+          messageType    : 'RecordsWrite',
+          target         : aliceDid
+        });
+
+        const message = response.message as RecordsWriteMessage;
+        const status = response.reply.status as MessageReply['status'];
+
+        expect(status.code).to.equal(202);
+        expect(message.encryption).to.exist;
+        expect(message?.encryption?.keyEncryption).to.have.length(1);
+        expect(message?.encryption?.keyEncryption[0]).to.have.property('derivationScheme', 'dataFormats');
+      });
+    });
+  });
+
   describe('sendDwnRequest', () => {
-    it('throws an exception if target did has no #dwn service endpoints', async () => {
+    it('throws an exception if target DID has no #dwn service endpoints', async () => {
       try {
         await testAgent.agent.sendDwnRequest({
           author         : did,
@@ -38,7 +242,7 @@ describe('Web5UserAgent', () => {
 
         expect.fail();
       } catch(e) {
-        expect(e.message).to.include(`${did} has no dwn service endpoints`);
+        expect(e.message).to.include(`has no '#dwn' service endpoints`);
       }
     });
 

--- a/packages/web5-user-agent/tests/fixtures/protocol-definitions/email.json
+++ b/packages/web5-user-agent/tests/fixtures/protocol-definitions/email.json
@@ -1,0 +1,49 @@
+{
+  "protocol": "http://email-protocol.xyz",
+  "types": {
+    "email": {
+      "schema": "email",
+      "dataFormats": [
+        "text/plain"
+      ]
+    }
+  },
+  "structure": {
+    "email": {
+      "$actions": [
+        {
+          "who": "anyone",
+          "can": "write"
+        },
+        {
+          "who": "author",
+          "of": "email",
+          "can": "read"
+        },
+        {
+          "who": "recipient",
+          "of": "email",
+          "can": "read"
+        }
+      ],
+      "email": {
+        "$actions": [
+          {
+            "who": "anyone",
+            "can": "write"
+          },
+          {
+            "who": "author",
+            "of": "email/email",
+            "can": "read"
+          },
+          {
+            "who": "recipient",
+            "of": "email/email",
+            "can": "read"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/packages/web5-user-agent/tests/fixtures/protocol-definitions/message.json
+++ b/packages/web5-user-agent/tests/fixtures/protocol-definitions/message.json
@@ -1,0 +1,19 @@
+{
+  "protocol": "http://message-protocol.xyz",
+  "types": {
+    "message": {
+      "schema": "https://protocols.xyz/message/schema/message",
+      "dataFormats": ["text/plain"]
+    }
+  },
+  "structure": {
+    "message": {
+      "$actions": [
+        {
+          "who": "anyone",
+          "can": "write"
+        }
+      ]
+    }
+  }
+}

--- a/packages/web5-user-agent/tests/fixtures/test-profiles.ts
+++ b/packages/web5-user-agent/tests/fixtures/test-profiles.ts
@@ -1,9 +1,9 @@
 import type { DidIonCreateOptions, KeyOption } from '@tbd54566975/dids';
-import type { TestProfileOptions } from '../test-utils/test-user-agent.js';
+import type { TestProfileOptions } from '../common/utils/test-user-agent.js';
 
 import { generateKeyPair } from '@decentralized-identity/ion-tools';
 
-const dwnNodes = ['https://dwn.tbddev.org/dwn0'];
+export const dwnNodes = ['https://dwn.tbddev.org/dwn0'];
 // const dwnNodes = ['http://localhost:3000'];
 
 export const keyIds = {

--- a/packages/web5-user-agent/tsconfig.test.json
+++ b/packages/web5-user-agent/tsconfig.test.json
@@ -15,6 +15,8 @@
     // `NodeNext` will throw compilation errors if relative import paths are missing file extension
     // reference: https://devblogs.microsoft.com/typescript/announcing-typescript-4-7/#ecmascript-module-support-in-node-js
     "moduleResolution": "NodeNext",
+    // allows us to import json files
+    "resolveJsonModule": true,
     "esModuleInterop": true
   },
   "include": [

--- a/packages/web5/README.md
+++ b/packages/web5/README.md
@@ -123,7 +123,7 @@ console.log(records); // an array of record entries from Bob's DWeb Nodes
 
 The query `request` contains the following properties:
 
-- **`from`** - _`DID string`_ (_optional_): the decentralized identifier of the DID of the DWeb Node the query will fetch results from.
+- **`from`** - _`DID string`_ (_optional_): the decentralized identifier of the DWeb Node the query will fetch results from.
 - **`message`** - _`object`_: the properties of the DWeb Node Message Descriptor that will be used to construct a valid record query:
   - **`filter`** - _`object`_: properties against which results of the query will be filtered:
     - **`protocol`** - _`URI string`_ (_optional_): the URI of the protocol bucket in which to query.
@@ -340,7 +340,7 @@ console.log(protocols); // logs an array of protocol configurations installed on
 
 The query `request` must contain the following:
 
-- **`from`** - _`DID string`_ (_optional_): the decentralized identifier of the DID of the DWeb Node the query will fetch results from.
+- **`from`** - _`DID string`_ (_optional_): the decentralized identifier of the DWeb Node the query will fetch results from.
 - **`message`** - _`object`_: The properties of the DWeb Node Message Descriptor that will be used to construct a valid record query:
   - **`filter`** - _`object`_: properties against which results of the query will be filtered:
     - **`protocol`** - _`URI string`_ (_optional_): the URI of the protocol bucket in which to query.

--- a/packages/web5/README.md
+++ b/packages/web5/README.md
@@ -164,7 +164,8 @@ const { status } = await record.send("did:example:bob"); // send the newly gener
 The `create` request object is composed as follows:
 
 - **`store`** - _`boolean`_: tells the create function whether or not to store the record in the user's local DWeb Node. (you might pass `false` if you didn't want to retain a copy of the record for yourself)
-- **`data`** - _`text|object|file|blob`_: The data payload of the record.
+- **`data`** - _`text|object|file|blob`_: the data payload of the record.
+- **`encrypt`** - _`boolean|object` (optional)_: whether to encrypt the record. A value of `true` encrypts the record using the local active DID's public key such that only they can decrypt. To encrypt a record using someone else's public key, specify their DID with a value of `{ for: 'did:example:bob'}`.
 - **`message`** - _`object`_: The properties of the DWeb Node Message Descriptor that will be used to construct a valid record query:
   - **`protocol`** - _`URI string`_ (_optional_): the URI of the protocol under which the record will be bucketed.
   - **`schema`** - _`URI string`_ (_optional_): the URI of the schema under which the record will be bucketed.

--- a/packages/web5/src/dwn-api.ts
+++ b/packages/web5/src/dwn-api.ts
@@ -1,16 +1,16 @@
-import type { Web5Agent } from '@tbd54566975/web5-agent';
+import type { RecordEncryptionOptions, Web5Agent } from '@tbd54566975/web5-agent';
 import type {
   MessageReply,
   ProtocolDefinition,
-  ProtocolsConfigureOptions,
-  ProtocolsQueryOptions,
-  RecordsDeleteOptions,
-  RecordsQueryOptions,
   RecordsReadOptions,
-  RecordsWriteDescriptor,
+  RecordsQueryOptions,
   RecordsWriteMessage,
   RecordsWriteOptions,
-  ProtocolsConfigureMessage
+  RecordsDeleteOptions,
+  ProtocolsQueryOptions,
+  RecordsWriteDescriptor,
+  ProtocolsConfigureMessage,
+  ProtocolsConfigureOptions,
 } from '@tbd54566975/dwn-sdk-js';
 
 import { DwnInterfaceName, DwnMethodName } from '@tbd54566975/dwn-sdk-js';
@@ -80,7 +80,6 @@ export type RecordsQueryReplyEntry = {
   encodedData?: string;
 };
 
-
 export type RecordsQueryRequest = {
   /** The from property indicates the DID to query from and return results. */
   from?: string;
@@ -105,6 +104,7 @@ export type RecordsReadResponse = {
 
 export type RecordsWriteRequest = {
   data: unknown;
+  encrypt?: boolean | RecordEncryptionOptions;
   message?: Omit<Partial<RecordsWriteOptions>, 'authorizationSignatureInput'>;
 }
 
@@ -343,7 +343,7 @@ export class DwnApi {
        * from the DWN datastore.
        */
       write: async (request: RecordsWriteRequest): Promise<RecordsWriteResponse> => {
-        const messageOptions: Partial<RecordsWriteOptions> = {
+        const messageOptions: Partial<RecordsWriteOptions> & { encryptionSubject?: string } = {
           ...request.message
         };
 
@@ -353,6 +353,7 @@ export class DwnApi {
         const agentResponse = await this.web5Agent.processDwnRequest({
           author      : this.connectedDid,
           dataStream  : dataBlob,
+          encrypt     : request.encrypt,
           messageOptions,
           messageType : DwnInterfaceName.Records + DwnMethodName.Write,
           target      : this.connectedDid

--- a/packages/web5/src/record.ts
+++ b/packages/web5/src/record.ts
@@ -100,7 +100,7 @@ export class Record implements RecordModel {
    * TODO: Document method.
    */
   get data() {
-    if (this.isDeleted) throw new Error(`Error: Record with ID '${this.id}' was previously deleted.`);
+    if (this.isDeleted) throw new Error('Operation failed: Attempted to access `data` of a record that has already been deleted.');
 
     if (!this.#encodedData && !this.#readableStream) {
       // `encodedData` will be set if `dataSize` <= DwnConstant.maxDataSizeAllowedToBeEncoded. (10KB as of April 2023)
@@ -124,7 +124,7 @@ export class Record implements RecordModel {
       // type is Base64 URL encoded string if the Record object was instantiated from a RecordsQuery response
       // If it is a string, we need to Base64 URL decode to bytes
       const dataBytes = Encoder.base64UrlToBytes(this.#encodedData);
-      this.#encodedData = new Blob([dataBytes]);
+      this.#encodedData = new Blob([dataBytes], { type: this.dataFormat });
     }
 
     // eslint-disable-next-line @typescript-eslint/no-this-alias
@@ -133,7 +133,7 @@ export class Record implements RecordModel {
     const dataObj = {
       async blob(): Promise<Blob> {
         if (self.#encodedData) return self.#encodedData as Blob;
-        if (self.#readableStream) return new Blob([this.stream().then(DataStream.toBytes)]);
+        if (self.#readableStream) return new Blob([this.stream().then(DataStream.toBytes)], { type: self.dataFormat });
       },
       async json() {
         if (self.#encodedData) return this.text().then(JSON.parse);
@@ -164,7 +164,7 @@ export class Record implements RecordModel {
    * TODO: Document method.
    */
   async delete(): Promise<RecordsDeleteResponse> {
-    if (this.isDeleted) throw new Error(`Record with ID '${this.id}' was previously deleted.`);
+    if (this.isDeleted) throw new Error('Operation failed: Attempted to call `delete()` on a record that has already been deleted.');
 
     // Attempt to delete the record from the DWN.
     const agentResponse = await this.#web5Agent.processDwnRequest({
@@ -188,7 +188,7 @@ export class Record implements RecordModel {
    * TODO: Document method.
    */
   async send(target: string): Promise<any> {
-    if (this.isDeleted) throw new Error(`Record with ID '${this.id}' was previously deleted.`);
+    if (this.isDeleted) throw new Error('Operation failed: Attempted to call `send()` on a record that has already been deleted.');
 
     const { reply: { status } } = await this.#web5Agent.sendDwnRequest({
       messageType    : DwnInterfaceName.Records + DwnMethodName.Write,
@@ -257,7 +257,7 @@ export class Record implements RecordModel {
    * TODO: Document method.
    */
   async update(options: RecordUpdateOptions = {}) {
-    if (this.isDeleted) throw new Error(`Error: Record with ID '${this.id}' was previously deleted.`);
+    if (this.isDeleted) throw new Error('Operation failed: Attempted to call `update()` on a record that has already been deleted.');
 
     // Begin assembling update message.
     let updateMessage = { ...this.#descriptor, ...options } as Partial<RecordsWriteOptions>;

--- a/packages/web5/tests/record.spec.ts
+++ b/packages/web5/tests/record.spec.ts
@@ -272,7 +272,7 @@ describe('Record', () => {
       let deleteResult = await record!.delete();
       expect(deleteResult.status.code).to.equal(202);
 
-      await expect(record!.delete()).to.eventually.be.rejectedWith('was previously deleted');
+      await expect(record!.delete()).to.eventually.be.rejectedWith('Operation failed');
     });
   });
 

--- a/packages/web5/tests/web5-dwn.spec.ts
+++ b/packages/web5/tests/web5-dwn.spec.ts
@@ -137,6 +137,39 @@ describe('web5.dwn', () => {
           expect(result.record).to.exist;
           expect(await result.record?.data.json()).to.deep.equal(dataJson);
         });
+
+        it('writes an encrypted record with encrypt: true', async () => {
+          testProfileOptions = await testProfile.ion.with.dwn.service.and.authorization.encryption.keys();
+          let { did: didAuthzEncr } = await testAgent.createProfile(testProfileOptions);
+          dwn = new DwnApi(testAgent.agent, didAuthzEncr);
+
+          const { record, status } = await dwn.records.write({
+            data    : 'Hello, world!',
+            encrypt : true,
+          });
+
+          expect(status.code).to.equal(202);
+          expect(record?.encryption).to.not.be.undefined;
+          expect(record?.encryption?.keyEncryption).to.have.length(1);
+          expect(record?.encryption?.keyEncryption[0]).to.have.property('derivationScheme', 'dataFormats');
+        });
+
+        it('writes an encrypted record with encrypt: did', async () => {
+          testProfileOptions = await testProfile.ion.with.dwn.service.and.authorization.encryption.keys();
+          let { did: didAuthzEncr } = await testAgent.createProfile(testProfileOptions);
+          dwn = new DwnApi(testAgent.agent, didAuthzEncr);
+          const { did: bobDid } = await testAgent.createProfile(testProfileOptions);
+
+          const { record, status } = await dwn.records.write({
+            data    : 'Hello, world!',
+            encrypt : { for: bobDid },
+          });
+
+          expect(status.code).to.equal(202);
+          expect(record?.encryption).to.not.be.undefined;
+          expect(record?.encryption?.keyEncryption).to.have.length(1);
+          expect(record?.encryption?.keyEncryption[0]).to.have.property('derivationScheme', 'dataFormats');
+        });
       });
 
       describe('agent store: false', () => {


### PR DESCRIPTION
This PR adds support for encrypting records using the encryption feature in DWN SDK.

The syntax for encrypting a record such that only the local active DID's keys can decrypt:
```typescript
const { record } = await web5.dwn.records.create({
  data: 'Hello',
  encrypt: true,
  message: {
    'schema': 'http://schemas.xyz/message'
  }
});
```

The syntax for encrypting a record such that only `bobDid`'s keys can decrypt:
```typescript
const { record } = await web5.dwn.records.create({
  data: 'Hello',
  encrypt: { for: bobDid },
  message: {
    'schema': 'http://schemas.xyz/message'
  }
});
```