### PR TITLE
Bump web5 and web5-user-agent packages for 0.7.8 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,11 @@ npm install @tbd54566975/web5
 _CDNs_
 
 ```yaml
-https://unpkg.com/@tbd54566975/web5@0.7.7/dist/browser.js
+https://unpkg.com/@tbd54566975/web5@0.7.8/dist/browser.js
 ```
 
 ```yaml
-https://cdn.jsdelivr.net/npm/@tbd54566975/web5@0.7.7/dist/browser.mjs
+https://cdn.jsdelivr.net/npm/@tbd54566975/web5@0.7.8/dist/browser.mjs
 ```
 
 ### Importing the SDK

--- a/package-lock.json
+++ b/package-lock.json
@@ -7757,7 +7757,7 @@
         },
         "packages/web5": {
             "name": "@tbd54566975/web5",
-            "version": "0.7.7",
+            "version": "0.7.8",
             "license": "Apache-2.0",
             "dependencies": {
                 "@decentralized-identity/ion-tools": "1.0.7",
@@ -7766,7 +7766,7 @@
                 "@tbd54566975/dwn-sdk-js": "0.0.33",
                 "@tbd54566975/web5-agent": "0.1.5",
                 "@tbd54566975/web5-proxy-agent": "0.1.5",
-                "@tbd54566975/web5-user-agent": "0.1.6",
+                "@tbd54566975/web5-user-agent": "0.1.7",
                 "level": "8.0.0",
                 "ms": "2.1.3",
                 "readable-web-to-node-stream": "3.0.2"
@@ -7889,7 +7889,7 @@
         },
         "packages/web5-user-agent": {
             "name": "@tbd54566975/web5-user-agent",
-            "version": "0.1.6",
+            "version": "0.1.7",
             "license": "Apache-2.0",
             "dependencies": {
                 "@decentralized-identity/ion-tools": "1.0.7",

--- a/packages/web5-user-agent/package.json
+++ b/packages/web5-user-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tbd54566975/web5-user-agent",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Web5 User Agent",
   "type": "module",
   "main": "./dist/cjs/main.cjs",

--- a/packages/web5/README.md
+++ b/packages/web5/README.md
@@ -37,11 +37,11 @@ npm install @tbd54566975/web5
 _CDNs_
 
 ```yaml
-https://unpkg.com/@tbd54566975/web5@0.7.7/dist/browser.js
+https://unpkg.com/@tbd54566975/web5@0.7.8/dist/browser.js
 ```
 
 ```yaml
-https://cdn.jsdelivr.net/npm/@tbd54566975/web5@0.7.7/dist/browser.mjs
+https://cdn.jsdelivr.net/npm/@tbd54566975/web5@0.7.8/dist/browser.mjs
 ```
 
 ### Importing the SDK

--- a/packages/web5/package.json
+++ b/packages/web5/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tbd54566975/web5",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "description": "SDK for accessing the features and capabilities of Web5",
   "type": "module",
   "main": "./dist/cjs/main.cjs",
@@ -85,7 +85,7 @@
     "@tbd54566975/dwn-sdk-js": "0.0.33",
     "@tbd54566975/web5-agent": "0.1.5",
     "@tbd54566975/web5-proxy-agent": "0.1.5",
-    "@tbd54566975/web5-user-agent": "0.1.6",
+    "@tbd54566975/web5-user-agent": "0.1.7",
     "level": "8.0.0",
     "ms": "2.1.3",
     "readable-web-to-node-stream": "3.0.2"


### PR DESCRIPTION
This is solely a bug fix release to resolve an issue with Sync in the `web5-user-agent` package.