### PR TITLE
Update to DWN SDK 0.0.37 and prepare for release 0.7.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,11 +52,11 @@ npm install @tbd54566975/web5
 _CDNs_
 
 ```yaml
-https://unpkg.com/@tbd54566975/web5@0.7.10/dist/browser.js
+https://unpkg.com/@tbd54566975/web5@0.7.11/dist/browser.js
 ```
 
 ```yaml
-https://cdn.jsdelivr.net/npm/@tbd54566975/web5@0.7.10/dist/browser.mjs
+https://cdn.jsdelivr.net/npm/@tbd54566975/web5@0.7.11/dist/browser.mjs
 ```
 
 ## Usage

--- a/package-lock.json
+++ b/package-lock.json
@@ -760,6 +760,17 @@
                 "npm": ">=7.0.0"
             }
         },
+        "node_modules/@noble/curves": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.1.0.tgz",
+            "integrity": "sha512-091oBExgENk/kGj3AZmtBDMpxQPDtxQABR2B9lb1JbVTs6ytdzZNwvhxQ4MWasRNEzlbEH8jCWFCwhF/Obj5AA==",
+            "dependencies": {
+                "@noble/hashes": "1.3.1"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            }
+        },
         "node_modules/@noble/ed25519": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-2.0.0.tgz",
@@ -770,6 +781,17 @@
                     "url": "https://paulmillr.com/funding/"
                 }
             ]
