### PR TITLE
Create create-site-issue.yml

### DIFF
--- a/.github/workflows/create-site-issue.yml
+++ b/.github/workflows/create-site-issue.yml
@@ -1,0 +1,26 @@
+name: Create Dev site Issue On Release
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  create-issue:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Create Issue
+      uses: actions/github-script@v6
+      with:
+        github-token: ${{ secrets.DOCS_PAT }}  # Assuming 'PAT' is your Personal Access Token stored as a secret
+        script: |
+          const issueTitle = `New web5 release ${context.payload.release.tag_name} just cut`;
+          const issueBody = `Please check the api docs etc for compatibility with the release. Here is the [link to release notes](${context.payload.release.html_url}).`;
+          const labels = ['triage', 'BLOCKER'];
+          github.rest.issues.create({
+            owner: 'TBD54566975',
+            repo: 'developer.tbd.website',
+            title: issueTitle,
+            body: issueBody,
+            labels: labels
+          });


### PR DESCRIPTION
This will create an issue in the dev site to ensure that any examples/docs are checked that require human input