### PR TITLE
Fix for CVE-2023-36665

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -94,11 +94,11 @@
             }
         },
         "node_modules/@decentralized-identity/ion-tools/node_modules/cross-fetch": {
-            "version": "3.1.6",
-            "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.6.tgz",
-            "integrity": "sha512-riRvo06crlE8HiqOwIpQhxwdOk4fOeR7FVM/wXoxchFEqMNUjvbs3bfo4OTgMEMHzppd4DxFBDbyySj8Cv781g==",
+            "version": "3.1.8",
+            "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.8.tgz",
+            "integrity": "sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==",
             "dependencies": {
-                "node-fetch": "^2.6.11"
+                "node-fetch": "^2.6.12"
             }
         },
         "node_modules/@decentralized-identity/ion-tools/node_modules/multiformats": {
@@ -111,9 +111,9 @@
             }
         },
         "node_modules/@decentralized-identity/ion-tools/node_modules/node-fetch": {
-            "version": "2.6.11",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.11.tgz",
-            "integrity": "sha512-4I6pdBY1EthSqDmJkiNk3JIT8cswwR9nfeW/cPdUagJYEQG7R95WRH74wpz7ma8Gh/9dI9FP+OU+0E4FvtA55w==",
+            "version": "2.6.12",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.12.tgz",
+            "integrity": "sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==",
             "dependencies": {
                 "whatwg-url": "^5.0.0"
             },
@@ -506,14 +506,14 @@
             }
         },
         "node_modules/@eslint/eslintrc": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.0.3.tgz",
-            "integrity": "sha512-+5gy6OQfk+xx3q0d6jGZZC3f3KzAkXc/IanVxd1is/VIIziRqqt3ongQz0FiTUXqTk0c7aDB3OaFuKnuSoJicQ==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.0.tgz",
+            "integrity": "sha512-Lj7DECXqIVCqnqjjHMPna4vn6GJcMgul/wuS0je9OZ9gsL0zzDpKPVtcG1HaDVc+9y+qgXneTeUMbCqXJNpH1A==",
             "dev": true,
             "dependencies": {
                 "ajv": "^6.12.4",
                 "debug": "^4.3.2",
-                "espree": "^9.5.2",
+                "espree": "^9.6.0",
                 "globals": "^13.19.0",
                 "ignore": "^5.2.0",
                 "import-fresh": "^3.2.1",
@@ -695,9 +695,9 @@
             }
         },
         "node_modules/@jridgewell/source-map": {
-            "version": "0.3.3",
-            "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.3.tgz",
-            "integrity": "sha512-b+fsZXeLYi9fEULmfBrhxn4IrPlINf8fiNarzTof004v3lFdntdwa9PF7vFJqm3mg7s+ScJMxXaE3Acp1irZcg==",
+            "version": "0.3.5",
+            "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.5.tgz",
+            "integrity": "sha512-UTYAUj/wviwdsMfzoSJspJxbkH5o1snzwX0//0ENX1u/55kkZZkcTZP6u9bwKGkv+dkk9at4m1Cpt0uY80kcpQ==",
             "dev": true,
             "peer": true,
             "dependencies": {
@@ -1023,9 +1023,9 @@
             }
         },
         "node_modules/@tbd54566975/dwn-sdk-js/node_modules/node-fetch": {
-            "version": "2.6.11",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.11.tgz",
-            "integrity": "sha512-4I6pdBY1EthSqDmJkiNk3JIT8cswwR9nfeW/cPdUagJYEQG7R95WRH74wpz7ma8Gh/9dI9FP+OU+0E4FvtA55w==",
+            "version": "2.6.12",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.12.tgz",
+            "integrity": "sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==",
             "dependencies": {
                 "whatwg-url": "^5.0.0"
             },
@@ -1162,9 +1162,9 @@
             "dev": true
         },
         "node_modules/@types/node": {
-            "version": "20.3.1",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.3.1.tgz",
-            "integrity": "sha512-EhcH/wvidPy1WeML3TtYFGR83UzjxeWRen9V402T8aUGYsCHOmfoisV3ZSg03gAFIbLq8TnWOJ0f4cALtnSEUg=="
+            "version": "20.4.1",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.1.tgz",
+            "integrity": "sha512-JIzsAvJeA/5iY6Y/OxZbv1lUcc8dNSE77lb2gnBH+/PJ3lFR1Ccvgwl5JWnHAkNHcRsT0TbpVOsiMKZ1F/yyJg=="
         },
         "node_modules/@types/readable-stream": {
             "version": "2.3.15",
@@ -1608,16 +1608,25 @@
             }
         },
         "node_modules/acorn": {
-            "version": "7.1.1",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
-            "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==",
+            "version": "8.10.0",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
+            "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
             "dev": true,
-            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
             "engines": {
                 "node": ">=0.4.0"
+            }
+        },
+        "node_modules/acorn-import-assertions": {
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz",
+            "integrity": "sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==",
+            "dev": true,
+            "peer": true,
+            "peerDependencies": {
+                "acorn": "^8"
             }
         },
         "node_modules/acorn-jsx": {
@@ -1716,6 +1725,12 @@
                 "minimalistic-assert": "^1.0.0",
                 "safer-buffer": "^2.1.0"
             }
