### PR TITLE
Add delete functionality to ProfileAPI

### DIFF
--- a/packages/web5-agent/src/query-store.ts
+++ b/packages/web5-agent/src/query-store.ts
@@ -3,7 +3,8 @@ export interface QueryStore<T> {
   get(id: string): Promise<T | undefined>;
   all(): Promise<T[]>;
   query(filter: Filter): Promise<T[]>;
-  delete(): Promise<void>;
+  delete(id: string): Promise<void>;
+  deleteAll(): Promise<void>;
 }
 
 

--- a/packages/web5-user-agent/src/profile-api.ts
+++ b/packages/web5-user-agent/src/profile-api.ts
@@ -41,4 +41,8 @@ export class ProfileApi implements ProfileManager {
   listProfiles(): Promise<Profile[]> {
     return this.store.all();
   }
+
+  deleteProfile(id: string): Promise<void> {
+    return this.store.delete(id);
+  }
 }

--- a/packages/web5-user-agent/src/profile-manager.ts
+++ b/packages/web5-user-agent/src/profile-manager.ts
@@ -4,6 +4,7 @@ export interface ProfileManager {
   createProfile(options: CreateProfileOptions): Promise<Profile>
   getProfile(id: string): Promise<Profile | undefined>
   listProfiles(): Promise<Profile[]>;
+  deleteProfile(id: string): Promise<void>;
 }
 
 export type Profile = {

--- a/packages/web5-user-agent/src/profile-store.ts
+++ b/packages/web5-user-agent/src/profile-store.ts
@@ -71,7 +71,12 @@ export class ProfileStore implements QueryStore<Profile> {
     return profiles;
   }
 
-  async delete(): Promise<void> {
+  async delete(id: string): Promise<void> {
+    const key = this.generateKey(id);
+    return this.db.del(key);
+  }
+
+  async deleteAll(): Promise<void> {
     throw new Error('Method not implemented.');
   }
 

--- a/packages/web5-user-agent/tests/common/profile-api.spec.ts
+++ b/packages/web5-user-agent/tests/common/profile-api.spec.ts
@@ -1,0 +1,33 @@
+import { expect } from 'chai';
+import { ProfileApi } from '../../src/profile-api.js';
+import { DidKeyApi } from '@tbd54566975/dids';
+
+let profileApi: ProfileApi;
+
+describe('ProfileApi', () => {
+  before(() => {
+    profileApi = new ProfileApi();
+  });
+
+  describe('deleteProfile', () => {
+    it('deletes profile if it exists', async () => {
+      const didKey = new DidKeyApi();
+      const didState = await didKey.create();
+
+      const profile = await profileApi.createProfile({
+        name : didState.id,
+        did  : didState,
+      });
+      expect(await profileApi.getProfile(profile.id)).to.exist;
+
+      await profileApi.deleteProfile(profile.id);
+      expect(await profileApi.getProfile(profile.id)).to.not.exist;
+    });
+
+    it('does not error when asked to delete profile that doesn\'t exist', async() => {
+      const profileId = '123';
+      expect(await profileApi.getProfile(profileId)).to.not.exist;
+      expect(await profileApi.deleteProfile(profileId)).to.not.throw;
+    });
+  });
+});


### PR DESCRIPTION
The `ProfileApi`, which implements the `ProfileManager` interface, currently has the ability to:
* Create a Profile
* Get a specific Profile
* List all Profiles

There currently isn't a way to delete a profile. The various agents (desktop & mobile) will allow users full management over their profiles, including the option to delete them.

This PR adds in this delete functionality, and adds a test around the functionality to make sure it works as expected. 