### PR TITLE
changes to `Web5.did`

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,7 +3,6 @@
         "aaron-bond.better-comments",
         "ambar.bundle-size",
         "dbaeumer.vscode-eslint",
-        "file-icons.file-icons",
         "eamodio.gitlens",
         "christian-kohler.npm-intellisense",
         "christian-kohler.path-intellisense"

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,11 @@
+{
+    "recommendations": [
+        "aaron-bond.better-comments",
+        "ambar.bundle-size",
+        "dbaeumer.vscode-eslint",
+        "file-icons.file-icons",
+        "eamodio.gitlens",
+        "christian-kohler.npm-intellisense",
+        "christian-kohler.path-intellisense"
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -37,11 +37,11 @@ npm install @tbd54566975/web5
 _CDNs_
 
 ```yaml
-https://unpkg.com/@tbd54566975/web5@0.7.5/dist/browser.js
+https://unpkg.com/@tbd54566975/web5@0.7.7/dist/browser.js
 ```
 
 ```yaml
-https://cdn.jsdelivr.net/npm/@tbd54566975/web5@0.7.5/dist/browser.mjs
+https://cdn.jsdelivr.net/npm/@tbd54566975/web5@0.7.7/dist/browser.mjs
 ```
 
 ### Importing the SDK

--- a/package-lock.json
+++ b/package-lock.json
@@ -7757,7 +7757,7 @@
         },
         "packages/web5": {
             "name": "@tbd54566975/web5",
-            "version": "0.7.6",
+            "version": "0.7.7",
             "license": "Apache-2.0",
             "dependencies": {
                 "@decentralized-identity/ion-tools": "1.0.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -766,13 +766,13 @@
             }
         },
         "node_modules/@playwright/test": {
-            "version": "1.33.0",
-            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.33.0.tgz",
-            "integrity": "sha512-YunBa2mE7Hq4CfPkGzQRK916a4tuZoVx/EpLjeWlTVOnD4S2+fdaQZE0LJkbfhN5FTSKNLdcl7MoT5XB37bTkg==",
+            "version": "1.34.3",
+            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.34.3.tgz",
+            "integrity": "sha512-zPLef6w9P6T/iT6XDYG3mvGOqOyb6eHaV9XtkunYs0+OzxBtrPAAaHotc0X+PJ00WPPnLfFBTl7mf45Mn8DBmw==",
             "dev": true,
             "dependencies": {
                 "@types/node": "*",
-                "playwright-core": "1.33.0"
+                "playwright-core": "1.34.3"
             },
             "bin": {
                 "playwright": "cli.js"
@@ -5963,41 +5963,13 @@
                 "node": ">=10"
             }
         },
-        "node_modules/playwright": {
-            "version": "1.31.2",
-            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.31.2.tgz",
-            "integrity": "sha512-jpC47n2PKQNtzB7clmBuWh6ftBRS/Bt5EGLigJ9k2QAKcNeYXZkEaDH5gmvb6+AbcE0DO6GnXdbl9ogG6Eh+og==",
-            "dev": true,
-            "hasInstallScript": true,
-            "dependencies": {
-                "playwright-core": "1.31.2"
-            },
-            "bin": {
-                "playwright": "cli.js"
-            },
-            "engines": {
-                "node": ">=14"
-            }
-        },
         "node_modules/playwright-core": {
-            "version": "1.33.0",
-            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.33.0.tgz",
-            "integrity": "sha512-aizyPE1Cj62vAECdph1iaMILpT0WUDCq3E6rW6I+dleSbBoGbktvJtzS6VHkZ4DKNEOG9qJpiom/ZxO+S15LAw==",
+            "version": "1.34.3",
+            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.34.3.tgz",
+            "integrity": "sha512-2pWd6G7OHKemc5x1r1rp8aQcpvDh7goMBZlJv6Co5vCNLVcQJdhxRL09SGaY6HcyHH9aT4tiynZabMofVasBYw==",
             "dev": true,
             "bin": {
-                "playwright": "cli.js"
-            },
-            "engines": {
-                "node": ">=14"
-            }
-        },
-        "node_modules/playwright/node_modules/playwright-core": {
-            "version": "1.31.2",
-            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.31.2.tgz",
-            "integrity": "sha512-a1dFgCNQw4vCsG7bnojZjDnPewZcw7tZUNFN0ZkcLYKj+mPmXvg4MpaaKZ5SgqPsOmqIf2YsVRkgqiRDxD+fDQ==",
-            "dev": true,
-            "bin": {
-                "playwright": "cli.js"
+                "playwright-core": "cli.js"
             },
             "engines": {
                 "node": ">=14"
@@ -7707,6 +7679,7 @@
                 "multiformats": "11.0.2"
             },
             "devDependencies": {
+                "@playwright/test": "1.34.3",
                 "@types/chai": "4.3.0",
                 "@types/chai-as-promised": "7.1.5",
                 "@types/ed2curve": "0.2.2",
@@ -7730,7 +7703,6 @@
                 "karma-webkit-launcher": "2.1.0",
                 "mocha": "10.2.0",
                 "node-stdlib-browser": "1.2.0",
-                "playwright": "1.31.2",
                 "rimraf": "4.4.0",
                 "sinon": "15.0.2",
                 "source-map-loader": "4.0.1",
@@ -7751,6 +7723,7 @@
                 "cross-fetch": "3.1.5"
             },
             "devDependencies": {
+                "@playwright/test": "1.34.3",
                 "@types/chai": "4.3.0",
                 "@types/chai-as-promised": "7.1.5",
                 "@types/eslint": "8.37.0",
@@ -7773,7 +7746,6 @@
                 "karma-webkit-launcher": "2.1.0",
                 "mocha": "10.2.0",
                 "node-stdlib-browser": "1.2.0",
-                "playwright": "1.31.2",
                 "rimraf": "4.4.0",
                 "sinon": "15.0.2",
                 "source-map-loader": "4.0.1",
@@ -7800,6 +7772,7 @@
                 "readable-web-to-node-stream": "3.0.2"
             },
             "devDependencies": {
+                "@playwright/test": "1.34.3",
                 "@types/chai": "4.3.0",
                 "@types/chai-as-promised": "7.1.5",
                 "@types/eslint": "8.37.0",
@@ -7823,7 +7796,6 @@
                 "karma-webkit-launcher": "2.1.0",
                 "mocha": "10.2.0",
                 "node-stdlib-browser": "1.2.0",
-                "playwright": "1.31.2",
                 "rimraf": "4.4.0",
                 "sinon": "15.0.2",
                 "source-map-loader": "4.0.1",
@@ -7842,6 +7814,7 @@
                 "readable-stream": "4.4.0"
             },
             "devDependencies": {
+                "@playwright/test": "1.34.3",
                 "@types/chai": "4.3.0",
                 "@types/chai-as-promised": "7.1.5",
                 "@types/eslint": "8.37.0",
@@ -7864,7 +7837,6 @@
                 "karma-webkit-launcher": "2.1.0",
                 "mocha": "10.2.0",
                 "node-stdlib-browser": "1.2.0",
-                "playwright": "1.31.2",
                 "rimraf": "4.4.0",
                 "sinon": "15.0.2",
                 "source-map-loader": "4.0.1",
@@ -7882,6 +7854,7 @@
                 "@tbd54566975/web5-agent": "0.1.5"
             },
             "devDependencies": {
+                "@playwright/test": "1.34.3",
                 "@types/chai": "4.3.0",
                 "@types/chai-as-promised": "7.1.5",
                 "@types/ed2curve": "0.2.2",
@@ -7905,7 +7878,6 @@
                 "karma-webkit-launcher": "2.1.0",
                 "mocha": "10.2.0",
                 "node-stdlib-browser": "1.2.0",
-                "playwright": "1.31.2",
                 "rimraf": "4.4.0",
                 "sinon": "15.0.2",
                 "source-map-loader": "4.0.1",
@@ -7933,7 +7905,7 @@
             },
             "devDependencies": {
                 "@faker-js/faker": "8.0.1",
-                "@playwright/test": "1.33.0",
+                "@playwright/test": "1.34.3",
                 "@types/chai": "4.3.0",
                 "@types/chai-as-promised": "7.1.5",
                 "@types/flat": "5.0.2",
@@ -7956,7 +7928,6 @@
                 "karma-webkit-launcher": "2.1.0",
                 "mocha": "10.2.0",
                 "node-stdlib-browser": "1.2.0",
-                "playwright": "1.31.2",
                 "rimraf": "4.4.0",
                 "sinon": "15.0.2",
                 "source-map-loader": "4.0.1",

--- a/packages/crypto/karma.conf.cjs
+++ b/packages/crypto/karma.conf.cjs
@@ -3,7 +3,7 @@
 // Karma does not support .mjs
 
 // playwright acts as a safari executable on windows and mac
-const playwright = require('playwright');
+const playwright = require('@playwright/test');
 const esbuildBrowserConfig = require('./build/esbuild-browser-config.cjs');
 
 // use playwright chrome exec path as run target for chromium tests
@@ -30,6 +30,12 @@ module.exports = function (config) {
     // available frameworks: https://www.npmjs.com/search?q=keywords:karma-adapter
     frameworks: ['mocha'],
 
+    // Increase Mocha's default timeout of 2 seconds to prevent timeouts during GitHub CI runs.
+    client: {
+      mocha: {
+        timeout: 10000 // 10 seconds
+      }
+    },
 
     // list of files / patterns to load in the browser
     files: [
@@ -71,5 +77,9 @@ module.exports = function (config) {
     // Continuous Integration mode
     // if true, Karma captures browsers, runs the tests and exits
     singleRun: true,
+
+    // Increase browser timeouts to avoid DISCONNECTED messages during GitHub CI runs.
+    browserDisconnectTimeout   : 10000, // default 2000
+    browserDisconnectTolerance : 1, // default 0
   });
 };

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -78,6 +78,7 @@
     "multiformats": "11.0.2"
   },
   "devDependencies": {
+    "@playwright/test": "1.34.3",
     "@types/chai": "4.3.0",
     "@types/chai-as-promised": "7.1.5",
     "@types/ed2curve": "0.2.2",
@@ -101,7 +102,6 @@
     "karma-webkit-launcher": "2.1.0",
     "mocha": "10.2.0",
     "node-stdlib-browser": "1.2.0",
-    "playwright": "1.31.2",
     "rimraf": "4.4.0",
     "sinon": "15.0.2",
     "source-map-loader": "4.0.1",

--- a/packages/dids/karma.conf.cjs
+++ b/packages/dids/karma.conf.cjs
@@ -3,7 +3,7 @@
 // Karma does not support .mjs
 
 // playwright acts as a safari executable on windows and mac
-const playwright = require('playwright');
+const playwright = require('@playwright/test');
 const esbuildBrowserConfig = require('./build/esbuild-browser-config.cjs');
 
 // use playwright chrome exec path as run target for chromium tests
@@ -30,6 +30,12 @@ module.exports = function (config) {
     // available frameworks: https://www.npmjs.com/search?q=keywords:karma-adapter
     frameworks: ['mocha'],
 
+    // Increase Mocha's default timeout of 2 seconds to prevent timeouts during GitHub CI runs.
+    client: {
+      mocha: {
+        timeout: 10000 // 10 seconds
+      }
+    },
 
     // list of files / patterns to load in the browser
     files: [
@@ -71,5 +77,9 @@ module.exports = function (config) {
     // Continuous Integration mode
     // if true, Karma captures browsers, runs the tests and exits
     singleRun: true,
+
+    // Increase browser timeouts to avoid DISCONNECTED messages during GitHub CI runs.
+    browserDisconnectTimeout   : 10000, // default 2000
+    browserDisconnectTolerance : 1, // default 0
   });
 };

--- a/packages/dids/package.json
+++ b/packages/dids/package.json
@@ -84,6 +84,7 @@
     "cross-fetch": "3.1.5"
   },
   "devDependencies": {
+    "@playwright/test": "1.34.3",
     "@types/chai": "4.3.0",
     "@types/chai-as-promised": "7.1.5",
     "@types/eslint": "8.37.0",
@@ -106,7 +107,6 @@
     "karma-webkit-launcher": "2.1.0",
     "mocha": "10.2.0",
     "node-stdlib-browser": "1.2.0",
-    "playwright": "1.31.2",
     "rimraf": "4.4.0",
     "sinon": "15.0.2",
     "source-map-loader": "4.0.1",

--- a/packages/web5-agent/karma.conf.cjs
+++ b/packages/web5-agent/karma.conf.cjs
@@ -3,7 +3,7 @@
 // Karma does not support .mjs
 
 // playwright acts as a safari executable on windows and mac
-const playwright = require('playwright');
+const playwright = require('@playwright/test');
 const esbuildBrowserConfig = require('./build/esbuild-browser-config.cjs');
 
 // use playwright chrome exec path as run target for chromium tests
@@ -30,6 +30,12 @@ module.exports = function (config) {
     // available frameworks: https://www.npmjs.com/search?q=keywords:karma-adapter
     frameworks: ['mocha'],
 
+    // Increase Mocha's default timeout of 2 seconds to prevent timeouts during GitHub CI runs.
+    client: {
+      mocha: {
+        timeout: 10000 // 10 seconds
+      }
+    },
 
     // list of files / patterns to load in the browser
     files: [
@@ -71,5 +77,9 @@ module.exports = function (config) {
     // Continuous Integration mode
     // if true, Karma captures browsers, runs the tests and exits
     singleRun: true,
+
+    // Increase browser timeouts to avoid DISCONNECTED messages during GitHub CI runs.
+    browserDisconnectTimeout   : 10000, // default 2000
+    browserDisconnectTolerance : 1, // default 0
   });
 };

--- a/packages/web5-agent/package.json
+++ b/packages/web5-agent/package.json
@@ -79,6 +79,7 @@
     "@tbd54566975/dwn-sdk-js": "0.0.33"
   },
   "devDependencies": {
+    "@playwright/test": "1.34.3",
     "@types/chai": "4.3.0",
     "@types/chai-as-promised": "7.1.5",
     "@types/eslint": "8.37.0",
@@ -101,7 +102,6 @@
     "karma-webkit-launcher": "2.1.0",
     "mocha": "10.2.0",
     "node-stdlib-browser": "1.2.0",
-    "playwright": "1.31.2",
     "rimraf": "4.4.0",
     "sinon": "15.0.2",
     "source-map-loader": "4.0.1",

--- a/packages/web5-proxy-agent/karma.conf.cjs
+++ b/packages/web5-proxy-agent/karma.conf.cjs
@@ -3,7 +3,7 @@
 // Karma does not support .mjs
 
 // playwright acts as a safari executable on windows and mac
-const playwright = require('playwright');
+const playwright = require('@playwright/test');
 const esbuildBrowserConfig = require('./build/esbuild-browser-config.cjs');
 
 // use playwright chrome exec path as run target for chromium tests
@@ -30,6 +30,12 @@ module.exports = function (config) {
     // available frameworks: https://www.npmjs.com/search?q=keywords:karma-adapter
     frameworks: ['mocha'],
 
+    // Increase Mocha's default timeout of 2 seconds to prevent timeouts during GitHub CI runs.
+    client: {
+      mocha: {
+        timeout: 10000 // 10 seconds
+      }
+    },
 
     // list of files / patterns to load in the browser
     files: [
@@ -71,5 +77,9 @@ module.exports = function (config) {
     // Continuous Integration mode
     // if true, Karma captures browsers, runs the tests and exits
     singleRun: true,
+
+    // Increase browser timeouts to avoid DISCONNECTED messages during GitHub CI runs.
+    browserDisconnectTimeout   : 10000, // default 2000
+    browserDisconnectTolerance : 1, // default 0
   });
 };

--- a/packages/web5-proxy-agent/package.json
+++ b/packages/web5-proxy-agent/package.json
@@ -78,6 +78,7 @@
     "@tbd54566975/web5-agent": "0.1.5"
   },
   "devDependencies": {
+    "@playwright/test": "1.34.3",
     "@types/chai": "4.3.0",
     "@types/chai-as-promised": "7.1.5",
     "@types/ed2curve": "0.2.2",
@@ -101,7 +102,6 @@
     "karma-webkit-launcher": "2.1.0",
     "mocha": "10.2.0",
     "node-stdlib-browser": "1.2.0",
-    "playwright": "1.31.2",
     "rimraf": "4.4.0",
     "sinon": "15.0.2",
     "source-map-loader": "4.0.1",

--- a/packages/web5-user-agent/karma.conf.cjs
+++ b/packages/web5-user-agent/karma.conf.cjs
@@ -3,7 +3,7 @@
 // Karma does not support .mjs
 
 // playwright acts as a safari executable on windows and mac
-const playwright = require('playwright');
+const playwright = require('@playwright/test');
 const esbuildBrowserConfig = require('./build/esbuild-browser-config.cjs');
 
 // use playwright chrome exec path as run target for chromium tests
@@ -30,6 +30,12 @@ module.exports = function (config) {
     // available frameworks: https://www.npmjs.com/search?q=keywords:karma-adapter
     frameworks: ['mocha'],
 
+    // Increase Mocha's default timeout of 2 seconds to prevent timeouts during GitHub CI runs.
+    client: {
+      mocha: {
+        timeout: 10000 // 10 seconds
+      }
+    },
 
     // list of files / patterns to load in the browser
     files: [
@@ -73,5 +79,9 @@ module.exports = function (config) {
     // Continuous Integration mode
     // if true, Karma captures browsers, runs the tests and exits
     singleRun: true,
+
+    // Increase browser timeouts to avoid DISCONNECTED messages during GitHub CI runs.
+    browserDisconnectTimeout   : 10000, // default 2000
+    browserDisconnectTolerance : 1, // default 0
   });
 };

--- a/packages/web5-user-agent/package.json
+++ b/packages/web5-user-agent/package.json
@@ -88,7 +88,7 @@
   },
   "devDependencies": {
     "@faker-js/faker": "8.0.1",
-    "@playwright/test": "1.33.0",
+    "@playwright/test": "1.34.3",
     "@types/chai": "4.3.0",
     "@types/chai-as-promised": "7.1.5",
     "@types/flat": "5.0.2",
@@ -111,7 +111,6 @@
     "karma-webkit-launcher": "2.1.0",
     "mocha": "10.2.0",
     "node-stdlib-browser": "1.2.0",
-    "playwright": "1.31.2",
     "rimraf": "4.4.0",
     "sinon": "15.0.2",
     "source-map-loader": "4.0.1",

--- a/packages/web5-user-agent/tests/common/web5-user-agent.spec.ts
+++ b/packages/web5-user-agent/tests/common/web5-user-agent.spec.ts
@@ -72,7 +72,7 @@ describe('Web5UserAgent', () => {
       expect(response.reply.status).to.exist;
       expect(response.reply.entries).to.exist;
       expect(response.reply.status.code).to.equal(200);
-    }).timeout(10_000);
+    });
 
     it('handles RecordsDelete Messages', async () => {
       const { did: aliceDid } = await testAgent.createProfile({

--- a/packages/web5/README.md
+++ b/packages/web5/README.md
@@ -37,11 +37,11 @@ npm install @tbd54566975/web5
 _CDNs_
 
 ```yaml
-https://unpkg.com/@tbd54566975/web5@0.7.5/dist/browser.js
+https://unpkg.com/@tbd54566975/web5@0.7.7/dist/browser.js
 ```
 
 ```yaml
-https://cdn.jsdelivr.net/npm/@tbd54566975/web5@0.7.5/dist/browser.mjs
+https://cdn.jsdelivr.net/npm/@tbd54566975/web5@0.7.7/dist/browser.mjs
 ```
 
 ### Importing the SDK

--- a/packages/web5/karma.conf.cjs
+++ b/packages/web5/karma.conf.cjs
@@ -3,7 +3,7 @@
 // Karma does not support .mjs
 
 // playwright acts as a safari executable on windows and mac
-const playwright = require('playwright');
+const playwright = require('@playwright/test');
 const esbuildBrowserConfig = require('./build/esbuild-browser-config.cjs');
 
 // use playwright chrome exec path as run target for chromium tests
@@ -30,6 +30,12 @@ module.exports = function (config) {
     // available frameworks: https://www.npmjs.com/search?q=keywords:karma-adapter
     frameworks: ['mocha'],
 
+    // Increase Mocha's default timeout of 2 seconds to prevent timeouts during GitHub CI runs.
+    client: {
+      mocha: {
+        timeout: 10000 // 10 seconds
+      }
+    },
 
     // list of files / patterns to load in the browser
     files: [
@@ -73,5 +79,9 @@ module.exports = function (config) {
     // Continuous Integration mode
     // if true, Karma captures browsers, runs the tests and exits
     singleRun: true,
+
+    // Increase browser timeouts to avoid DISCONNECTED messages during GitHub CI runs.
+    browserDisconnectTimeout   : 10000, // default 2000
+    browserDisconnectTolerance : 1, // default 0
   });
 };

--- a/packages/web5/package.json
+++ b/packages/web5/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tbd54566975/web5",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "SDK for accessing the features and capabilities of Web5",
   "type": "module",
   "main": "./dist/cjs/main.cjs",

--- a/packages/web5/package.json
+++ b/packages/web5/package.json
@@ -91,6 +91,7 @@
     "readable-web-to-node-stream": "3.0.2"
   },
   "devDependencies": {
+    "@playwright/test": "1.34.3",
     "@types/chai": "4.3.0",
     "@types/chai-as-promised": "7.1.5",
     "@types/eslint": "8.37.0",
@@ -114,7 +115,6 @@
     "karma-webkit-launcher": "2.1.0",
     "mocha": "10.2.0",
     "node-stdlib-browser": "1.2.0",
-    "playwright": "1.31.2",
     "rimraf": "4.4.0",
     "sinon": "15.0.2",
     "source-map-loader": "4.0.1",

--- a/packages/web5/src/did-api.ts
+++ b/packages/web5/src/did-api.ts
@@ -46,8 +46,13 @@ export class DidApi {
       this.methodCreatorMap.set(methodApi.methodName, methodApi);
     }
   }
-  // TODO: discuss whether we want this approach or would rather just go with options being unknown. this approach
-  //       leads to a better devex because intellisense will work based on what was provided for method
+
+  /**
+   * Creates a DID of the method provided
+   * @param method - the method of DID to create
+   * @param options - method-specific options
+   * @returns the created DID
+   */
   create<M extends keyof CreateMethodOptions>(method: M, options?: CreateOptions<M>): Promise<DidState> {
     const didMethodCreator = this.methodCreatorMap.get(method);
     if (!didMethodCreator) {

--- a/packages/web5/src/did-api.ts
+++ b/packages/web5/src/did-api.ts
@@ -62,6 +62,12 @@ export class DidApi {
     return didMethodCreator.create(options);
   }
 
+  /**
+   * Resolves the provided DID
+   * @param did - the did to resolve
+   * @see {@link https://www.w3.org/TR/did-core/#did-resolution | DID Resolution}
+   * @returns DID Resolution Result
+   */
   resolve(did: string): Promise<DidResolutionResult> {
     return this.didResolver.resolve(did);
   }

--- a/packages/web5/src/web5.ts
+++ b/packages/web5/src/web5.ts
@@ -13,18 +13,31 @@ import { AppStorage } from './app-storage.js';
 import { getRandomInt } from './utils.js';
 import { DidResolutionCache } from './did-resolution-cache.js';
 
+/**
+ * overrides to defaults configured for technical preview phase
+ */
 export type TechPreviewOptions = {
+  /** overrides default dwnEndpoints provided for technical preview. see `Web5.#enqueueNextSync` */
   dwnEndpoints?: string[];
 }
 
-// TODO: discuss what other options we want
+/**
+ * optional overrides that can be provided when calling {@link Web5.connect}
+ */
 export type Web5ConnectOptions = {
+  /** a custom {@link Web5Agent}. Defaults to creating an embedded {@link Web5UserAgent} if one isnt provided */
   web5Agent?: Web5Agent;
+  /** additional {@link DidMethodApi}s that can be used to create and resolve DID methods. defaults to did:key and did:ion */
   didMethodApis?: DidMethodApi[];
+  /** custom cache used to store DidResolutionResults. defaults to a {@link DidResolutionCache} */
   didResolutionCache?: DidResolverCache;
+  /** overrides to defaults configured for technical preview phase. See {@link TechPreviewOptions} */
   techPreview?: TechPreviewOptions;
 }
 
+/**
+ * @see {@link Web5ConnectOptions}
+ */
 type Web5Options = {
   web5Agent: Web5Agent;
   appStorage?: AppStorage;
@@ -36,14 +49,20 @@ export class Web5 {
   dwn: DwnApi;
   #connectedDid: string;
 
+  /**
+   * Statically available DID functionality. can be used to create and resolve DIDs without calling {@link connect}.
+   * By default, can create and resolve `did:key` and `did:ion`. DID resolution results are not cached unless `connect`
+   * is called
+   */
   static did = new DidApi({
     didMethodApis : [new DidIonApi(), new DidKeyApi()],
     cache         : new DidResolutionCache()
   });
 
-  get did() {
-    return Web5.did;
-  }
+  /**
+   * DID functionality (e.g. creating and resolving DIDs)
+   */
+  get did() { return Web5.did; }
 
   private static APP_DID_KEY = 'WEB5_APP_DID';
 
@@ -54,6 +73,11 @@ export class Web5 {
     this.appStorage ||= new AppStorage();
   }
 
+  /**
+   * Connects to a {@link Web5Agent}. defaults to creating an embedded {@link Web5UserAgent} if one isn't provided
+   * @param options - optional overrides
+   * @returns
+   */
   static async connect(options: Web5ConnectOptions = {}) {
     // load app's did
     const appStorage = new AppStorage();

--- a/packages/web5/src/web5.ts
+++ b/packages/web5/src/web5.ts
@@ -55,8 +55,7 @@ export class Web5 {
    * is called
    */
   static did = new DidApi({
-    didMethodApis : [new DidIonApi(), new DidKeyApi()],
-    cache         : new DidResolutionCache()
+    didMethodApis: [new DidIonApi(), new DidKeyApi()]
   });
 
   /**
@@ -65,7 +64,6 @@ export class Web5 {
   get did() { return Web5.did; }
 
   private static APP_DID_KEY = 'WEB5_APP_DID';
-
 
   private constructor(options: Web5Options) {
     this.#connectedDid = options.connectedDid;
@@ -98,10 +96,18 @@ export class Web5 {
     const profileApi = new ProfileApi();
     let [ profile ] = await profileApi.listProfiles();
 
+    options.didMethodApis ??= [];
+
+    // override default cache used by `Web5.did`
+    Web5.did = new DidApi({
+      didMethodApis : [new DidIonApi(), new DidKeyApi(), ...options.didMethodApis],
+      cache         : options.didResolutionCache || new DidResolutionCache()
+    });
+
     const dwn = await Dwn.create();
     const syncManager = new SyncApi({
       profileManager : profileApi,
-      didResolver    : Web5.did.resolver,
+      didResolver    : Web5.did.resolver, // share the same resolver to share the same underlying cache
       dwn            : dwn
     });
 
@@ -122,7 +128,7 @@ export class Web5 {
 
     const agent = await Web5UserAgent.create({
       profileManager : profileApi,
-      didResolver    : Web5.did.resolver,
+      didResolver    : Web5.did.resolver, // share the same resolver to share the same underlying cache
       syncManager    : syncManager,
       dwn            : dwn,
     });

--- a/packages/web5/tests/record.spec.ts
+++ b/packages/web5/tests/record.spec.ts
@@ -595,7 +595,7 @@ describe('Record', () => {
       expect(aliceRemoteQueryResult.records!.length).to.equal(1);
       const [ aliceRemoteEmailRecord ] = aliceAgentQueryResult!.records!;
       expect(await aliceRemoteEmailRecord.data.text()).to.equal(dataString);
-    }).timeout(10_000);
+    });
 
     it(`writes records to remote DWNs for someone else's DID`, async () => {
       const dataString = 'Hello, world!';
@@ -660,7 +660,7 @@ describe('Record', () => {
       expect(bobQueryResult.records!.length).to.equal(1);
       const [ bobRemoteEmailRecord ] = bobQueryResult!.records!;
       expect(await bobRemoteEmailRecord.data.text()).to.equal(dataString);
-    }).timeout(10_000);
+    });
 
     describe('with `store: false`', () => {
       it('writes records to your own remote DWN but not your agent DWN', async () => {
@@ -714,7 +714,7 @@ describe('Record', () => {
         expect(aliceRemoteQueryResult.records!.length).to.equal(1);
         const [ aliceRemoteEmailRecord ] = aliceRemoteQueryResult!.records!;
         expect(await aliceRemoteEmailRecord.data.text()).to.equal(dataString);
-      }).timeout(10_000);
+      });
 
       it(`writes records to someone else's remote DWN but not your agent DWN`, async () => {
         // Install a protocol on Alice's agent connected DWN.
@@ -802,7 +802,7 @@ describe('Record', () => {
         expect(bobQueryResult.records!.length).to.equal(1);
         const [ bobRemoteEmailRecord ] = bobQueryResult!.records!;
         expect(await bobRemoteEmailRecord.data.text()).to.equal(dataString);
-      }).timeout(10_000);
+      });
 
       it('has no effect if `store: true`', async () => {
         // Alice writes a message to her agent DWN with `store: true`.


### PR DESCRIPTION
Currently, `Web5.did` functionality is bootstrapped [like so](https://github.com/TBD54566975/web5-js/blob/main/packages/web5/src/web5.ts#L39-L42). This causes issues for two reasons:
1. `Web5.did` is using a level-based cache for did resolution results by default.
2. the way in which `static` class properties are transpiled causes their assigned values to be evaluated on `import`. For example, this typescript:

```typescript
class Dodo {
    constructor() {
        console.log("foo bar");
    }
}

class Yolo {
    static ahoy = new Dodo()
}
```

transpiles to:
```javascript
var Dodo = /** @class */ (function () {
    function Dodo() {
        console.log("foo bar");
    }
    return Dodo;
}());
var Yolo = /** @class *

/ (function () {
    function Yolo() {
    }
    Yolo.ahoy = new Dodo();
    return Yolo;
}());
```

when the resulting javascript is run or imported the following happens:

![image](https://github.com/TBD54566975/web5-js/assets/4887440/47a20c16-976e-4c96-b290-ecf5838624f6)

notice the `console.log` prints. if you swap out that `console.log` for `new Level()` (which is what's really happening), level attempts to "open a connection" to a database on instantiation. this causes issues for environments/runtimes that don't filesystem access or `indexedDB` available. 

This PR defaults static `Web5.did` to use no cache until `connect` is called. `connect` can be provided with a custom did resolution cache if needed. otherwise it defaults to using the level-based cache