+        },
+        "node_modules/asn1.js/node_modules/bn.js": {
+            "version": "4.12.0",
+            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+            "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+            "dev": true
         },
         "node_modules/assert": {
             "version": "2.0.0",
@@ -1831,9 +1846,10 @@
             }
         },
         "node_modules/bn.js": {
-            "version": "4.12.0",
-            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-            "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
+            "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==",
+            "dev": true
         },
         "node_modules/body-parser": {
             "version": "1.20.2",
@@ -1974,12 +1990,6 @@
                 "randombytes": "^2.0.1"
             }
         },
-        "node_modules/browserify-rsa/node_modules/bn.js": {
-            "version": "5.2.1",
-            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
-            "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==",
-            "dev": true
-        },
         "node_modules/browserify-sign": {
             "version": "4.2.1",
             "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.1.tgz",
@@ -1996,12 +2006,6 @@
                 "readable-stream": "^3.6.0",
                 "safe-buffer": "^5.2.0"
             }
-        },
-        "node_modules/browserify-sign/node_modules/bn.js": {
-            "version": "5.2.1",
-            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
-            "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==",
-            "dev": true
         },
         "node_modules/browserify-sign/node_modules/readable-stream": {
             "version": "3.6.2",
@@ -2206,9 +2210,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001507",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001507.tgz",
-            "integrity": "sha512-SFpUDoSLCaE5XYL2jfqe9ova/pbQHEmbheDf5r4diNwbAgR3qxM9NQtfsiSscjqoya5K7kFcHPUQ+VsUkIJR4A==",
+            "version": "1.0.30001514",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001514.tgz",
+            "integrity": "sha512-ENcIpYBmwAAOm/V2cXgM7rZUrKKaqisZl4ZAI520FIkqGXUxJjmaIssbRW5HVVR5tyV6ygTLIm15aU8LUmQSaQ==",
             "dev": true,
             "funding": [
                 {
@@ -2240,9 +2244,9 @@
             }
         },
         "node_modules/cborg": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/cborg/-/cborg-2.0.2.tgz",
-            "integrity": "sha512-2b+30FYdBmAukzlpzWcigJDUE9ym4Mo3ldCmShfgDkq7zOOk+NnLGl1SueAFPHXi55FlyLUuT0yEXgY/1CcymA==",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/cborg/-/cborg-2.0.3.tgz",
+            "integrity": "sha512-f1IbyqgRLQK4ruNM+V3WikfYfXQg/f/zC1oneOw1P7F/Dn2OJX6MaXIdei3JMpz361IjY7OENBKcE53nkJFVCQ==",
             "bin": {
                 "cborg": "cli.js"
             }
@@ -2521,6 +2525,12 @@
                 "elliptic": "^6.5.3"
             }
         },
