### PR TITLE
enable manually triggering npm release github action

### DIFF
--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -3,6 +3,7 @@ name: Release to NPM Registry
 on:
   release:
     types: [created]
+  workflow_dispatch:
 
 # Allow only one concurrent deployment,but do NOT cancel in-progress runs as
 # we want to allow these release deployments to complete.


### PR DESCRIPTION
will allow us to manually trigger the github action used to publish packages to npm. helpful in scenarios where we don't want/need to publish a _github release_. will come in handy to publish updated `dids` package