### PR TITLE
Fix NPM release workflow for new packages

### DIFF
--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -62,7 +62,7 @@ jobs:
           cd packages/${{ matrix.package }}
 
           # Fetch the published version on NPMjs.com.
-          PUBLISHED_VERSION=$(npm view @tbd54566975/${{ matrix.package }} version)
+          PUBLISHED_VERSION=$(npm view @tbd54566975/${{ matrix.package }} version 2>/dev/null || echo "0.0.0")
           echo "Published Version: $PUBLISHED_VERSION"
 
           # Fetch the version in the GitHub repo's package.json file.


### PR DESCRIPTION
This PR makes a minor change to the GitHub Actions workflow `Release to NPM Registry`:
- When a new package is added to the Web5 JS polyrepo, the existing workflow checked to see what the published version was before attempting to publish to NPM Registry.  While this makes sense for an existing package, this command throws an error for a package that is being published for the first time.
- This PR will return `0.0.0` as the version if the package has never been published, to ensure that first time publishing is executed.