+        "node_modules/create-ecdh/node_modules/bn.js": {
+            "version": "4.12.0",
+            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+            "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+            "dev": true
+        },
         "node_modules/create-hash": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
@@ -2734,6 +2744,12 @@
                 "randombytes": "^2.0.0"
             }
         },
+        "node_modules/diffie-hellman/node_modules/bn.js": {
+            "version": "4.12.0",
+            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+            "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+            "dev": true
+        },
         "node_modules/dir-glob": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
@@ -2805,9 +2821,9 @@
             "dev": true
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.4.439",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.439.tgz",
-            "integrity": "sha512-BHpErPSNhb9FB25+OwQP6mCAf3ZXfGbmuvc4LzBNVJwpCcXQJm++LerimocYRG9FRxUVRKZqaB7d0+pImSTPSg==",
+            "version": "1.4.454",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.454.tgz",
+            "integrity": "sha512-pmf1rbAStw8UEQ0sr2cdJtWl48ZMuPD9Sto8HVQOq9vx9j2WgDEN6lYoaqFvqEHYOmGA9oRGn7LqWI9ta0YugQ==",
             "dev": true,
             "peer": true
         },
@@ -2825,6 +2841,11 @@
                 "minimalistic-crypto-utils": "^1.0.1"
             }
         },
