### PR TITLE
Add `recordID` as a property of filter 

### DIFF
--- a/packages/web5/src/dwn-api.ts
+++ b/packages/web5/src/dwn-api.ts
@@ -206,7 +206,7 @@ export class DwnApi {
       /**
        * TODO: Document method.
        */
-      delete: async (request: RecordsDeleteRequest): Promise<RecordsDeleteResponse> => {
+      delete: async (request: { from?: string, message: { filter: { recordId: string } } }): Promise<RecordsDeleteResponse> => {
         const agentRequest = {
           author         : this.connectedDid,
           messageOptions : request.message,
@@ -272,7 +272,7 @@ export class DwnApi {
       /**
        * TODO: Document method.
        */
-      read: async (request: RecordsReadRequest): Promise<RecordsReadResponse> => {
+      read: async (request: { from?: string, message: { filter: { recordId: string } } }): Promise<RecordsReadResponse> => {
         const agentRequest = {
           author         : this.connectedDid,
           messageOptions : request.message,

--- a/packages/web5/src/dwn-api.ts
+++ b/packages/web5/src/dwn-api.ts
@@ -55,7 +55,7 @@ export type RecordsCreateFromRequest = {
 
 export type RecordsDeleteRequest = {
   from?: string;
-  message: Omit<RecordsDeleteOptions, 'authorizationSignatureInput'>;
+  message: { filter: { recordId: string }, dataFormat?: string };
 }
 
 export type RecordsDeleteResponse = {
@@ -76,7 +76,7 @@ export type RecordsQueryResponse = {
 export type RecordsReadRequest = {
   /** The from property indicates the DID to read from and return results fro. */
   from?: string;
-  message: Omit<RecordsReadOptions, 'authorizationSignatureInput'>;
+  message: { filter: { recordId: string }, dataFormat?: string };
 }
 
 export type RecordsReadResponse = {
@@ -206,7 +206,7 @@ export class DwnApi {
       /**
        * TODO: Document method.
        */
-      delete: async (request: { from?: string, message: { filter: { recordId: string } } }): Promise<RecordsDeleteResponse> => {
+      delete: async (request: RecordsDeleteRequest): Promise<RecordsDeleteResponse> => {
         const agentRequest = {
           author         : this.connectedDid,
           messageOptions : request.message,
@@ -272,7 +272,7 @@ export class DwnApi {
       /**
        * TODO: Document method.
        */
-      read: async (request: { from?: string, message: { filter: { recordId: string } } }): Promise<RecordsReadResponse> => {
+      read: async (request: RecordsReadRequest): Promise<RecordsReadResponse> => {
         const agentRequest = {
           author         : this.connectedDid,
           messageOptions : request.message,

--- a/packages/web5/src/dwn-api.ts
+++ b/packages/web5/src/dwn-api.ts
@@ -1,11 +1,9 @@
 import type { Web5Agent } from '@tbd54566975/web5-agent';
 import type {
   UnionMessageReply,
-  RecordsReadOptions,
   RecordsQueryOptions,
   RecordsWriteMessage,
   RecordsWriteOptions,
-  RecordsDeleteOptions,
   ProtocolsQueryOptions,
   RecordsQueryReplyEntry,
   ProtocolsConfigureMessage,

--- a/packages/web5/tests/record.spec.ts
+++ b/packages/web5/tests/record.spec.ts
@@ -208,7 +208,9 @@ describe('Record', () => {
 
       const readResult = await dwn.records.read({
         message: {
-          recordId: record!.id
+          filter: {
+            recordId: record!.id
+          }
         }
       });
 
@@ -273,7 +275,7 @@ describe('Record', () => {
         expect(status.code).to.equal(202);
 
         // Read the record that was just created.
-        const { record: readRecord, status: readRecordStatus } = await dwn.records.read({ message: { recordId: record!.id }});
+        const { record: readRecord, status: readRecordStatus } = await dwn.records.read({ message: { filter: {recordId: record!.id }}});
 
         expect(readRecordStatus.code).to.equal(200);
 
@@ -318,7 +320,7 @@ describe('Record', () => {
         expect(status.code).to.equal(202);
 
         // Read the record that was just created.
-        const { record: readRecord, status: readRecordStatus } = await dwn.records.read({ message: { recordId: record!.id }});
+        const { record: readRecord, status: readRecordStatus } = await dwn.records.read({ message: { filter: { recordId: record!.id }}});
 
         expect(readRecordStatus.code).to.equal(200);
 
@@ -365,7 +367,7 @@ describe('Record', () => {
         expect(status.code).to.equal(202);
 
         // Read the record that was just created.
-        const { record: readRecord, status: readRecordStatus } = await dwn.records.read({ message: { recordId: record!.id }});
+        const { record: readRecord, status: readRecordStatus } = await dwn.records.read({ message: { filter: {recordId: record!.id }}});
 
         expect(readRecordStatus.code).to.equal(200);
 
@@ -410,7 +412,7 @@ describe('Record', () => {
         expect(status.code).to.equal(202);
 
         // Read the record that was just created.
-        const { record: readRecord, status: readRecordStatus } = await dwn.records.read({ message: { recordId: record!.id }});
+        const { record: readRecord, status: readRecordStatus } = await dwn.records.read({ message: { filter: {recordId: record!.id }}});
 
         expect(readRecordStatus.code).to.equal(200);
 
@@ -454,7 +456,7 @@ describe('Record', () => {
         expect(status.code).to.equal(202);
 
         // Read the record that was just created.
-        const { record: readRecord, status: readRecordStatus } = await dwn.records.read({ message: { recordId: record!.id }});
+        const { record: readRecord, status: readRecordStatus } = await dwn.records.read({ message: { filter: {recordId: record!.id }}});
 
         expect(readRecordStatus.code).to.equal(200);
 
@@ -495,7 +497,7 @@ describe('Record', () => {
         expect(status.code).to.equal(202);
 
         // Read the record that was just created.
-        const { record: readRecord, status: readRecordStatus } = await dwn.records.read({ message: { recordId: record!.id }});
+        const { record: readRecord, status: readRecordStatus } = await dwn.records.read({ message: { filter: {recordId: record!.id }}});
 
         expect(readRecordStatus.code).to.equal(200);
 

--- a/packages/web5/tests/web5-dwn.spec.ts
+++ b/packages/web5/tests/web5-dwn.spec.ts
@@ -277,7 +277,9 @@ describe('web5.dwn', () => {
 
           const result = await dwn.records.read({
             message: {
-              recordId: writeResult.record!.id
+              filter: {
+                recordId: writeResult.record!.id
+              }
             }
           });
 
@@ -302,7 +304,9 @@ describe('web5.dwn', () => {
 
           const result = await dwn.records.read({
             message: {
-              recordId: writeResult.record!.id
+              filter: {
+                recordId: writeResult.record!.id
+              }
             }
           });
 
@@ -325,7 +329,9 @@ describe('web5.dwn', () => {
           const result = await dwn.records.read({
             from    : bobDid,
             message : {
-              recordId: record!.id
+              filter: {
+                recordId: record!.id
+              }
             }
           });
 
@@ -352,7 +358,9 @@ describe('web5.dwn', () => {
 
           const deleteResult = await dwn.records.delete({
             message: {
-              recordId: writeResult.record!.id
+              filter: {
+                recordId: writeResult.record!.id
+              }
             }
           });
 
@@ -362,7 +370,9 @@ describe('web5.dwn', () => {
         it('returns a 404 when the specified record does not exist', async () => {
           let deleteResult = await dwn.records.delete({
             message: {
-              recordId: 'abcd1234'
+              filter: {
+                recordId: 'abcd1234'
+              }
             }
           });
           expect(deleteResult.status.code).to.equal(404);
@@ -379,7 +389,9 @@ describe('web5.dwn', () => {
           const deleteResult = await dwn.records.delete({
             from    : bobDid,
             message : {
-              recordId: 'abcd1234'
+              filter: {
+                recordId: 'abcd1234'
+              }
             }
           });
 


### PR DESCRIPTION
## Overview
This pull request makes the `recordID` property the only required filed for `filter`, simplyfing the developer's experience. 
Also, the `dataFormat` property can still be added but it's now optional.
 
See #154 for more details

## Example

```javascript
const {records} = await web5.dwn.records.query({
  message: {
    filter: {
      recordId: 'bafyreiaz5oycqbrnmmpvffxqyoqxvx6bcnqueprmt2qnvzcurpc52r5uyy',
    }
  }
});
```