### PR TITLE
Add react-native directives to each package.json

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -60,6 +60,11 @@
     "./dist/cjs/main.cjs": "./dist/browser.js",
     "types": "./dist/types/main.d.ts"
   },
+  "react-native": {
+    "./dist/esm/main.mjs": "./dist/esm/main.mjs",
+    "./dist/cjs/main.cjs": "./dist/esm/main.mjs",
+    "types": "./dist/types/main.d.ts"
+  },
   "keywords": [
     "decentralized",
     "decentralized-applications",

--- a/packages/credentials/package.json
+++ b/packages/credentials/package.json
@@ -61,6 +61,11 @@
     "./dist/cjs/main.cjs": "./dist/browser.js",
     "types": "./dist/types/main.d.ts"
   },
+  "react-native": {
+    "./dist/esm/main.mjs": "./dist/esm/main.mjs",
+    "./dist/cjs/main.cjs": "./dist/esm/main.mjs",
+    "types": "./dist/types/main.d.ts"
+  },
   "keywords": [
     "decentralized",
     "decentralized-applications",

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -61,6 +61,11 @@
     "./dist/cjs/main.cjs": "./dist/browser.js",
     "types": "./dist/types/main.d.ts"
   },
+  "react-native": {
+    "./dist/esm/main.mjs": "./dist/esm/main.mjs",
+    "./dist/cjs/main.cjs": "./dist/esm/main.mjs",
+    "types": "./dist/types/main.d.ts"
+  },
   "keywords": [
     "cryptography",
     "ed25519",

--- a/packages/dids/package.json
+++ b/packages/dids/package.json
@@ -61,6 +61,11 @@
     "./dist/cjs/main.cjs": "./dist/browser.js",
     "types": "./dist/types/main.d.ts"
   },
+  "react-native": {
+    "./dist/esm/main.mjs": "./dist/esm/main.mjs",
+    "./dist/cjs/main.cjs": "./dist/esm/main.mjs",
+    "types": "./dist/types/main.d.ts"
+  },
   "keywords": [
     "decentralized",
     "decentralized-identity",

--- a/packages/old/package.json
+++ b/packages/old/package.json
@@ -19,6 +19,10 @@
     "./dist/esm/index.js": "./dist/browser.mjs",
     "./dist/cjs/index.js": "./dist/browser.js"
   },
+  "react-native": {
+    "./dist/esm/main.mjs": "./dist/esm/main.mjs",
+    "./dist/cjs/main.cjs": "./dist/esm/main.mjs"
+  },
   "files": [
     "dist",
     "src"

--- a/packages/web5-agent/package.json
+++ b/packages/web5-agent/package.json
@@ -61,6 +61,11 @@
     "./dist/cjs/main.cjs": "./dist/browser.js",
     "types": "./dist/types/main.d.ts"
   },
+  "react-native": {
+    "./dist/esm/main.mjs": "./dist/esm/main.mjs",
+    "./dist/cjs/main.cjs": "./dist/esm/main.mjs",
+    "types": "./dist/types/main.d.ts"
+  },
   "keywords": [
     "decentralized",
     "decentralized-applications",

--- a/packages/web5-proxy-agent/package.json
+++ b/packages/web5-proxy-agent/package.json
@@ -61,6 +61,11 @@
     "./dist/cjs/main.cjs": "./dist/browser.js",
     "types": "./dist/types/main.d.ts"
   },
+  "react-native": {
+    "./dist/esm/main.mjs": "./dist/esm/main.mjs",
+    "./dist/cjs/main.cjs": "./dist/esm/main.mjs",
+    "types": "./dist/types/main.d.ts"
+  },
   "keywords": [
     "decentralized",
     "decentralized-applications",

--- a/packages/web5-user-agent/package.json
+++ b/packages/web5-user-agent/package.json
@@ -61,6 +61,11 @@
     "./dist/cjs/main.cjs": "./dist/browser.js",
     "types": "./dist/types/main.d.ts"
   },
+  "react-native": {
+    "./dist/esm/main.mjs": "./dist/esm/main.mjs",
+    "./dist/cjs/main.cjs": "./dist/esm/main.mjs",
+    "types": "./dist/types/main.d.ts"
+  },
   "keywords": [
     "decentralized",
     "decentralized-applications",

--- a/packages/web5/package.json
+++ b/packages/web5/package.json
@@ -61,6 +61,11 @@
     "./dist/cjs/main.cjs": "./dist/browser.js",
     "types": "./dist/types/main.d.ts"
   },
+  "react-native": {
+    "./dist/esm/main.mjs": "./dist/esm/main.mjs",
+    "./dist/cjs/main.cjs": "./dist/esm/main.mjs",
+    "types": "./dist/types/main.d.ts"
+  },
   "keywords": [
     "decentralized",
     "decentralized-applications",


### PR DESCRIPTION
In React Native, the directive priority order goes:
`react-native > browser > main`

The `react-native` directive was previously not present, so it would instead use the values from the `browser` directive. This caused react native to consume `./dist/browser.js`, which causes issues in that environment. This required workarounds in react native apps that consume it.

To fix, this PR directly sets values for `./dist/esm/src/index.js` and `./dist/cjs/src/index.js` to always point to the esm version.