### PR TITLE
Add web5-agent Dependency To dids package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7720,6 +7720,7 @@
                 "@decentralized-identity/ion-tools": "1.0.7",
                 "@tbd54566975/crypto": "0.1.4",
                 "@tbd54566975/dwn-sdk-js": "0.0.33",
+                "@tbd54566975/web5-agent": "^0.1.5",
                 "cross-fetch": "3.1.5"
             },
             "devDependencies": {

--- a/packages/dids/package.json
+++ b/packages/dids/package.json
@@ -81,6 +81,7 @@
     "@decentralized-identity/ion-tools": "1.0.7",
     "@tbd54566975/crypto": "0.1.4",
     "@tbd54566975/dwn-sdk-js": "0.0.33",
+    "@tbd54566975/web5-agent": "^0.1.5",
     "cross-fetch": "3.1.5"
   },
   "devDependencies": {


### PR DESCRIPTION
The `dids` package imports types from `web5-agent` ([line 1 here](https://github.com/TBD54566975/web5-js/blob/main/packages/dids/src/types.ts#L1)) but `web5-agent` isn't included in the package dependencies. This manifests itself as a build bug when I try to consume the `@tbd54566975/dids` and build it, I was getting a typescript build error:

```
node_modules/@tbd54566975/dids/dist/types/types.d.ts:1:36 - error TS2307: Cannot find module '@tbd54566975/web5-agent' or its corresponding type declarations.

1 import type { KeyValueStore } from '@tbd54566975/web5-agent';
```

@frankhinek @mistermoe I used the `^` syntax on the version, b/c that was the default w/ `npm install` command, but lmk if we should be exact.