### PR TITLE
Missing exports

### DIFF
--- a/packages/web5/src/main.ts
+++ b/packages/web5/src/main.ts
@@ -1,1 +1,4 @@
+export type { Record } from './record.js';
+
 export * from './web5.js';
+export { DateSort } from '@tbd54566975/dwn-sdk-js';


### PR DESCRIPTION
# Changes

## export `DateSort`

currently, in order to use the `DateSort` enum, you have to include `dwn-sdk-js` as a dependency. the `DateSort` enum is needed when using the `dateSort` property of `dwn.records.query` e.g.

```js
const { records, status } = await web5.dwn.records.query({
  from    : pfiDid,
  message : {
    filter: {
      schema: 'https://tbd.website/resources/tbdex/Offering'
    },
    dateSort: DateSort.createdAscending
  }
})
```

## export `Record` type

useful when you're passing something of type `Record` to other functions