### PR TITLE
Add browser exports

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -49,6 +49,11 @@
       "types": "./dist/types/index.d.ts",
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js"
+    },
+    "./browser": {
+      "types": "./dist/types/index.d.ts",
+      "import": "./dist/browser.mjs",
+      "require": "./dist/browser.js"
     }
   },
   "react-native": "./dist/esm/index.js",


### PR DESCRIPTION
Adding browser exports back to the package.json. This seems to be the only way to get it to work seamlessly with Docusaurus.