+        },
+        "node_modules/@noble/hashes": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.1.tgz",
+            "integrity": "sha512-EbqwksQwz9xDRGfDST86whPBgM65E0OH/pCgqW0GBVzO22bNE+NuIbeTb714+IfSjU3aRk47EUvXIb5bTsenKA==",
+            "engines": {
+                "node": ">= 16"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            }
         },
         "node_modules/@noble/secp256k1": {
             "version": "2.0.0",
@@ -957,9 +979,9 @@
             "link": true
         },
         "node_modules/@tbd54566975/dwn-sdk-js": {
-            "version": "0.0.36",
-            "resolved": "https://registry.npmjs.org/@tbd54566975/dwn-sdk-js/-/dwn-sdk-js-0.0.36.tgz",
-            "integrity": "sha512-Jj679thwBTVzEn1NJx3CQWeff9x4v2j27lwilKW6S4SeLF7GYQAEYvGWLdE7hpNS2tRrBPcQxleZReopyEkWLg==",
+            "version": "0.0.37",
+            "resolved": "https://registry.npmjs.org/@tbd54566975/dwn-sdk-js/-/dwn-sdk-js-0.0.37.tgz",
+            "integrity": "sha512-E2Wt+1KpNOQ8lx0sWWx+UmW59hDpd4HrqzPwFwXcWA4AGCREoCl6pNSA6u66fqlDKqvwMxFbs/dku1uy0p5VqQ==",
             "dependencies": {
                 "@ipld/dag-cbor": "9.0.3",
                 "@js-temporal/polyfill": "0.4.4",
@@ -969,7 +991,7 @@
                 "ajv": "8.12.0",
                 "blockstore-core": "4.2.0",
                 "cross-fetch": "3.1.6",
-                "eccrypto": "1.1.6",
+                "eciesjs": "0.4.0",
                 "flat": "5.0.2",
                 "interface-blockstore": "5.2.3",
                 "interface-store": "5.1.2",
@@ -1589,6 +1611,8 @@
             "version": "7.1.1",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
             "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==",
+            "dev": true,
+            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -1768,24 +1792,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/bindings": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-            "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-            "optional": true,
-            "dependencies": {
-                "file-uri-to-path": "1.0.0"
-            }
-        },
-        "node_modules/bip66": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz",
-            "integrity": "sha512-nemMHz95EmS38a26XbbdxIYj5csHd3RMP3H5bwQknX0WYHF01qhpufP42mLOwVICuH2JmhIhXiWs89MfUGL7Xw==",
-            "optional": true,
-            "dependencies": {
-                "safe-buffer": "^5.0.1"
-            }
-        },
         "node_modules/bl": {
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/bl/-/bl-5.1.0.tgz",
@@ -1925,7 +1931,7 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
             "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
-            "devOptional": true,
+            "dev": true,
             "dependencies": {
                 "buffer-xor": "^1.0.3",
                 "cipher-base": "^1.0.0",
@@ -2107,7 +2113,7 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
             "integrity": "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ==",
-            "devOptional": true
+            "dev": true
         },
         "node_modules/builtin-status-codes": {
             "version": "3.0.0",
@@ -2362,7 +2368,7 @@
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
             "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
-            "devOptional": true,
+            "dev": true,
             "dependencies": {
                 "inherits": "^2.0.1",
                 "safe-buffer": "^5.0.1"
@@ -2519,7 +2525,7 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
             "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
-            "devOptional": true,
+            "dev": true,
             "dependencies": {
                 "cipher-base": "^1.0.1",
                 "inherits": "^2.0.1",
@@ -2532,7 +2538,7 @@
             "version": "1.1.7",
             "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
             "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
-            "devOptional": true,
+            "dev": true,
             "dependencies": {
                 "cipher-base": "^1.0.3",
                 "create-hash": "^1.1.0",
@@ -2776,53 +2782,12 @@
                 "url": "https://bevry.me/fund"
             }
         },
-        "node_modules/drbg.js": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/drbg.js/-/drbg.js-1.0.1.tgz",
-            "integrity": "sha512-F4wZ06PvqxYLFEZKkFxTDcns9oFNk34hvmJSEwdzsxVQ8YI5YaxtACgQatkYgv2VI2CFkUd2Y+xosPQnHv809g==",
-            "optional": true,
+        "node_modules/eciesjs": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/eciesjs/-/eciesjs-0.4.0.tgz",
+            "integrity": "sha512-z4dEeaH16xxYVgtxJ8YVwpifH4Keg4gyp5F451mnDNwbAN3MgL5jcoEQGpqJrapv/zW8KwDnXG21Dw5B0hqvmw==",
             "dependencies": {
-                "browserify-aes": "^1.0.6",
-                "create-hash": "^1.1.2",
-                "create-hmac": "^1.1.4"
-            },
-            "engines": {
-                "node": ">=0.10"
-            }
-        },
-        "node_modules/eccrypto": {
-            "version": "1.1.6",
-            "resolved": "https://registry.npmjs.org/eccrypto/-/eccrypto-1.1.6.tgz",
-            "integrity": "sha512-d78ivVEzu7Tn0ZphUUaL43+jVPKTMPFGtmgtz1D0LrFn7cY3K8CdrvibuLz2AAkHBLKZtR8DMbB2ukRYFk987A==",
-            "hasInstallScript": true,
-            "dependencies": {
-                "acorn": "7.1.1",
-                "elliptic": "6.5.4",
-                "es6-promise": "4.2.8",
-                "nan": "2.14.0"
-            },
-            "optionalDependencies": {
-                "secp256k1": "3.7.1"
-            }
-        },
-        "node_modules/eccrypto/node_modules/secp256k1": {
-            "version": "3.7.1",
-            "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.7.1.tgz",
-            "integrity": "sha512-1cf8sbnRreXrQFdH6qsg2H71Xw91fCCS9Yp021GnUNJzWJS/py96fS4lHbnTnouLp08Xj6jBoBB6V78Tdbdu5g==",
-            "hasInstallScript": true,
-            "optional": true,
-            "dependencies": {
-                "bindings": "^1.5.0",
-                "bip66": "^1.1.5",
-                "bn.js": "^4.11.8",
-                "create-hash": "^1.2.0",
-                "drbg.js": "^1.0.1",
-                "elliptic": "^6.4.1",
-                "nan": "^2.14.0",
-                "safe-buffer": "^5.1.2"
-            },
-            "engines": {
-                "node": ">=4.0.0"
+                "@noble/curves": "^1.1.0"
             }
         },
         "node_modules/ed2curve": {
@@ -2942,11 +2907,6 @@
             "resolved": "https://registry.npmjs.org/es6-object-assign/-/es6-object-assign-1.1.0.tgz",
             "integrity": "sha512-MEl9uirslVwqQU369iHNWZXsI8yaZYGg/D65aOgZkeyFJwHYSxilf7rQzXKI7DdDuBPrBXbfk3sl9hJhmd5AUw==",
             "dev": true
-        },
-        "node_modules/es6-promise": {
-            "version": "4.2.8",
-            "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-            "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
         },
         "node_modules/esbuild": {
             "version": "0.16.17",
@@ -3298,7 +3258,7 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
             "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
-            "devOptional": true,
+            "dev": true,
             "dependencies": {
                 "md5.js": "^1.3.4",
                 "safe-buffer": "^5.1.1"
@@ -3375,12 +3335,6 @@
             "engines": {
                 "node": "^10.12.0 || >=12.0.0"
             }
-        },
-        "node_modules/file-uri-to-path": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-            "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-            "optional": true
         },
         "node_modules/fill-range": {
             "version": "7.0.1",
@@ -3798,7 +3752,7 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz",
             "integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
-            "devOptional": true,
+            "dev": true,
             "dependencies": {
                 "inherits": "^2.0.4",
                 "readable-stream": "^3.6.0",
@@ -3812,7 +3766,7 @@
             "version": "3.6.2",
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
             "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-            "devOptional": true,
+            "dev": true,
             "dependencies": {
                 "inherits": "^2.0.3",
                 "string_decoder": "^1.1.1",
@@ -3826,7 +3780,7 @@
             "version": "5.2.1",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
             "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-            "devOptional": true,
+            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -5092,7 +5046,7 @@
             "version": "1.3.5",
             "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
             "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
-            "devOptional": true,
+            "dev": true,
             "dependencies": {
                 "hash-base": "^3.0.0",
                 "inherits": "^2.0.1",
@@ -5441,11 +5395,6 @@
             "engines": {
                 "node": ">=8.0.0"
             }
-        },
-        "node_modules/nan": {
-            "version": "2.14.0",
-            "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-            "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
         },
         "node_modules/nanoid": {
             "version": "3.3.3",
@@ -6408,7 +6357,7 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
             "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
-            "devOptional": true,
+            "dev": true,
             "dependencies": {
                 "hash-base": "^3.0.0",
                 "inherits": "^2.0.1"
@@ -6587,7 +6536,7 @@
             "version": "2.4.11",
             "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
             "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
-            "devOptional": true,
+            "dev": true,
             "dependencies": {
                 "inherits": "^2.0.1",
                 "safe-buffer": "^5.0.1"
@@ -7748,7 +7697,7 @@
         },
         "packages/crypto": {
             "name": "@tbd54566975/crypto",
-            "version": "0.1.5",
+            "version": "0.1.6",
             "license": "Apache-2.0",
             "dependencies": {
                 "ed2curve": "0.3.0",
@@ -7791,13 +7740,13 @@
         },
         "packages/dids": {
             "name": "@tbd54566975/dids",
-            "version": "0.1.8",
+            "version": "0.1.9",
             "license": "Apache-2.0",
             "dependencies": {
                 "@decentralized-identity/ion-tools": "1.1.1",
                 "@tbd54566975/common": "0.1.1",
-                "@tbd54566975/crypto": "0.1.5",
-                "@tbd54566975/dwn-sdk-js": "0.0.36",
+                "@tbd54566975/crypto": "0.1.6",
+                "@tbd54566975/dwn-sdk-js": "0.0.37",
                 "cross-fetch": "3.1.5"
             },
             "devDependencies": {
@@ -7836,16 +7785,16 @@
         },
         "packages/web5": {
             "name": "@tbd54566975/web5",
-            "version": "0.7.10",
+            "version": "0.7.11",
             "license": "Apache-2.0",
             "dependencies": {
                 "@decentralized-identity/ion-tools": "1.1.1",
-                "@tbd54566975/crypto": "0.1.5",
-                "@tbd54566975/dids": "0.1.8",
-                "@tbd54566975/dwn-sdk-js": "0.0.36",
-                "@tbd54566975/web5-agent": "0.1.6",
-                "@tbd54566975/web5-proxy-agent": "0.1.6",
-                "@tbd54566975/web5-user-agent": "0.1.9",
+                "@tbd54566975/crypto": "0.1.6",
+                "@tbd54566975/dids": "0.1.9",
+                "@tbd54566975/dwn-sdk-js": "0.0.37",
+                "@tbd54566975/web5-agent": "0.1.7",
+                "@tbd54566975/web5-proxy-agent": "0.1.7",
+                "@tbd54566975/web5-user-agent": "0.1.10",
                 "level": "8.0.0",
                 "ms": "2.1.3",
                 "readable-web-to-node-stream": "3.0.2"
@@ -7888,10 +7837,10 @@
         },
         "packages/web5-agent": {
             "name": "@tbd54566975/web5-agent",
-            "version": "0.1.6",
+            "version": "0.1.7",
             "license": "Apache-2.0",
             "dependencies": {
-                "@tbd54566975/dwn-sdk-js": "0.0.36",
+                "@tbd54566975/dwn-sdk-js": "0.0.37",
                 "readable-stream": "4.4.0"
             },
             "devDependencies": {
@@ -7900,6 +7849,7 @@
                 "@types/chai-as-promised": "7.1.5",
                 "@types/eslint": "8.37.0",
                 "@types/mocha": "10.0.1",
+                "@types/readable-stream": "2.3.15",
                 "@types/sinon": "10.0.15",
                 "@typescript-eslint/eslint-plugin": "5.59.0",
                 "@typescript-eslint/parser": "5.59.0",
@@ -7930,10 +7880,10 @@
         },
         "packages/web5-proxy-agent": {
             "name": "@tbd54566975/web5-proxy-agent",
-            "version": "0.1.6",
+            "version": "0.1.7",
             "license": "Apache-2.0",
             "dependencies": {
-                "@tbd54566975/web5-agent": "0.1.6"
+                "@tbd54566975/web5-agent": "0.1.7"
             },
             "devDependencies": {
                 "@playwright/test": "1.34.3",
@@ -7972,13 +7922,13 @@
         },
         "packages/web5-user-agent": {
             "name": "@tbd54566975/web5-user-agent",
-            "version": "0.1.9",
+            "version": "0.1.10",
             "license": "Apache-2.0",
             "dependencies": {
                 "@decentralized-identity/ion-tools": "1.1.1",
-                "@tbd54566975/dids": "0.1.8",
-                "@tbd54566975/dwn-sdk-js": "0.0.36",
-                "@tbd54566975/web5-agent": "0.1.6",
+                "@tbd54566975/dids": "0.1.9",
+                "@tbd54566975/dwn-sdk-js": "0.0.37",
+                "@tbd54566975/web5-agent": "0.1.7",
                 "abstract-level": "1.0.3",
                 "cross-fetch": "3.1.5",
                 "flat": "5.0.2",

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tbd54566975/crypto",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "TBD crypto library",
   "type": "module",
   "main": "./dist/cjs/main.cjs",

--- a/packages/crypto/src/utils.ts
+++ b/packages/crypto/src/utils.ts
@@ -27,7 +27,7 @@ export function base64UrlToBytes(base64urlString: string): Uint8Array {
 export function bytesToBase58btcMultibase(header: Uint8Array, bytes: Uint8Array): string {
   const multibaseBytes = new Uint8Array(header.length + bytes.length);
   multibaseBytes.set(header);
-  multibaseBytes.set(bytes);
+  multibaseBytes.set(bytes, header.length);
 
   return base58btc.encode(multibaseBytes);
 }

--- a/packages/crypto/tests/needed.spec.ts
+++ b/packages/crypto/tests/needed.spec.ts
@@ -1,7 +1,0 @@
-import { expect } from 'chai';
-
-describe('@tbd54566975/crypto', () => {
-  it('should have tests', () => {
-    expect(true).to.equal(true);
-  });
-});

--- a/packages/crypto/tests/utils.spec.ts
+++ b/packages/crypto/tests/utils.spec.ts
@@ -1,0 +1,32 @@
+import { expect } from 'chai';
+
+import { bytesToBase58btcMultibase } from '../src/utils.js';
+
+describe('Crypto Utils', () => {
+  describe('bytesToBase58btcMultibase()', () => {
+    it('returns a multibase encoded string', () => {
+    // Test Vector 1.
+      const input = {
+        header : new Uint8Array([0x00, 0x00]),
+        data   : new Uint8Array([0x00, 0x00])
+      };
+      const output = 'z1111';
+      const encoded = bytesToBase58btcMultibase(input.header, input.data);
+      expect(encoded).to.be.a.string;
+      expect(encoded.substring(0, 1)).to.equal('z');
+      expect(encoded).to.deep.equal(output);
+    });
+
+    it('returns multibase encoded value with specified header', () => {
+    // Test Vector 1.
+      const input = {
+        header : new Uint8Array([0x01, 0x02]),
+        data   : new Uint8Array([3, 4, 5, 6, 7])
+      };
+      const output = 'z3DUyZY2dc';
+
+      const encoded = bytesToBase58btcMultibase(input.header, input.data);
+      expect(encoded).to.deep.equal(output);
+    });
+  });
+});

--- a/packages/dids/package.json
+++ b/packages/dids/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tbd54566975/dids",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "TBD DIDs library",
   "type": "module",
   "main": "./dist/cjs/main.cjs",
@@ -85,8 +85,8 @@
   "dependencies": {
     "@decentralized-identity/ion-tools": "1.1.1",
     "@tbd54566975/common": "0.1.1",
-    "@tbd54566975/crypto": "0.1.5",
-    "@tbd54566975/dwn-sdk-js": "0.0.36",
+    "@tbd54566975/crypto": "0.1.6",
+    "@tbd54566975/dwn-sdk-js": "0.0.37",
     "cross-fetch": "3.1.5"
   },
   "devDependencies": {

--- a/packages/web5-agent/package.json
+++ b/packages/web5-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tbd54566975/web5-agent",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Web5 Agent",
   "type": "module",
   "main": "./dist/cjs/main.cjs",
@@ -81,7 +81,7 @@
   },
   "dependencies": {
     "readable-stream": "4.4.0",
-    "@tbd54566975/dwn-sdk-js": "0.0.36"
+    "@tbd54566975/dwn-sdk-js": "0.0.37"
   },
   "devDependencies": {
     "@playwright/test": "1.34.3",
@@ -89,6 +89,7 @@
     "@types/chai-as-promised": "7.1.5",
     "@types/eslint": "8.37.0",
     "@types/mocha": "10.0.1",
+    "@types/readable-stream": "2.3.15",
     "@types/sinon": "10.0.15",
     "@typescript-eslint/eslint-plugin": "5.59.0",
     "@typescript-eslint/parser": "5.59.0",

--- a/packages/web5-agent/src/web5-agent.ts
+++ b/packages/web5-agent/src/web5-agent.ts
@@ -1,14 +1,14 @@
 import type { Readable } from 'readable-stream';
 
 import {
-  MessageReply,
+  EventsGetMessage,
+  UnionMessageReply,
+  MessagesGetMessage,
   RecordsQueryMessage,
+  RecordsWriteMessage,
+  RecordsDeleteMessage,
   ProtocolsQueryMessage,
   ProtocolsConfigureMessage,
-  EventsGetMessage,
-  MessagesGetMessage,
-  RecordsWriteMessage,
-  RecordsDeleteMessage
 } from '@tbd54566975/dwn-sdk-js';
 
 export interface Web5Agent {
@@ -51,7 +51,7 @@ export type SendDwnRequest = DwnRequest & (ProcessDwnRequest | { messageCid: str
 export type DwnResponse = {
   message?: unknown;
   messageCid?: string;
-  reply: MessageReply;
+  reply: UnionMessageReply;
 };
 
 
@@ -97,4 +97,4 @@ export type DwnRpcRequest = {
 /**
  * TODO: add jsdoc
  */
-export type DwnRpcResponse = MessageReply;
+export type DwnRpcResponse = UnionMessageReply;

--- a/packages/web5-proxy-agent/package.json
+++ b/packages/web5-proxy-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tbd54566975/web5-proxy-agent",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Web5 Proxy Agent",
   "type": "module",
   "main": "./dist/cjs/main.cjs",
@@ -80,7 +80,7 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
-    "@tbd54566975/web5-agent": "0.1.6"
+    "@tbd54566975/web5-agent": "0.1.7"
   },
   "devDependencies": {
     "@playwright/test": "1.34.3",

--- a/packages/web5-user-agent/package.json
+++ b/packages/web5-user-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tbd54566975/web5-user-agent",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "Web5 User Agent",
   "type": "module",
   "main": "./dist/cjs/main.cjs",
@@ -81,9 +81,9 @@
   },
   "dependencies": {
     "@decentralized-identity/ion-tools": "1.1.1",
-    "@tbd54566975/dids": "0.1.8",
-    "@tbd54566975/dwn-sdk-js": "0.0.36",
-    "@tbd54566975/web5-agent": "0.1.6",
+    "@tbd54566975/dids": "0.1.9",
+    "@tbd54566975/dwn-sdk-js": "0.0.37",
+    "@tbd54566975/web5-agent": "0.1.7",
     "abstract-level": "1.0.3",
     "cross-fetch": "3.1.5",
     "flat": "5.0.2",

--- a/packages/web5-user-agent/src/web5-user-agent.ts
+++ b/packages/web5-user-agent/src/web5-user-agent.ts
@@ -1,29 +1,29 @@
 import type { DwnServiceEndpoint } from '@tbd54566975/dids';
 import {
-  SignatureInput,
-  RecordsWriteOptions,
-  RecordsWriteMessage,
-  PrivateJwk as DwnPrivateKeyJwk,
-  MessagesGetReply,
   DataStream,
+  SignatureInput,
+  MessagesGetReply,
   RecordsReadReply,
-  MessageReply,
+  UnionMessageReply,
+  RecordsWriteMessage,
+  RecordsWriteOptions,
+  PrivateJwk as DwnPrivateKeyJwk,
 } from '@tbd54566975/dwn-sdk-js';
 
 import { Readable } from 'readable-stream';
 import {
   DwnRpc,
   Web5Agent,
-  DwnRpcRequest,
-  ProcessDwnRequest,
   DwnResponse,
+  DwnRpcRequest,
   SendDwnRequest,
+  ProcessDwnRequest,
 } from '@tbd54566975/web5-agent';
 
 import {
   Cid,
   Encoder,
-  Message
+  Message,
 } from '@tbd54566975/dwn-sdk-js';
 
 import type { SyncManager } from './sync-manager.js';
@@ -111,7 +111,7 @@ export class Web5UserAgent implements Web5Agent {
   async processDwnRequest(request: ProcessDwnRequest): Promise<DwnResponse> {
     const { message, dataStream }= await this.#constructDwnMessage(request);
 
-    let reply: MessageReply;
+    let reply: UnionMessageReply;
     if (request.store !== false) {
       reply = await this.dwn.processMessage(request.target, message, dataStream as any);
     } else {

--- a/packages/web5/README.md
+++ b/packages/web5/README.md
@@ -52,11 +52,11 @@ npm install @tbd54566975/web5
 _CDNs_
 
 ```yaml
-https://unpkg.com/@tbd54566975/web5@0.7.10/dist/browser.js
+https://unpkg.com/@tbd54566975/web5@0.7.11/dist/browser.js
 ```
 
 ```yaml
-https://cdn.jsdelivr.net/npm/@tbd54566975/web5@0.7.10/dist/browser.mjs
+https://cdn.jsdelivr.net/npm/@tbd54566975/web5@0.7.11/dist/browser.mjs
 ```
 
 ## Usage

--- a/packages/web5/package.json
+++ b/packages/web5/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tbd54566975/web5",
-  "version": "0.7.10",
+  "version": "0.7.11",
   "description": "SDK for accessing the features and capabilities of Web5",
   "type": "module",
   "main": "./dist/cjs/main.cjs",
@@ -85,12 +85,12 @@
   },
   "dependencies": {
     "@decentralized-identity/ion-tools": "1.1.1",
-    "@tbd54566975/crypto": "0.1.5",
-    "@tbd54566975/dids": "0.1.8",
-    "@tbd54566975/dwn-sdk-js": "0.0.36",
-    "@tbd54566975/web5-agent": "0.1.6",
-    "@tbd54566975/web5-proxy-agent": "0.1.6",
-    "@tbd54566975/web5-user-agent": "0.1.9",
+    "@tbd54566975/crypto": "0.1.6",
+    "@tbd54566975/dids": "0.1.9",
+    "@tbd54566975/dwn-sdk-js": "0.0.37",
+    "@tbd54566975/web5-agent": "0.1.7",
+    "@tbd54566975/web5-proxy-agent": "0.1.7",
+    "@tbd54566975/web5-user-agent": "0.1.10",
     "level": "8.0.0",
     "ms": "2.1.3",
     "readable-web-to-node-stream": "3.0.2"

--- a/packages/web5/src/dwn-api.ts
+++ b/packages/web5/src/dwn-api.ts
@@ -1,16 +1,16 @@
 import type { Web5Agent } from '@tbd54566975/web5-agent';
 import type {
-  MessageReply,
-  ProtocolsConfigureDescriptor,
-  ProtocolsConfigureOptions,
-  ProtocolsQueryOptions,
-  RecordsDeleteOptions,
-  RecordsQueryOptions,
-  RecordsQueryReplyEntry,
+  UnionMessageReply,
   RecordsReadOptions,
+  RecordsQueryOptions,
   RecordsWriteMessage,
   RecordsWriteOptions,
-  ProtocolsConfigureMessage
+  RecordsDeleteOptions,
+  ProtocolsQueryOptions,
+  RecordsQueryReplyEntry,
+  ProtocolsConfigureMessage,
+  ProtocolsConfigureOptions,
+  ProtocolsConfigureDescriptor,
 } from '@tbd54566975/dwn-sdk-js';
 
 import { DwnInterfaceName, DwnMethodName } from '@tbd54566975/dwn-sdk-js';
@@ -24,7 +24,7 @@ export type ProtocolsConfigureRequest = {
 }
 
 export type ProtocolsConfigureResponse = {
-  status: MessageReply['status'];
+  status: UnionMessageReply['status'];
   protocol?: Protocol;
 }
 
@@ -39,7 +39,7 @@ export type ProtocolsQueryRequest = {
 
 export type ProtocolsQueryResponse = {
   protocols: Protocol[];
-  status: MessageReply['status'];
+  status: UnionMessageReply['status'];
 }
 
 export type RecordsCreateRequest = RecordsWriteRequest;
@@ -59,7 +59,7 @@ export type RecordsDeleteRequest = {
 }
 
 export type RecordsDeleteResponse = {
-  status: MessageReply['status'];
+  status: UnionMessageReply['status'];
 };
 
 export type RecordsQueryRequest = {
@@ -69,7 +69,7 @@ export type RecordsQueryRequest = {
 }
 
 export type RecordsQueryResponse = {
-  status: MessageReply['status'];
+  status: UnionMessageReply['status'];
   records?: Record[]
 };
 
@@ -80,7 +80,7 @@ export type RecordsReadRequest = {
 }
 
 export type RecordsReadResponse = {
-  status: MessageReply['status'];
+  status: UnionMessageReply['status'];
   record: Record;
 };
 
@@ -91,7 +91,7 @@ export type RecordsWriteRequest = {
 }
 
 export type RecordsWriteResponse = {
-  status: MessageReply['status'];
+  status: UnionMessageReply['status'];
   record?: Record
 };
 


### PR DESCRIPTION
This PR will:
- Fix a bug in the bytesToBase58btcMultibase() function and add tests.
- Replace `MessageReply` type with `UnionMessageReply` to reflect changes in DWN SDK.
- Add missing `@types/readable-stream` to `web5-agent`.
- Bump versions of all modified Web5.js packages.