### PR TITLE
Resolve Issue #133 by removing tests from crypto and proxy-agent tsconfig

### DIFF
--- a/packages/crypto/tsconfig.json
+++ b/packages/crypto/tsconfig.json
@@ -18,8 +18,7 @@
     "esModuleInterop": true
   },
   "include": [
-    "src",
-    "tests" // building tests also so we can run tests directly without the need for ts-node, ts-mocha
+    "src"
   ],
   "exclude": [
     "node_modules",

--- a/packages/crypto/tsconfig.test.json
+++ b/packages/crypto/tsconfig.test.json
@@ -20,8 +20,7 @@
   },
   "include": [
     "src",
-    "tests",
-    "typings"
+    "tests"
   ],
   "exclude": [
     "node_modules",

--- a/packages/web5-proxy-agent/tsconfig.json
+++ b/packages/web5-proxy-agent/tsconfig.json
@@ -19,8 +19,7 @@
     "esModuleInterop": true
   },
   "include": [
-    "src",
-    "tests" // building tests also so we can run tests directly without the need for ts-node, ts-mocha
+    "src"
   ],
   "exclude": [
     "node_modules",


### PR DESCRIPTION
Discovered today that the root cause of Issue #133 is that two of the Web5.js packages differ from the others in terms of the directives in `tsconfig.json`.  The crypto and web5-proxy-agent packages have the tests directory under include:
```json
  "include": [
    "src",
    "tests" // building tests also so we can run tests directly without the need for ts-node, ts-mocha
  ],
```

which results in the `dist/types` directory having sub-directories for `src` and `tests`:
![image](https://github.com/TBD54566975/web5-js/assets/134693/dd3c4fe7-4cde-4459-9548-66da08a94172)

instead of the type declarations being directly under `types`:
![image](https://github.com/TBD54566975/web5-js/assets/134693/dec1fe55-4749-41e4-a7d1-cd42d994dd47)

which then breaks the path in package.json for `types`:
![image](https://github.com/TBD54566975/web5-js/assets/134693/3f506ebe-421e-4a40-b35e-04fdd2cd8cba)

since the path is actually `./dist/types/src/main.d.ts`.

This PR removes `tests` from being included in the `tsconfig.json` configuration and also removes an errant `typings` exclusion in the `crypto` package since that is only needed in the `dids` package.