### PR TITLE
`dids` version bump

### DIFF
--- a/.github/workflows/alpha-npm.yml
+++ b/.github/workflows/alpha-npm.yml
@@ -23,6 +23,7 @@ jobs:
       matrix:
         package:
           [
+            "common",
             "crypto",
             "dids",
             "web5",

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -23,6 +23,7 @@ jobs:
       matrix:
         package:
           [
+            "common",
             "crypto",
             "dids",
             "web5",

--- a/codecov.yml
+++ b/codecov.yml
@@ -11,6 +11,10 @@ component_management:
         target: 100 # every PR opened should strive for full test coverage
 
   individual_components:
+    - component_id: package_common
+      name: common
+      paths: ["packages/common/**"]
+
     - component_id: package_credentials
       name: credentials
       paths: ["packages/credentials/**"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,4 @@
 {
-    "name": "web5-js",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
@@ -7793,6 +7792,7 @@
             }
         },
         "packages/credentials": {
+            "name": "@tbd54566975/credentials",
             "version": "0.1.4",
             "license": "Apache-2.0",
             "devDependencies": {
@@ -8258,7 +8258,7 @@
         },
         "packages/dids": {
             "name": "@tbd54566975/dids",
-            "version": "0.1.6",
+            "version": "0.1.7",
             "license": "Apache-2.0",
             "dependencies": {
                 "@decentralized-identity/ion-tools": "1.0.7",
@@ -8697,7 +8697,7 @@
             "dependencies": {
                 "@decentralized-identity/ion-tools": "1.0.7",
                 "@tbd54566975/crypto": "0.1.4",
-                "@tbd54566975/dids": "0.1.6",
+                "@tbd54566975/dids": "0.1.7",
                 "@tbd54566975/dwn-sdk-js": "0.0.33",
                 "@tbd54566975/web5-agent": "0.1.5",
                 "@tbd54566975/web5-proxy-agent": "0.1.5",
@@ -9609,7 +9609,7 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "@decentralized-identity/ion-tools": "1.0.7",
-                "@tbd54566975/dids": "0.1.6",
+                "@tbd54566975/dids": "0.1.7",
                 "@tbd54566975/dwn-sdk-js": "0.0.33",
                 "@tbd54566975/web5-agent": "0.1.5",
                 "abstract-level": "1.0.3",
@@ -11616,7 +11616,7 @@
                 "@decentralized-identity/ion-tools": "1.0.7",
                 "@playwright/test": "1.34.3",
                 "@tbd54566975/crypto": "0.1.4",
-                "@tbd54566975/dids": "0.1.6",
+                "@tbd54566975/dids": "0.1.7",
                 "@tbd54566975/dwn-sdk-js": "0.0.33",
                 "@tbd54566975/web5-agent": "0.1.5",
                 "@tbd54566975/web5-proxy-agent": "0.1.5",
@@ -12288,7 +12288,7 @@
                 "@decentralized-identity/ion-tools": "1.0.7",
                 "@faker-js/faker": "8.0.1",
                 "@playwright/test": "1.34.3",
-                "@tbd54566975/dids": "0.1.6",
+                "@tbd54566975/dids": "0.1.7",
                 "@tbd54566975/dwn-sdk-js": "0.0.33",
                 "@tbd54566975/web5-agent": "0.1.5",
                 "@types/chai": "4.3.0",

--- a/packages/dids/package.json
+++ b/packages/dids/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tbd54566975/dids",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "TBD DIDs library",
   "type": "module",
   "main": "./dist/cjs/main.cjs",

--- a/packages/web5-user-agent/package.json
+++ b/packages/web5-user-agent/package.json
@@ -76,7 +76,7 @@
   },
   "dependencies": {
     "@decentralized-identity/ion-tools": "1.0.7",
-    "@tbd54566975/dids": "0.1.6",
+    "@tbd54566975/dids": "0.1.7",
     "@tbd54566975/dwn-sdk-js": "0.0.33",
     "@tbd54566975/web5-agent": "0.1.5",
     "abstract-level": "1.0.3",

--- a/packages/web5/package.json
+++ b/packages/web5/package.json
@@ -81,7 +81,7 @@
   "dependencies": {
     "@decentralized-identity/ion-tools": "1.0.7",
     "@tbd54566975/crypto": "0.1.4",
-    "@tbd54566975/dids": "0.1.6",
+    "@tbd54566975/dids": "0.1.7",
     "@tbd54566975/dwn-sdk-js": "0.0.33",
     "@tbd54566975/web5-agent": "0.1.5",
     "@tbd54566975/web5-proxy-agent": "0.1.5",

--- a/web5-js.code-workspace
+++ b/web5-js.code-workspace
@@ -6,6 +6,11 @@
 			"path": "."
 		},
 		{
+			// @tbd54566975/common
+			"name": "common",
+			"path": "packages/common",
+		},
+		{
 			// @tbd54566975/credentials
 			"name": "credentials",
 			"path": "packages/credentials",


### PR DESCRIPTION
ran into the following when attempting to use `@tbd54566975/dids` in another project:

<img width="1717" alt="image" src="https://github.com/TBD54566975/web5-js/assets/4887440/fe58f78b-f48a-4810-b050-dd3765c9aeb2">

caught me by surprise because we just fixed this issue until i realized that we forgot to version bump the `dids` package hehe. i think we also need to publish `common`. debating whether we should version bump `web5-agent` as well since it no longer includes `KeyValueStore`