+        "node_modules/elliptic/node_modules/bn.js": {
+            "version": "4.12.0",
+            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+            "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+        },
         "node_modules/emoji-regex": {
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -2841,9 +2862,9 @@
             }
         },
         "node_modules/engine.io": {
-            "version": "6.5.0",
-            "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.5.0.tgz",
-            "integrity": "sha512-UlfoK1iD62Hkedw2TmuHdhDsZCGaAyp+LZ/AvnImjYBeWagA3qIEETum90d6shMeFZiDuGT66zVCdx1wKYKGGg==",
+            "version": "6.5.1",
+            "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.5.1.tgz",
+            "integrity": "sha512-mGqhI+D7YxS9KJMppR6Iuo37Ed3abhU8NdfgSvJSDUafQutrN+sPTncJYTyM9+tkhSmWodKtVYGPPHyXJEwEQA==",
             "dev": true,
             "dependencies": {
                 "@types/cookie": "^0.4.1",
@@ -3145,12 +3166,12 @@
             "dev": true
         },
         "node_modules/espree": {
-            "version": "9.5.2",
-            "resolved": "https://registry.npmjs.org/espree/-/espree-9.5.2.tgz",
-            "integrity": "sha512-7OASN1Wma5fum5SrNhFMAMJxOUAbhyfQ8dQ//PJaJbNw0URTPWqIghHWt1MmAANKhHZIYOHruW4Kw4ruUWOdGw==",
+            "version": "9.6.0",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.0.tgz",
+            "integrity": "sha512-1FH/IiruXZ84tpUlm0aCUEwMl2Ho5ilqVh0VvQXw+byAz/4SAciyHLlfmL5WYqsvD38oymdUwBss0LtK8m4s/A==",
             "dev": true,
             "dependencies": {
-                "acorn": "^8.8.0",
+                "acorn": "^8.9.0",
                 "acorn-jsx": "^5.3.2",
                 "eslint-visitor-keys": "^3.4.1"
             },
@@ -3159,18 +3180,6 @@
             },
             "funding": {
                 "url": "https://opencollective.com/eslint"
-            }
-        },
-        "node_modules/espree/node_modules/acorn": {
-            "version": "8.9.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.9.0.tgz",
-            "integrity": "sha512-jaVNAFBHNLXspO543WnNNPZFRtavh3skAkITqD0/2aeMkKZTN+254PyhwxFYrk3vQ1xfY+2wbesJMs/JC8/PwQ==",
-            "dev": true,
-            "bin": {
-                "acorn": "bin/acorn"
-            },
-            "engines": {
-                "node": ">=0.4.0"
             }
         },
         "node_modules/esquery": {
@@ -3276,9 +3285,9 @@
             "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
         },
         "node_modules/fast-glob": {
-            "version": "3.2.12",
-            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
-            "integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.0.tgz",
+            "integrity": "sha512-ChDuvbOypPuNjO8yIDf36x7BlZX1smcUMTTcyoIjycexOxd6DFsKsg21qVBzEmr3G7fUKIRy2/psii+CIUt7FA==",
             "dev": true,
             "dependencies": {
                 "@nodelib/fs.stat": "^2.0.2",
@@ -4332,7 +4341,7 @@
             "dev": true,
             "dependencies": {
                 "istanbul-lib-coverage": "^3.0.0",
-                "make-dir": "^4.0.0",
+                "make-dir": "^3.0.0",
                 "supports-color": "^7.1.0"
             },
             "engines": {
@@ -4472,9 +4481,12 @@
             }
         },
         "node_modules/it-pushable": {
-            "version": "3.1.3",
-            "resolved": "https://registry.npmjs.org/it-pushable/-/it-pushable-3.1.3.tgz",
-            "integrity": "sha512-f50iQ85HISS6DaWCyrqf9QJ6G/kQtKIMf9xZkgZgyOvxEQDfn8OfYcLXXquCqgoLboxQtAW1ZFZyFIAsLHDtJw==",
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/it-pushable/-/it-pushable-3.2.1.tgz",
+            "integrity": "sha512-sLFz2Q0oyDCJpTciZog7ipP4vSftfPy3e6JnH6YyztRa1XqkpGQaafK3Jw/JlfEBtCXfnX9uVfcpu3xpSAqCVQ==",
+            "dependencies": {
+                "p-defer": "^4.0.0"
+            },
             "engines": {
                 "node": ">=16.0.0",
                 "npm": ">=7.0.0"
@@ -5104,6 +5116,12 @@
                 "miller-rabin": "bin/miller-rabin"
             }
         },
+        "node_modules/miller-rabin/node_modules/bn.js": {
+            "version": "4.12.0",
+            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+            "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+            "dev": true
+        },
         "node_modules/mime": {
             "version": "2.6.0",
             "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
@@ -5498,9 +5516,9 @@
             }
         },
         "node_modules/node-releases": {
-            "version": "2.0.12",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.12.tgz",
-            "integrity": "sha512-QzsYKWhXTWx8h1kIvqfnC++o0pEmpRQA/aenALsL2F4pqNVr7YzcdMlDij5WBnwftRbJCNJL/O7zdKaxKPHqgQ==",
+            "version": "2.0.13",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz",
+            "integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==",
             "dev": true,
             "peer": true
         },
@@ -5823,13 +5841,13 @@
             "dev": true
         },
         "node_modules/path-scurry": {
-            "version": "1.9.2",
-            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.9.2.tgz",
-            "integrity": "sha512-qSDLy2aGFPm8i4rsbHd4MNyTcrzHFsLQykrtbuGRknZZCBBVXSv2tSCDN2Cg6Rt/GFRw8GoW9y9Ecw5rIPG1sg==",
+            "version": "1.10.1",
+            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.10.1.tgz",
+            "integrity": "sha512-MkhCqzzBEpPvxxQ71Md0b1Kk51W01lrYvlMzSUaIzNsODdd7mqhiimSZlr+VegAz5Z6Vzt9Xg2ttE//XBhH3EQ==",
             "dev": true,
             "dependencies": {
-                "lru-cache": "^9.1.1",
-                "minipass": "^5.0.0 || ^6.0.2"
+                "lru-cache": "^9.1.1 || ^10.0.0",
+                "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
             },
             "engines": {
                 "node": ">=16 || 14 >=14.17"
@@ -5839,9 +5857,9 @@
             }
         },
         "node_modules/path-scurry/node_modules/minipass": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/minipass/-/minipass-6.0.2.tgz",
