### PR TITLE
Fix broken links in README and add missing VScode config

### DIFF
--- a/packages/crypto/.vscode/launch.json
+++ b/packages/crypto/.vscode/launch.json
@@ -1,0 +1,22 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "test:node",
+      "runtimeExecutable": "${workspaceFolder:root}/node_modules/.bin/mocha",
+      "runtimeArgs": [
+        "${workspaceFolder:crypto}/__tests__/**/*.spec.js"
+      ],
+      "console": "internalConsole",
+      "preLaunchTask": "tsc: build - tsconfig.test.json",
+      "outFiles": [
+        "${workspaceFolder:crypto}/__tests__/**/*.js"
+      ],
+    }
+  ]
+}

--- a/packages/crypto/.vscode/tasks.json
+++ b/packages/crypto/.vscode/tasks.json
@@ -1,0 +1,45 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "npm run build",
+      "type": "npm",
+      "script": "build",
+      "problemMatcher": [],
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      }
+    },
+    {
+      "label": "tsc: build - tsconfig.json",
+      "type": "typescript",
+      "tsconfig": "tsconfig.json",
+      "problemMatcher": [
+        "$tsc"
+      ],
+      "group": {
+        "kind": "build",
+        "isDefault": false
+      },
+      "options": {
+        "cwd": "${workspaceFolder:root}"
+      }
+    },
+    {
+      "label": "tsc: build - tsconfig.test.json",
+      "type": "typescript",
+      "tsconfig": "tsconfig.test.json",
+      "problemMatcher": [
+        "$tsc"
+      ],
+      "group": {
+        "kind": "build",
+        "isDefault": false
+      },
+      "options": {
+        "cwd": "${workspaceFolder:root}"
+      }
+    },
+  ]
+}

--- a/packages/dids/.vscode/launch.json
+++ b/packages/dids/.vscode/launch.json
@@ -1,0 +1,22 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "test:node",
+      "runtimeExecutable": "${workspaceFolder:root}/node_modules/.bin/mocha",
+      "runtimeArgs": [
+        "${workspaceFolder:dids}/__tests__/**/*.spec.js"
+      ],
+      "console": "internalConsole",
+      "preLaunchTask": "tsc: build - tsconfig.test.json",
+      "outFiles": [
+        "${workspaceFolder:dids}/__tests__/**/*.js"
+      ],
+    }
+  ]
+}

--- a/packages/dids/.vscode/tasks.json
+++ b/packages/dids/.vscode/tasks.json
@@ -1,0 +1,45 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "npm run build",
+      "type": "npm",
+      "script": "build",
+      "problemMatcher": [],
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      }
+    },
+    {
+      "label": "tsc: build - tsconfig.json",
+      "type": "typescript",
+      "tsconfig": "tsconfig.json",
+      "problemMatcher": [
+        "$tsc"
+      ],
+      "group": {
+        "kind": "build",
+        "isDefault": false
+      },
+      "options": {
+        "cwd": "${workspaceFolder:root}"
+      }
+    },
+    {
+      "label": "tsc: build - tsconfig.test.json",
+      "type": "typescript",
+      "tsconfig": "tsconfig.test.json",
+      "problemMatcher": [
+        "$tsc"
+      ],
+      "group": {
+        "kind": "build",
+        "isDefault": false
+      },
+      "options": {
+        "cwd": "${workspaceFolder:root}"
+      }
+    },
+  ]
+}

--- a/packages/web5-agent/.vscode/launch.json
+++ b/packages/web5-agent/.vscode/launch.json
@@ -1,0 +1,22 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "test:node",
+      "runtimeExecutable": "${workspaceFolder:root}/node_modules/.bin/mocha",
+      "runtimeArgs": [
+        "${workspaceFolder:web5-agent}/__tests__/**/*.spec.js"
+      ],
+      "console": "internalConsole",
+      "preLaunchTask": "tsc: build - tsconfig.test.json",
+      "outFiles": [
+        "${workspaceFolder:web5-agent}/__tests__/**/*.js"
+      ],
+    }
+  ]
+}

--- a/packages/web5-agent/.vscode/tasks.json
+++ b/packages/web5-agent/.vscode/tasks.json
@@ -1,0 +1,45 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "npm run build",
+      "type": "npm",
+      "script": "build",
+      "problemMatcher": [],
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      }
+    },
+    {
+      "label": "tsc: build - tsconfig.json",
+      "type": "typescript",
+      "tsconfig": "tsconfig.json",
+      "problemMatcher": [
+        "$tsc"
+      ],
+      "group": {
+        "kind": "build",
+        "isDefault": false
+      },
+      "options": {
+        "cwd": "${workspaceFolder:root}"
+      }
+    },
+    {
+      "label": "tsc: build - tsconfig.test.json",
+      "type": "typescript",
+      "tsconfig": "tsconfig.test.json",
+      "problemMatcher": [
+        "$tsc"
+      ],
+      "group": {
+        "kind": "build",
+        "isDefault": false
+      },
+      "options": {
+        "cwd": "${workspaceFolder:root}"
+      }
+    },
+  ]
+}

