### PR TITLE
Sync Fixes

### DIFF
--- a/packages/web5-user-agent/src/sync-api.ts
+++ b/packages/web5-user-agent/src/sync-api.ts
@@ -171,7 +171,7 @@ export class SyncApi implements SyncManager {
           message   : dwnMessage.message
         });
 
-        if (reply.status.code === 202) {
+        if (reply.status.code === 202 || reply.status.code === 409) {
           delOps.push({ type: 'del', key: key });
           await this.setWatermark(did, dwnUrl, 'push', watermark);
           await this.#addMessage(did, messageCid);
@@ -185,8 +185,6 @@ export class SyncApi implements SyncManager {
   }
 
   async enqueuePull() {
-    await this.enqueuePull();
-
     const profileDids = await this.#db.sublevel('registeredProfiles').keys().all();
     const syncStates: SyncState[] = [];
 
@@ -243,6 +241,8 @@ export class SyncApi implements SyncManager {
   }
 
   async pull() {
+    await this.enqueuePull();
+
     const pullQueue = this.#getPullQueue();
     const pullJobs = await pullQueue.iterator().all();
     const delOps: DbBatchOperation[] = [];
@@ -318,7 +318,7 @@ export class SyncApi implements SyncManager {
 
         const pullReply = await this.#dwn.processMessage(did, entry.message, dataStream);
 
-        if (pullReply.status.code === 202) {
+        if (pullReply.status.code === 202 || pullReply.status.code === 409) {
           await this.setWatermark(did, dwnUrl, 'pull', watermark);
           await this.#addMessage(did, messageCid);
           delOps.push({ type: 'del', key });


### PR DESCRIPTION
* ignore 409s. 409s occur when the record already exists which means the record was already pushed or pulled
* fix `pull` so that it enqueues first.