-            "integrity": "sha512-MzWSV5nYVT7mVyWCwn2o7JH13w2TBRmmSqSRCKzTw+lmft9X4z+3wjvs06Tzijo5z4W/kahUCDpRXTF+ZrmF/w==",
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.1.tgz",
+            "integrity": "sha512-NQ8MCKimInjVlaIqx51RKJJB7mINVkLTJbsZKmto4UAAOC/CWXES8PGaOgoBZyqoUsUA/U3DToGK7GJkkHbjJw==",
             "dev": true,
             "engines": {
                 "node": ">=16 || 14 >=14.17"
@@ -5987,9 +6005,9 @@
             }
         },
         "node_modules/protobufjs": {
-            "version": "7.2.3",
-            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.3.tgz",
-            "integrity": "sha512-TtpvOqwB5Gdz/PQmOjgsrGH1nHjAQVCN7JG4A6r1sXRWESL5rNMAiRcBQlCAdKxZcAbstExQePYG8xof/JVRgg==",
+            "version": "7.2.4",
+            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.4.tgz",
+            "integrity": "sha512-AT+RJgD2sH8phPmCf7OUZR8xGdcJRga4+1cOaXJ64hvcSkVhNcRHOwIxUatPH15+nj59WAGTDv3LSGZPEQbJaQ==",
             "hasInstallScript": true,
             "dependencies": {
                 "@protobufjs/aspromise": "^1.1.2",
@@ -6010,16 +6028,12 @@
             }
         },
         "node_modules/protons-runtime": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-5.0.0.tgz",
-            "integrity": "sha512-QqjGnPGkpvbzq0dITzhG9DVK10rRIHf7nePcU2QQVVpFGuYbwrOWnvGSvei1GcceAzB9syTz6vHzvTPmGRR0PA==",
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-5.0.1.tgz",
+            "integrity": "sha512-AwyAA3pQ4Ka4tEBMdIjLi/cRdpb322f7sgv3NruVq9yguLggzwu5eeLe1HuRPFYlI4UsVN/QK/AQXjLPVLCzTA==",
             "dependencies": {
                 "protobufjs": "^7.0.0",
                 "uint8arraylist": "^2.4.3"
-            },
-            "engines": {
-                "node": ">=16.0.0",
-                "npm": ">=7.0.0"
             },
             "peerDependencies": {
                 "uint8arraylist": "^2.3.2"
@@ -6038,6 +6052,12 @@
                 "randombytes": "^2.0.1",
                 "safe-buffer": "^5.1.2"
             }