--- a/packages/web5-proxy-agent/.vscode/launch.json
+++ b/packages/web5-proxy-agent/.vscode/launch.json
@@ -1,0 +1,22 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "test:node",
+      "runtimeExecutable": "${workspaceFolder:root}/node_modules/.bin/mocha",
+      "runtimeArgs": [
+        "${workspaceFolder:web5-proxy-agent}/__tests__/**/*.spec.js"
+      ],
+      "console": "internalConsole",
+      "preLaunchTask": "tsc: build - tsconfig.test.json",
+      "outFiles": [
+        "${workspaceFolder:web5-proxy-agent}/__tests__/**/*.js"
+      ],
+    }
+  ]
+}

--- a/packages/web5-proxy-agent/.vscode/tasks.json
+++ b/packages/web5-proxy-agent/.vscode/tasks.json
@@ -1,0 +1,45 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "npm run build",
+      "type": "npm",
+      "script": "build",
+      "problemMatcher": [],
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      }
+    },
+    {
+      "label": "tsc: build - tsconfig.json",
+      "type": "typescript",
+      "tsconfig": "tsconfig.json",
+      "problemMatcher": [
+        "$tsc"
+      ],
+      "group": {
+        "kind": "build",
+        "isDefault": false
+      },
+      "options": {
+        "cwd": "${workspaceFolder:root}"
+      }
+    },
+    {
+      "label": "tsc: build - tsconfig.test.json",
+      "type": "typescript",
+      "tsconfig": "tsconfig.test.json",
+      "problemMatcher": [
+        "$tsc"
+      ],
+      "group": {
+        "kind": "build",
+        "isDefault": false
+      },
+      "options": {
+        "cwd": "${workspaceFolder:root}"
+      }
+    },
+  ]
+}

--- a/packages/web5-user-agent/.vscode/launch.json
+++ b/packages/web5-user-agent/.vscode/launch.json
@@ -1,0 +1,22 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "test:node",
+      "runtimeExecutable": "${workspaceFolder:root}/node_modules/.bin/mocha",
+      "runtimeArgs": [
+        "${workspaceFolder:web5-user-agent}/__tests__/**/*.spec.js"
+      ],
+      "console": "internalConsole",
+      "preLaunchTask": "tsc: build - tsconfig.test.json",
+      "outFiles": [
+        "${workspaceFolder:web5-user-agent}/__tests__/**/*.js"
+      ],
+    }
+  ]
+}

--- a/packages/web5-user-agent/.vscode/tasks.json
+++ b/packages/web5-user-agent/.vscode/tasks.json
@@ -1,0 +1,45 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "npm run build",
+      "type": "npm",
+      "script": "build",
+      "problemMatcher": [],
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      }
+    },
+    {
+      "label": "tsc: build - tsconfig.json",
+      "type": "typescript",
+      "tsconfig": "tsconfig.json",
+      "problemMatcher": [
+        "$tsc"
+      ],
+      "group": {
+        "kind": "build",
+        "isDefault": false
+      },
+      "options": {
+        "cwd": "${workspaceFolder:root}"
+      }
+    },
+    {
+      "label": "tsc: build - tsconfig.test.json",
+      "type": "typescript",
+      "tsconfig": "tsconfig.test.json",
+      "problemMatcher": [
+        "$tsc"
+      ],
+      "group": {
+        "kind": "build",
+        "isDefault": false
+      },
+      "options": {
+        "cwd": "${workspaceFolder:root}"
+      }
+    },
+  ]
+}

--- a/packages/web5/README.md
+++ b/packages/web5/README.md
@@ -357,10 +357,10 @@ const myDid = await Web5.did.create("ion");
 
 ## Project Resources
 
-| Resource                                   | Description                                                                   |
-| ------------------------------------------ | ----------------------------------------------------------------------------- |
-| [CODEOWNERS](./CODEOWNERS)                 | Outlines the project lead(s)                                                  |
-| [CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md) | Expected behavior for project contributors, promoting a welcoming environment |
-| [CONTRIBUTING.md](./CONTRIBUTING.md)       | Developer guide to build, test, run, access CI, chat, discuss, file issues    |
-| [GOVERNANCE.md](./GOVERNANCE.md)           | Project governance                                                            |
-| [LICENSE](./LICENSE)                       | Apache License, Version 2.0                                                   |
+| Resource                                                                                  | Description                                                                   |
+| ----------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| [CODEOWNERS](https://github.com/TBD54566975/web5-js/blob/main/CODEOWNERS)                 | Outlines the project lead(s)                                                  |
+| [CODE_OF_CONDUCT.md](https://github.com/TBD54566975/web5-js/blob/main/CODE_OF_CONDUCT.md) | Expected behavior for project contributors, promoting a welcoming environment |
+| [CONTRIBUTING.md](https://github.com/TBD54566975/web5-js/blob/main/CONTRIBUTING.md)       | Developer guide to build, test, run, access CI, chat, discuss, file issues    |
+| [GOVERNANCE.md](https://github.com/TBD54566975/web5-js/blob/main/GOVERNANCE.md)           | Project governance                                                            |
+| [LICENSE](./LICENSE)                                                                      | Apache License, Version 2.0                                                   |


### PR DESCRIPTION
This PR:
- fixes broken links in the `@tbd54566975/web` package README
- adds the remaining VScode build/test config that makes debugging more efficient and easier on developers.