### PR TITLE
export all relevant types

### DIFF
--- a/packages/web5/src/main.ts
+++ b/packages/web5/src/main.ts
@@ -1,1 +1,3 @@
 export * from './web5.js';
+
+export type * from './record.js';

--- a/packages/web5/src/main.ts
+++ b/packages/web5/src/main.ts
@@ -1,3 +1,15 @@
 export * from './web5.js';
 
 export type * from './record.js';
+
+export type * from './app-storage.js';
+
+export type * from './did-api.js';
+
+export type * from './did-resolution-cache.js';
+
+export type * from './dwn-api.js';
+
+export type * from './protocol.js';
+
+export type * from './record.js';


### PR DESCRIPTION
Fixes: 

```
The inferred type of 'createProtocolRecord' cannot be named without a reference to '../../../node_modules/@tbd54566975/web5/dist/types/record.js'. This is likely not portable. A type annotation is necessary.ts(2742)
```

What we are doing: 

```
import type { Web5 } from '@tbd54566975/web5'

async createProtocolRecord() {
...
  const response = await this.web5.dwn.records.create({
        data: recordData,
        message: message,
      })
  return response.record!
}
```