+        },
+        "node_modules/public-encrypt/node_modules/bn.js": {
+            "version": "4.12.0",
+            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+            "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+            "dev": true
         },
         "node_modules/punycode": {
             "version": "1.4.1",
@@ -6487,9 +6507,9 @@
             }
         },
         "node_modules/semver": {
-            "version": "7.5.3",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
-            "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
+            "version": "7.5.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+            "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
             "dependencies": {
                 "lru-cache": "^6.0.0"
             },
@@ -6623,9 +6643,9 @@
             }
         },
         "node_modules/socket.io": {
-            "version": "4.7.0",
-            "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.7.0.tgz",
-            "integrity": "sha512-eOpu7oCNiPGBHn9Falg0cAGivp6TpDI3Yt596fbsf+vln8kRLFWxXKrecFrybn/xNYVn9HcdJNAkYToCmTjsyg==",
+            "version": "4.7.1",
+            "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.7.1.tgz",
+            "integrity": "sha512-W+utHys2w//dhFjy7iQQu9sGd3eokCjGbl2r59tyLqNiJJBdIebn3GAKEXBr3osqHTObJi2die/25bCx2zsaaw==",
             "dev": true,
             "dependencies": {
                 "accepts": "~1.3.4",
@@ -6902,9 +6922,9 @@
             }
         },
         "node_modules/terser": {
-            "version": "5.18.1",
-            "resolved": "https://registry.npmjs.org/terser/-/terser-5.18.1.tgz",
-            "integrity": "sha512-j1n0Ao919h/Ai5r43VAnfV/7azUYW43GPxK7qSATzrsERfW7+y2QW9Cp9ufnRF5CQUWbnLSo7UJokSWCqg4tsQ==",
+            "version": "5.18.2",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-5.18.2.tgz",
+            "integrity": "sha512-Ah19JS86ypbJzTzvUCX7KOsEIhDaRONungA4aYBjEP3JZRf4ocuDzTg4QWZnPn9DEMiMYGJPiSOy7aykoCc70w==",
             "dev": true,
             "peer": true,
             "dependencies": {
@@ -6963,19 +6983,6 @@
             "peer": true,
             "dependencies": {
                 "randombytes": "^2.1.0"
-            }
-        },
-        "node_modules/terser/node_modules/acorn": {
-            "version": "8.9.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.9.0.tgz",
-            "integrity": "sha512-jaVNAFBHNLXspO543WnNNPZFRtavh3skAkITqD0/2aeMkKZTN+254PyhwxFYrk3vQ1xfY+2wbesJMs/JC8/PwQ==",
-            "dev": true,
-            "peer": true,
-            "bin": {
-                "acorn": "bin/acorn"
-            },
-            "engines": {
-                "node": ">=0.4.0"
             }
         },
         "node_modules/test-exclude": {
@@ -7064,9 +7071,9 @@
             "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
         },
         "node_modules/tslib": {
-            "version": "2.5.3",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-            "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
+            "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
         },
         "node_modules/tsutils": {
             "version": "3.21.0",
@@ -7378,9 +7385,9 @@
             "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
         },
         "node_modules/webpack": {
-            "version": "5.88.0",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.88.0.tgz",
-            "integrity": "sha512-O3jDhG5e44qIBSi/P6KpcCcH7HD+nYIHVBhdWFxcLOcIGN8zGo5nqF3BjyNCxIh4p1vFdNnreZv2h2KkoAw3lw==",
+            "version": "5.88.1",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.88.1.tgz",
+            "integrity": "sha512-FROX3TxQnC/ox4N+3xQoWZzvGXSuscxR32rbzjpXgEzWudJFEJBpdlkkob2ylrv5yzzufD1zph1OoFsLtm6stQ==",
             "dev": true,
             "peer": true,
             "dependencies": {
@@ -7433,29 +7440,6 @@
             "peer": true,
             "engines": {
                 "node": ">=10.13.0"
-            }
-        },
-        "node_modules/webpack/node_modules/acorn": {
-            "version": "8.9.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.9.0.tgz",
-            "integrity": "sha512-jaVNAFBHNLXspO543WnNNPZFRtavh3skAkITqD0/2aeMkKZTN+254PyhwxFYrk3vQ1xfY+2wbesJMs/JC8/PwQ==",
-            "dev": true,
-            "peer": true,
-            "bin": {
-                "acorn": "bin/acorn"
-            },
-            "engines": {
-                "node": ">=0.4.0"
-            }
-        },
-        "node_modules/webpack/node_modules/acorn-import-assertions": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz",
-            "integrity": "sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==",
-            "dev": true,
-            "peer": true,
-            "peerDependencies": {
-                "acorn": "^8"
             }
         },
         "node_modules/whatwg-url": {

--- a/package.json
+++ b/package.json
@@ -13,5 +13,12 @@
         "clean": "npx npkill -d $(pwd) -t node_modules && npx npkill -d $(pwd) -t dist",
         "build": "npm run build --ws"
     },
-    "private": true
+    "private": true,
+    "overrides": {
+      "c8": {
+        "istanbul-lib-report": {
+          "make-dir": "^4.0.0"
+        }
+      }
+    }
 }

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -105,8 +105,5 @@
     "playwright": "1.31.2",
     "rimraf": "4.4.0",
     "typescript": "5.0.4"
-  },
-  "overrides": {
-    "socket.io-parser@>4.0.4 <4.2.3": "4.2.3"
   }
 }

