### PR TITLE
Address high severity vulnerability in socket.io-parser

### DIFF
--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -100,5 +100,10 @@
     "playwright": "1.31.2",
     "rimraf": "4.4.0",
     "typescript": "5.0.4"
+  },
+  "overrides": {
+    "karma": {
+      "socket.io-parser@>4.0.4 <4.2.3": "4.2.3"
+    }
   }
 }

--- a/packages/dids/package.json
+++ b/packages/dids/package.json
@@ -105,5 +105,10 @@
     "playwright": "1.31.2",
     "rimraf": "4.4.0",
     "typescript": "5.0.4"
+  },
+  "overrides": {
+    "karma": {
+      "socket.io-parser@>4.0.4 <4.2.3": "4.2.3"
+    }
   }
 }

--- a/packages/web5-agent/package.json
+++ b/packages/web5-agent/package.json
@@ -100,5 +100,10 @@
     "playwright": "1.31.2",
     "rimraf": "4.4.0",
     "typescript": "5.0.4"
+  },
+  "overrides": {
+    "karma": {
+      "socket.io-parser@>4.0.4 <4.2.3": "4.2.3"
+    }
   }
 }

--- a/packages/web5-proxy-agent/package.json
+++ b/packages/web5-proxy-agent/package.json
@@ -86,7 +86,6 @@
     "@typescript-eslint/parser": "5.59.0",
     "chai": "4.3.7",
     "chai-as-promised": "7.1.1",
-    "dts-bundle-generator": "^8.0.1",
     "esbuild": "0.16.7",
     "eslint": "8.39.0",
     "karma": "6.4.1",
@@ -102,5 +101,10 @@
     "playwright": "1.31.2",
     "rimraf": "4.4.0",
     "typescript": "5.0.4"
+  },
+  "overrides": {
+    "karma": {
+      "socket.io-parser@>4.0.4 <4.2.3": "4.2.3"
+    }
   }
 }

--- a/packages/web5-user-agent/package.json
+++ b/packages/web5-user-agent/package.json
@@ -111,5 +111,10 @@
     "sinon": "15.0.2",
     "source-map-loader": "4.0.1",
     "typescript": "5.0.4"
+  },
+  "overrides": {
+    "karma": {
+      "socket.io-parser@>4.0.4 <4.2.3": "4.2.3"
+    }
   }
 }

--- a/packages/web5/package.json
+++ b/packages/web5/package.json
@@ -95,7 +95,7 @@
     "@types/chai": "4.3.0",
     "@types/chai-as-promised": "7.1.5",
     "@types/ms": "0.7.31",
-    "@types/sinon": "^10.0.15",
+    "@types/sinon": "10.0.15",
     "@typescript-eslint/eslint-plugin": "5.59.0",
     "@typescript-eslint/parser": "5.59.0",
     "chai": "4.3.7",
@@ -117,5 +117,10 @@
     "sinon": "15.0.2",
     "source-map-loader": "4.0.1",
     "typescript": "5.0.4"
+  },
+  "overrides": {
+    "karma": {
+      "socket.io-parser@>4.0.4 <4.2.3": "4.2.3"
+    }
   }
 }


### PR DESCRIPTION
The package Web5 JS uses for running browser tests, [karma](https://www.npmjs.com/package/karma), depends on [socket.io](https://www.npmjs.com/package/socket.io) `^4.4.1` which, in turn, depends on [socket.io-parser](https://www.npmjs.com/package/socket.io-parser) `v4.2.2` for which a high severity vulnerability was announced:

- [Insufficient validation when decoding a Socket.IO packet](https://github.com/advisories/GHSA-cqmj-92xf-r6r9)

Until a new Karma release is published, overrides were added to the `package.json` files of all active projects in this repo.

Once Karma has bumped their socket.io version, the `package.json` overrides should be removed.  Issue #96 was created to track.