### PR TITLE
Temporarily expose access to local ProfileManager through `web5.techPreview.profileManager`

### DIFF
--- a/packages/web5/src/web5.ts
+++ b/packages/web5/src/web5.ts
@@ -79,7 +79,7 @@ export class Web5 {
     this.appStorage ||= new AppStorage();
 
     this.#techPreview = {
-      userAgent: options.web5Agent
+      userAgent: options.web5Agent as Web5UserAgent
     };
   }
 

--- a/packages/web5/src/web5.ts
+++ b/packages/web5/src/web5.ts
@@ -210,6 +210,3 @@ export class Web5 {
     }, delay);
   }
 }
-
-const { web5, did } = await Web5.connect();
-

--- a/packages/web5/src/web5.ts
+++ b/packages/web5/src/web5.ts
@@ -1,5 +1,5 @@
 import type { Web5Agent } from '@tbd54566975/web5-agent';
-import type { SyncManager } from '@tbd54566975/web5-user-agent';
+import type { ProfileManager, SyncManager } from '@tbd54566975/web5-user-agent';
 import type { DidState, DidMethodApi, DidResolverCache, DwnServiceEndpoint } from '@tbd54566975/dids';
 
 import ms from 'ms';
@@ -44,6 +44,7 @@ export type Web5ConnectOptions = {
 type Web5Options = {
   web5Agent: Web5Agent;
   appStorage?: AppStorage;
+  profileManager: ProfileManager;
   connectedDid: string;
 };
 
@@ -52,7 +53,9 @@ export class Web5 {
   dwn: DwnApi;
   vc: VcApi;
   #connectedDid: string;
-  #techPreview: { userAgent: Web5UserAgent };
+  #techPreview: {
+    profileManager: ProfileManager
+   };
 
   /**
    * Statically available DID functionality. can be used to create and resolve DIDs without calling {@link connect}.
@@ -79,7 +82,7 @@ export class Web5 {
     this.appStorage ||= new AppStorage();
 
     this.#techPreview = {
-      userAgent: options.web5Agent as Web5UserAgent
+      profileManager: options.profileManager
     };
   }
 
@@ -146,7 +149,7 @@ export class Web5 {
     });
 
     const connectedDid = profile.did.id;
-    const web5 = new Web5({ appStorage: appStorage, web5Agent: agent, connectedDid });
+    const web5 = new Web5({ appStorage: appStorage, profileManager: profileApi, web5Agent: agent, connectedDid });
 
     Web5.#enqueueNextSync(syncManager, ms('2m'));
 
@@ -207,3 +210,6 @@ export class Web5 {
     }, delay);
   }
 }
+
+const { web5, did } = await Web5.connect();
+

--- a/packages/web5/src/web5.ts
+++ b/packages/web5/src/web5.ts
@@ -52,6 +52,7 @@ export class Web5 {
   dwn: DwnApi;
   vc: VcApi;
   #connectedDid: string;
+  #techPreview: { userAgent: Web5UserAgent };
 
   /**
    * Statically available DID functionality. can be used to create and resolve DIDs without calling {@link connect}.
@@ -67,6 +68,8 @@ export class Web5 {
    */
   get did() { return Web5.did; }
 
+  get techPreview() { return this.#techPreview; }
+
   private static APP_DID_KEY = 'WEB5_APP_DID';
 
   private constructor(options: Web5Options) {
@@ -74,6 +77,10 @@ export class Web5 {
     this.dwn = new DwnApi(options.web5Agent, this.#connectedDid);
     this.vc = new VcApi(options.web5Agent, this.#connectedDid);
     this.appStorage ||= new AppStorage();
+
+    this.#techPreview = {
+      userAgent: options.web5Agent
+    };
   }
 
   /**


### PR DESCRIPTION
enables the ability to import/export profiles that will change once future changes land