--- a/packages/credentials/package.json
+++ b/packages/credentials/package.json
@@ -106,8 +106,5 @@
     "playwright": "1.31.2",
     "rimraf": "4.4.0",
     "typescript": "5.0.4"
-  },
-  "overrides": {
-    "socket.io-parser@>4.0.4 <4.2.3": "4.2.3"
   }
 }

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -112,8 +112,5 @@
     "sinon": "15.0.2",
     "source-map-loader": "4.0.1",
     "typescript": "5.0.4"
-  },
-  "overrides": {
-    "socket.io-parser@>4.0.4 <4.2.3": "4.2.3"
   }
 }

--- a/packages/dids/package.json
+++ b/packages/dids/package.json
@@ -118,8 +118,5 @@
     "sinon": "15.0.2",
     "source-map-loader": "4.0.1",
     "typescript": "5.0.4"
-  },
-  "overrides": {
-    "socket.io-parser@>4.0.4 <4.2.3": "4.2.3"
   }
 }

--- a/packages/web5-agent/package.json
+++ b/packages/web5-agent/package.json
@@ -113,8 +113,5 @@
     "sinon": "15.0.2",
     "source-map-loader": "4.0.1",
     "typescript": "5.0.4"
-  },
-  "overrides": {
-    "socket.io-parser@>4.0.4 <4.2.3": "4.2.3"
   }
 }

--- a/packages/web5-proxy-agent/package.json
+++ b/packages/web5-proxy-agent/package.json
@@ -112,8 +112,5 @@
     "sinon": "15.0.2",
     "source-map-loader": "4.0.1",
     "typescript": "5.0.4"
-  },
-  "overrides": {
-    "socket.io-parser@>4.0.4 <4.2.3": "4.2.3"
   }
 }

--- a/packages/web5-user-agent/package.json
+++ b/packages/web5-user-agent/package.json
@@ -122,8 +122,5 @@
     "sinon": "15.0.2",
     "source-map-loader": "4.0.1",
     "typescript": "5.0.4"
-  },
-  "overrides": {
-    "socket.io-parser@>4.0.4 <4.2.3": "4.2.3"
   }
 }

--- a/packages/web5/package.json
+++ b/packages/web5/package.json
@@ -126,8 +126,5 @@
     "sinon": "15.0.2",
     "source-map-loader": "4.0.1",
     "typescript": "5.0.4"
-  },
-  "overrides": {
-    "socket.io-parser@>4.0.4 <4.2.3": "4.2.3"
   }
 }


### PR DESCRIPTION
This PR is primarily to address a high severity vulnerability:

- [CVE-2023-36665](https://github.com/advisories/GHSA-h755-8qp9-cq85) - protobufjs Prototype Pollution vulnerability

The polyrepo's `package-lock.json` was re-created to allow for the patched `v7.2.4` version of `protobufjs` to be installed.

Additionally, in the process of resolving this security vulnerability, two other changes were made:
1. Discovered a better way to resolve [CVE-2022-25883](https://github.com/advisories/GHSA-c2qf-rxjj-qqgw) than manually patching `package-lock.json`, which is to add the following the polyrepo root `package.json`:
    ```json
    "overrides": {
      "c8": {
        "istanbul-lib-report": {
          "make-dir": "^4.0.0"
        }
      }
    }
    ```
    Updated Issue #135 to note that this override can be removed if `istanbul-lib-report` is ever updated.
2. The [`socket.io`](https://www.npmjs.com/package/socket.io) package was finally updated and the latest `v4.7.1` no longer relies on the version of [`socket.io-parser`](https://www.npmjs.com/package/socket.io-parser) that contained a high severity vulnerability.  As a result, the following override was removed from all polyrepo `package.json` files which will close #96 once this PR is merged:
    ```json
    "overrides": {
      "karma": {
        "socket.io-parser@>4.0.4 <4.2.3": "4.2.3"
      }
    }
    ```