### PR TITLE
Adding builder for VerifiableCredential

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7793,6 +7793,7 @@
             }
         },
         "packages/credentials": {
+            "name": "@tbd54566975/credentials",
             "version": "0.1.4",
             "license": "Apache-2.0",
             "devDependencies": {

--- a/packages/credentials/src/types.ts
+++ b/packages/credentials/src/types.ts
@@ -4,14 +4,14 @@
  */
 export type VerifiableCredential = {
   /** see {@link https://www.w3.org/TR/vc-data-model/#contexts | Contexts} */
-  '@context': ['https://www.w3.org/2018/credentials/v1', ...string[]];
+  '@context': string[]
   credentialSubject: CredentialSubject | CredentialSubject[];
   /** @see {@link https://www.w3.org/TR/vc-data-model/#identifiers | Identifiers} */
   id?: string;
   /** @see {@link IssuerType} */
   issuer: Issuer;
   /** @see {@link https://www.w3.org/TR/vc-data-model/#types | Types} */
-  type?: string[] | string;
+  type: string[]
   /** @see {@link https://www.w3.org/TR/vc-data-model/#issuance-date | Issuance Date} */
   issuanceDate: string;
   /** @see {@link https://www.w3.org/TR/vc-data-model/#expiration | Expiration} */
@@ -20,6 +20,7 @@ export type VerifiableCredential = {
   credentialStatus?: CredentialStatusReference;
   [key: string]: any;
 }
+
 
 /**
  * The issuer of a {@link VerifiableCredential}.

--- a/packages/credentials/src/utils.ts
+++ b/packages/credentials/src/utils.ts
@@ -1,0 +1,11 @@
+export function getCurrentTimestamp() : string {
+  return new Date().toISOString();
+}
+
+export function isRFC3339Timestamp(timestamp: string): boolean {
+  if (typeof timestamp !== 'string') {
+    return false;
+  }
+
+  return !isNaN(Date.parse(timestamp));
+}

--- a/packages/credentials/src/utils.ts
+++ b/packages/credentials/src/utils.ts
@@ -1,11 +1,13 @@
-export function getCurrentTimestamp() : string {
-  return new Date().toISOString();
+export function getCurrentXmlSchema112Timestamp() : string {
+  // Omit the milliseconds part from toISOString() output
+  return new Date().toISOString().replace(/\.\d+Z$/, 'Z');
 }
 
-export function isRFC3339Timestamp(timestamp: string): boolean {
-  if (typeof timestamp !== 'string') {
+export function isXmlSchema112Timestamp(timestamp : string): boolean {
+  if (isNaN(Date.parse(timestamp))) {
     return false;
   }
-
-  return !isNaN(Date.parse(timestamp));
+  // Omit the milliseconds part from toISOString() output
+  const isoStr = new Date(timestamp).toISOString().replace(/\.\d+Z$/, 'Z');
+  return isoStr === timestamp;
 }

--- a/packages/credentials/src/verifiable-credential-builder.ts
+++ b/packages/credentials/src/verifiable-credential-builder.ts
@@ -1,36 +1,36 @@
 import type { VerifiableCredential, CredentialSubject, Issuer } from './types.js';
-import { getCurrentTimestamp, isRFC3339Timestamp } from './utils.js';
+import { getCurrentXmlSchema112Timestamp, isXmlSchema112Timestamp } from './utils.js';
 
 export class VerifiableCredentialBuilder {
   verifiableCredential: VerifiableCredential;
 
   constructor(credentialSubject: CredentialSubject | CredentialSubject[], issuer: Issuer) {
-    const contexts = ['https://www.w3.org/2018/credentials/v1'];
+    const context = ['https://www.w3.org/2018/credentials/v1'];
     const types: string[] = ['VerifiableCredential'];
 
     this.verifiableCredential = {
-      '@context'        : contexts as ['https://www.w3.org/2018/credentials/v1', ...string[]],
+      '@context'        : context,
       credentialSubject : credentialSubject,
       issuer            : issuer,
       type              : types,
-      issuanceDate      : getCurrentTimestamp(),
+      issuanceDate      : getCurrentXmlSchema112Timestamp(),
     };
   }
 
-  addContext(context: string[] | string): VerifiableCredentialBuilder  {
+  addContext(context: string | string[]): VerifiableCredentialBuilder  {
     if (!context || context === '' || context.length === 0) {
       throw new Error('context cannot be empty');
     }
 
     let contextArray = Array.isArray(context) ? context : [context];
-    this.verifiableCredential['@context'] = [
-      ...new Set([...this.verifiableCredential['@context'], ...contextArray])
-    ] as ['https://www.w3.org/2018/credentials/v1', ...string[]];
+    let combined = [...this.verifiableCredential['@context'], ...contextArray];
+
+    this.verifiableCredential['@context'] = combined;
 
     return this;
   }
 
-  addType(type: string[] | string): VerifiableCredentialBuilder  {
+  addType(type: string | string[]): VerifiableCredentialBuilder  {
     if (!type || type === '' || type.length === 0) {
       throw new Error('type cannot be empty');
     }
@@ -45,7 +45,7 @@ export class VerifiableCredentialBuilder {
     return this;
   }
 
-  setID(id: string): VerifiableCredentialBuilder  {
+  setId(id: string): VerifiableCredentialBuilder  {
     if (!id || id === '') {
       throw new Error('id cannot be empty');
 
@@ -63,26 +63,34 @@ export class VerifiableCredentialBuilder {
     return this;
   }
 
-  setIssuanceDate(issuanceDate: string): VerifiableCredentialBuilder  {
+  setIssuanceDate(issuanceDate: string | Date): VerifiableCredentialBuilder  {
     if (!issuanceDate || issuanceDate === '') {
       throw new Error('issuanceDate cannot be empty');
     }
 
-    if (isRFC3339Timestamp(issuanceDate) === false) {
-      throw new Error('issuanceDate is not a valid RFC3339 timestamp');
+    if (typeof issuanceDate === 'object' && issuanceDate instanceof Date) {
+      issuanceDate = issuanceDate.toISOString().replace(/\.\d+Z$/, 'Z');
+    }
+
+    if (isXmlSchema112Timestamp(issuanceDate) === false) {
+      throw new Error('issuanceDate is not a valid XMLSCHEMA11-2 timestamp');
     }
 
     this.verifiableCredential.issuanceDate = issuanceDate;
     return this;
   }
 
-  setExpirationDate(expirationDate: string): VerifiableCredentialBuilder  {
+  setExpirationDate(expirationDate: string | Date): VerifiableCredentialBuilder  {
     if (!expirationDate || expirationDate === '') {
       throw new Error('expirationDate cannot be empty');
     }
 
-    if (isRFC3339Timestamp(expirationDate) === false) {
-      throw new Error('expirationDate is not a valid RFC3339 timestamp');
+    if (typeof expirationDate === 'object' && expirationDate instanceof Date) {
+      expirationDate = expirationDate.toISOString().replace(/\.\d+Z$/, 'Z');
+    }
+
+    if (isXmlSchema112Timestamp(expirationDate) === false) {
+      throw new Error('expirationDate is not a valid XMLSCHEMA11-2 timestamp');
     }
 
     this.verifiableCredential.expirationDate = expirationDate;

--- a/packages/credentials/src/verifiable-credential-builder.ts
+++ b/packages/credentials/src/verifiable-credential-builder.ts
@@ -1,0 +1,96 @@
+import type { VerifiableCredential, CredentialSubject, Issuer } from './types.js';
+import { getCurrentTimestamp, isRFC3339Timestamp } from './utils.js';
+
+export class VerifiableCredentialBuilder {
+  verifiableCredential: VerifiableCredential;
+
+  constructor(credentialSubject: CredentialSubject | CredentialSubject[], issuer: Issuer) {
+    const contexts = ['https://www.w3.org/2018/credentials/v1'];
+    const types: string[] = ['VerifiableCredential'];
+
+    this.verifiableCredential = {
+      '@context'        : contexts as ['https://www.w3.org/2018/credentials/v1', ...string[]],
+      credentialSubject : credentialSubject,
+      issuer            : issuer,
+      type              : types,
+      issuanceDate      : getCurrentTimestamp(),
+    };
+  }
+
+  addContext(context: string[] | string): VerifiableCredentialBuilder  {
+    if (!context || context === '' || context.length === 0) {
+      throw new Error('context cannot be empty');
+    }
+
+    let contextArray = Array.isArray(context) ? context : [context];
+    this.verifiableCredential['@context'] = [
+      ...new Set([...this.verifiableCredential['@context'], ...contextArray])
+    ] as ['https://www.w3.org/2018/credentials/v1', ...string[]];
+
+    return this;
+  }
+
+  addType(type: string[] | string): VerifiableCredentialBuilder  {
+    if (!type || type === '' || type.length === 0) {
+      throw new Error('type cannot be empty');
+    }
+
+    let typeArray = Array.isArray(type) ? type : [type];
+
+    if (!Array.isArray(this.verifiableCredential.type)) {
+      this.verifiableCredential.type = [this.verifiableCredential.type] as string[];
+    }
+
+    this.verifiableCredential.type = [...new Set([...this.verifiableCredential.type, ...typeArray])];
+    return this;
+  }
+
+  setID(id: string): VerifiableCredentialBuilder  {
+    if (!id || id === '') {
+      throw new Error('id cannot be empty');
+
+    }
+    this.verifiableCredential.id = id;
+    return this;
+  }
+
+  setIssuer(issuer: Issuer): VerifiableCredentialBuilder  {
+    if (!issuer || Object.keys(issuer).length === 0) {
+      throw new Error('issuer must be a non-empty object');
+    }
+
+    this.verifiableCredential.issuer = issuer;
+    return this;
+  }
+
+  setIssuanceDate(issuanceDate: string): VerifiableCredentialBuilder  {
+    if (!issuanceDate || issuanceDate === '') {
+      throw new Error('issuanceDate cannot be empty');
+    }
+
+    if (isRFC3339Timestamp(issuanceDate) === false) {
+      throw new Error('issuanceDate is not a valid RFC3339 timestamp');
+    }
+
+    this.verifiableCredential.issuanceDate = issuanceDate;
+    return this;
+  }
+
+  setExpirationDate(expirationDate: string): VerifiableCredentialBuilder  {
+    if (!expirationDate || expirationDate === '') {
+      throw new Error('expirationDate cannot be empty');
+    }
+
+    if (isRFC3339Timestamp(expirationDate) === false) {
+      throw new Error('expirationDate is not a valid RFC3339 timestamp');
+    }
+
+    this.verifiableCredential.expirationDate = expirationDate;
+    return this;
+  }
+
+
+  build(): VerifiableCredential {
+    return this.verifiableCredential;
+  }
+}

--- a/packages/credentials/src/verifiable-credential-builder.ts
+++ b/packages/credentials/src/verifiable-credential-builder.ts
@@ -97,7 +97,6 @@ export class VerifiableCredentialBuilder {
     return this;
   }
 
-
   build(): VerifiableCredential {
     return this.verifiableCredential;
   }

--- a/packages/credentials/tests/example.spec.ts
+++ b/packages/credentials/tests/example.spec.ts
@@ -1,7 +1,0 @@
-import { expect } from 'chai';
-
-describe('example', () => {
-  it('needs more tests', () => {
-    expect(true).to.be.true;
-  });
-});

--- a/packages/credentials/tests/utils.spec.ts
+++ b/packages/credentials/tests/utils.spec.ts
@@ -1,0 +1,25 @@
+import { expect } from 'chai';
+import { isXmlSchema112Timestamp } from '../src/utils.js';
+
+describe('Utils', async () => {
+  describe('isXmlSchema112Timestamp', () => {
+    it('returns false for invalid timestamp string', () => {
+      expect(isXmlSchema112Timestamp('0')).to.be.false;
+      expect(isXmlSchema112Timestamp('2023-06-14')).to.be.false;
+      expect(isXmlSchema112Timestamp('2023-06-14T11:29')).to.be.false;
+      expect(isXmlSchema112Timestamp('January 20')).to.be.false;
+      expect(isXmlSchema112Timestamp('Sun, 26 Feb 2023 01:22:14 +0000')).to.be.false;
+      expect(isXmlSchema112Timestamp('"2022-13-01T12:34:56Z"')).to.be.false;
+      expect(isXmlSchema112Timestamp('2023-06-16T19:34:52.589Z')).to.be.false;
+    });
+
+    it('returns true for valid timestamp string', () => {
+      expect(isXmlSchema112Timestamp('2023-06-16T14:45:30Z')).to.be.true;
+      expect(isXmlSchema112Timestamp('2000-01-01T00:00:00Z')).to.be.true;
+      expect(isXmlSchema112Timestamp('2022-12-31T23:59:59Z')).to.be.true;
+      expect(isXmlSchema112Timestamp('1996-02-29T12:34:56Z')).to.be.true;
+      expect(isXmlSchema112Timestamp('2021-05-30T01:23:45Z')).to.be.true;
+      expect(isXmlSchema112Timestamp('2023-06-16T19:34:52Z')).to.be.true;
+    });
+  });
+});

--- a/packages/credentials/tests/verifiable-credential-builder.spec.ts
+++ b/packages/credentials/tests/verifiable-credential-builder.spec.ts
@@ -1,0 +1,130 @@
+import { expect } from 'chai';
+
+import type { CredentialSubject, Issuer } from '../src/types.js';
+import {VerifiableCredentialBuilder}  from '../src/verifiable-credential-builder.js';
+import { DidKeyApi } from '../../dids/src/did-key.js';
+
+
+describe('VCBuilder', async () => {
+  const didKey = new DidKeyApi();
+  const did = await didKey.create();
+
+  const credentialSubject: CredentialSubject = {
+    id: did.id
+  };
+
+  const issuer: Issuer = {
+    id: did.id
+  };
+
+  describe('VCBuilder builds VC()', () => {
+    it('can build a valid vc', async () => {
+      const vcBuilder = new VerifiableCredentialBuilder(credentialSubject, issuer);
+      const vc = vcBuilder.build();
+
+      expect(vc).to.exist;
+
+      expect(vc['@context']).to.include('https://www.w3.org/2018/credentials/v1');
+      expect(vc.credentialSubject).to.equal(credentialSubject);
+      expect(vc.issuer).to.equal(issuer);
+      expect(vc.type).to.include('VerifiableCredential');
+      expect(vc.issuanceDate).to.exist;
+
+      expect(vc.id).to.not.exist;
+      expect(vc.credentialStatus).to.not.exist;
+      expect(vc.expirationDate).to.not.exist;
+
+
+    });
+
+    it('can set the ID', () => {
+      const vcBuilder = new VerifiableCredentialBuilder(credentialSubject, issuer);
+      vcBuilder.setID('customID');
+      const vc = vcBuilder.build();
+
+      expect(vc.id).to.equal('customID');
+    });
+
+    it('throws an error when setting an empty ID', () => {
+      const vcBuilder = new VerifiableCredentialBuilder(credentialSubject, issuer);
+
+      expect(() => vcBuilder.setID('')).to.throw('id cannot be empty');
+    });
+
+    it('can add new context', () => {
+      const vcBuilder = new VerifiableCredentialBuilder(credentialSubject, issuer);
+      vcBuilder.addContext(['newContext']);
+      const vc = vcBuilder.build();
+
+      expect(vc['@context']).to.include('https://www.w3.org/2018/credentials/v1');
+      expect(vc['@context']).to.include('newContext');
+      expect(vc['@context'].length).to.equal(2);
+    });
+
+    it('can add new type', () => {
+      const vcBuilder = new VerifiableCredentialBuilder(credentialSubject, issuer);
+      vcBuilder.addType('newType');
+      const vc = vcBuilder.build();
+
+      expect(vc.type).to.include('newType');
+      expect(vc.type).to.include('VerifiableCredential');
+      expect(vc.type!.length).to.equal(2);
+    });
+
+
+    it('can set the issuer', () => {
+      const vcBuilder = new VerifiableCredentialBuilder(credentialSubject, issuer);
+      vcBuilder.setIssuer({ id: 'customIssuer' });
+      const vc = vcBuilder.build();
+
+      expect(vc.issuer).to.deep.equal({ id: 'customIssuer' });
+    });
+
+    it('throws an error when setting an empty issuer', () => {
+      const vcBuilder = new VerifiableCredentialBuilder(credentialSubject, issuer);
+
+      expect(() => vcBuilder.setIssuer({} as Issuer)).to.throw('issuer must be a non-empty object');
+    });
+
+    it('can set the issuance date', () => {
+      const vcBuilder = new VerifiableCredentialBuilder(credentialSubject, issuer);
+      vcBuilder.setIssuanceDate('2023-12-31T23:59:59Z');
+      const vc = vcBuilder.build();
+
+      expect(vc.issuanceDate).to.equal('2023-12-31T23:59:59Z');
+    });
+
+    it('throws an error when setting an empty issuance date', () => {
+      const vcBuilder = new VerifiableCredentialBuilder(credentialSubject, issuer);
+
+      expect(() => vcBuilder.setIssuanceDate('')).to.throw('issuanceDate cannot be empty');
+    });
+
+    it('throws an error when setting an invalid issuance date', () => {
+      const vcBuilder = new VerifiableCredentialBuilder(credentialSubject, issuer);
+
+      expect(() => vcBuilder.setIssuanceDate('not-a-date')).to.throw('issuanceDate is not a valid RFC3339 timestamp');
+    });
+
+    it('can set the expiration date', () => {
+      const vcBuilder = new VerifiableCredentialBuilder(credentialSubject, issuer);
+      vcBuilder.setExpirationDate('2024-12-31T23:59:59Z');
+      const vc = vcBuilder.build();
+
+      expect(vc.expirationDate).to.equal('2024-12-31T23:59:59Z');
+    });
+
+    it('throws an error when setting an empty expiration date', () => {
+      const vcBuilder = new VerifiableCredentialBuilder(credentialSubject, issuer);
+
+      expect(() => vcBuilder.setExpirationDate('')).to.throw('expirationDate cannot be empty');
+    });
+
+    it('throws an error when setting an invalid expiration date', () => {
+      const vcBuilder = new VerifiableCredentialBuilder(credentialSubject, issuer);
+
+      expect(() => vcBuilder.setExpirationDate('not-a-date')).to.throw('expirationDate is not a valid RFC3339 timestamp');
+    });
+
+  });
+});

--- a/packages/credentials/tests/verifiable-credential-builder.spec.ts
+++ b/packages/credentials/tests/verifiable-credential-builder.spec.ts
@@ -18,21 +18,23 @@ describe('VerifiableCredentialBuilder', async () => {
     id: did.id
   };
 
-  it('can build a valid vc', async () => {
-    const vcBuilder = new VerifiableCredentialBuilder(credentialSubject, issuer);
-    const vc = vcBuilder.build();
+  describe('build', () => {
+    it('can build a valid vc', async () => {
+      const vcBuilder = new VerifiableCredentialBuilder(credentialSubject, issuer);
+      const vc = vcBuilder.build();
 
-    expect(vc).to.exist;
+      expect(vc).to.exist;
 
-    expect(vc['@context']).to.include('https://www.w3.org/2018/credentials/v1');
-    expect(vc.credentialSubject).to.equal(credentialSubject);
-    expect(vc.issuer).to.equal(issuer);
-    expect(vc.type).to.include('VerifiableCredential');
-    expect(vc.issuanceDate).to.exist;
+      expect(vc['@context']).to.include('https://www.w3.org/2018/credentials/v1');
+      expect(vc.credentialSubject).to.equal(credentialSubject);
+      expect(vc.issuer).to.equal(issuer);
+      expect(vc.type).to.include('VerifiableCredential');
+      expect(vc.issuanceDate).to.exist;
 
-    expect(vc.id).to.not.exist;
-    expect(vc.credentialStatus).to.not.exist;
-    expect(vc.expirationDate).to.not.exist;
+      expect(vc.id).to.not.exist;
+      expect(vc.credentialStatus).to.not.exist;
+      expect(vc.expirationDate).to.not.exist;
+    });
   });
 
   describe('setId', () => {

--- a/packages/credentials/tests/verifiable-credential-builder.spec.ts
+++ b/packages/credentials/tests/verifiable-credential-builder.spec.ts
@@ -5,7 +5,8 @@ import {VerifiableCredentialBuilder}  from '../src/verifiable-credential-builder
 import { DidKeyApi } from '../../dids/src/did-key.js';
 
 
-describe('VCBuilder', async () => {
+
+describe('VerifiableCredentialBuilder', async () => {
   const didKey = new DidKeyApi();
   const did = await didKey.create();
 
@@ -17,29 +18,27 @@ describe('VCBuilder', async () => {
     id: did.id
   };
 
-  describe('VCBuilder builds VC()', () => {
-    it('can build a valid vc', async () => {
-      const vcBuilder = new VerifiableCredentialBuilder(credentialSubject, issuer);
-      const vc = vcBuilder.build();
+  it('can build a valid vc', async () => {
+    const vcBuilder = new VerifiableCredentialBuilder(credentialSubject, issuer);
+    const vc = vcBuilder.build();
 
-      expect(vc).to.exist;
+    expect(vc).to.exist;
 
-      expect(vc['@context']).to.include('https://www.w3.org/2018/credentials/v1');
-      expect(vc.credentialSubject).to.equal(credentialSubject);
-      expect(vc.issuer).to.equal(issuer);
-      expect(vc.type).to.include('VerifiableCredential');
-      expect(vc.issuanceDate).to.exist;
+    expect(vc['@context']).to.include('https://www.w3.org/2018/credentials/v1');
+    expect(vc.credentialSubject).to.equal(credentialSubject);
+    expect(vc.issuer).to.equal(issuer);
+    expect(vc.type).to.include('VerifiableCredential');
+    expect(vc.issuanceDate).to.exist;
 
-      expect(vc.id).to.not.exist;
-      expect(vc.credentialStatus).to.not.exist;
-      expect(vc.expirationDate).to.not.exist;
+    expect(vc.id).to.not.exist;
+    expect(vc.credentialStatus).to.not.exist;
+    expect(vc.expirationDate).to.not.exist;
+  });
 
-
-    });
-
+  describe('setId', () => {
     it('can set the ID', () => {
       const vcBuilder = new VerifiableCredentialBuilder(credentialSubject, issuer);
-      vcBuilder.setID('customID');
+      vcBuilder.setId('customID');
       const vc = vcBuilder.build();
 
       expect(vc.id).to.equal('customID');
@@ -48,9 +47,11 @@ describe('VCBuilder', async () => {
     it('throws an error when setting an empty ID', () => {
       const vcBuilder = new VerifiableCredentialBuilder(credentialSubject, issuer);
 
-      expect(() => vcBuilder.setID('')).to.throw('id cannot be empty');
+      expect(() => vcBuilder.setId('')).to.throw('id cannot be empty');
     });
+  });
 
+  describe('addContext', () => {
     it('can add new context', () => {
       const vcBuilder = new VerifiableCredentialBuilder(credentialSubject, issuer);
       vcBuilder.addContext(['newContext']);
@@ -60,7 +61,9 @@ describe('VCBuilder', async () => {
       expect(vc['@context']).to.include('newContext');
       expect(vc['@context'].length).to.equal(2);
     });
+  });
 
+  describe('addType', () => {
     it('can add new type', () => {
       const vcBuilder = new VerifiableCredentialBuilder(credentialSubject, issuer);
       vcBuilder.addType('newType');
@@ -70,8 +73,10 @@ describe('VCBuilder', async () => {
       expect(vc.type).to.include('VerifiableCredential');
       expect(vc.type!.length).to.equal(2);
     });
+  });
 
 
+  describe('setIssuer', () => {
     it('can set the issuer', () => {
       const vcBuilder = new VerifiableCredentialBuilder(credentialSubject, issuer);
       vcBuilder.setIssuer({ id: 'customIssuer' });
@@ -80,12 +85,17 @@ describe('VCBuilder', async () => {
       expect(vc.issuer).to.deep.equal({ id: 'customIssuer' });
     });
 
+
     it('throws an error when setting an empty issuer', () => {
       const vcBuilder = new VerifiableCredentialBuilder(credentialSubject, issuer);
 
       expect(() => vcBuilder.setIssuer({} as Issuer)).to.throw('issuer must be a non-empty object');
     });
 
+  });
+
+
+  describe('setIssuanceDate', () => {
     it('can set the issuance date', () => {
       const vcBuilder = new VerifiableCredentialBuilder(credentialSubject, issuer);
       vcBuilder.setIssuanceDate('2023-12-31T23:59:59Z');
@@ -103,9 +113,11 @@ describe('VCBuilder', async () => {
     it('throws an error when setting an invalid issuance date', () => {
       const vcBuilder = new VerifiableCredentialBuilder(credentialSubject, issuer);
 
-      expect(() => vcBuilder.setIssuanceDate('not-a-date')).to.throw('issuanceDate is not a valid RFC3339 timestamp');
+      expect(() => vcBuilder.setIssuanceDate('not-a-date')).to.throw('issuanceDate is not a valid XMLSCHEMA11-2 timestamp');
     });
+  });
 
+  describe('setExpirationDate', () => {
     it('can set the expiration date', () => {
       const vcBuilder = new VerifiableCredentialBuilder(credentialSubject, issuer);
       vcBuilder.setExpirationDate('2024-12-31T23:59:59Z');
@@ -123,8 +135,7 @@ describe('VCBuilder', async () => {
     it('throws an error when setting an invalid expiration date', () => {
       const vcBuilder = new VerifiableCredentialBuilder(credentialSubject, issuer);
 
-      expect(() => vcBuilder.setExpirationDate('not-a-date')).to.throw('expirationDate is not a valid RFC3339 timestamp');
+      expect(() => vcBuilder.setExpirationDate('not-a-date')).to.throw('expirationDate is not a valid XMLSCHEMA11-2 timestamp');
     });
-
   });
 });

--- a/packages/credentials/tests/verifiable-credential-builder.spec.ts
+++ b/packages/credentials/tests/verifiable-credential-builder.spec.ts
@@ -4,8 +4,6 @@ import type { CredentialSubject, Issuer } from '../src/types.js';
 import {VerifiableCredentialBuilder}  from '../src/verifiable-credential-builder.js';
 import { DidKeyApi } from '../../dids/src/did-key.js';
 
-
-
 describe('VerifiableCredentialBuilder', async () => {
   const didKey = new DidKeyApi();
   const did = await didKey.create();
@@ -76,8 +74,6 @@ describe('VerifiableCredentialBuilder', async () => {
       expect(vc.type!.length).to.equal(2);
     });
   });
-
-
   describe('setIssuer', () => {
     it('can set the issuer', () => {
       const vcBuilder = new VerifiableCredentialBuilder(credentialSubject, issuer);
@@ -95,7 +91,6 @@ describe('VerifiableCredentialBuilder', async () => {
     });
 
   });
-
 
   describe('setIssuanceDate', () => {
     it('can set the issuance date', () => {

--- a/packages/credentials/tests/verifiable-credential-builder.spec.ts
+++ b/packages/credentials/tests/verifiable-credential-builder.spec.ts
@@ -101,6 +101,14 @@ describe('VerifiableCredentialBuilder', async () => {
       expect(vc.issuanceDate).to.equal('2023-12-31T23:59:59Z');
     });
 
+    it('can set the issuance date', () => {
+      const vcBuilder = new VerifiableCredentialBuilder(credentialSubject, issuer);
+      vcBuilder.setIssuanceDate(new Date('2023-12-31T23:59:59Z'));
+      const vc = vcBuilder.build();
+
+      expect(vc.issuanceDate).to.equal('2023-12-31T23:59:59Z');
+    });
+
     it('throws an error when setting an empty issuance date', () => {
       const vcBuilder = new VerifiableCredentialBuilder(credentialSubject, issuer);
 
@@ -115,9 +123,17 @@ describe('VerifiableCredentialBuilder', async () => {
   });
 
   describe('setExpirationDate', () => {
-    it('can set the expiration date', () => {
+    it('can set the expiration date string', () => {
       const vcBuilder = new VerifiableCredentialBuilder(credentialSubject, issuer);
       vcBuilder.setExpirationDate('2024-12-31T23:59:59Z');
+      const vc = vcBuilder.build();
+
+      expect(vc.expirationDate).to.equal('2024-12-31T23:59:59Z');
+    });
+
+    it('can set the expiration date', () => {
+      const vcBuilder = new VerifiableCredentialBuilder(credentialSubject, issuer);
+      vcBuilder.setExpirationDate(new Date('2024-12-31T23:59:59Z'));
       const vc = vcBuilder.build();
 
       expect(vc.expirationDate).to.equal('2024-12-31T23:59:59Z');
@@ -133,6 +149,7 @@ describe('VerifiableCredentialBuilder', async () => {
       const vcBuilder = new VerifiableCredentialBuilder(credentialSubject, issuer);
 
       expect(() => vcBuilder.setExpirationDate('not-a-date')).to.throw('expirationDate is not a valid XMLSCHEMA11-2 timestamp');
+      expect(() => vcBuilder.setExpirationDate('0')).to.throw('expirationDate is not a valid XMLSCHEMA11-2 timestamp');
     });
   });
 });


### PR DESCRIPTION
Added VerifiableCredential builder along with unit tests.

The default constructor sets only things that are not optional:
```
    this.verifiableCredential = {
      '@context'        : contexts as ['https://www.w3.org/2018/credentials/v1', ...string[]],
      credentialSubject : credentialSubject,
      issuer            : issuer,
      type              : types,
      issuanceDate      : getCurrentTimestamp(),
    };
```

Added the builder pattern for the rest of the fields with simple validation
Added unit tests
<img width="492" alt="image" src="https://github.com/TBD54566975/web5-js/assets/5314059/f192c147-bf83-42ea-9c3a-1a627e5be850">
