### PR TITLE
Set package versions to match NPM Registry

### DIFF
--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web5/agent",
-  "version": "0.2.0",
+  "version": "0.1.7",
   "type": "module",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
@@ -68,9 +68,9 @@
   },
   "dependencies": {
     "@tbd54566975/dwn-sdk-js": "0.2.1",
-    "@web5/common": "0.2.0",
-    "@web5/crypto": "0.2.0",
-    "@web5/dids": "0.2.0",
+    "@web5/common": "0.1.1",
+    "@web5/crypto": "0.1.6",
+    "@web5/dids": "0.1.9",
     "level": "8.0.0",
     "readable-stream": "4.4.2",
     "readable-web-to-node-stream": "3.0.2"

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web5/api",
-  "version": "0.8.1",
+  "version": "0.8.0",
   "description": "SDK for accessing the features and capabilities of Web5",
   "type": "module",
   "main": "./dist/cjs/index.js",
@@ -71,10 +71,10 @@
   },
   "dependencies": {
     "@tbd54566975/dwn-sdk-js": "0.2.1",
-    "@web5/agent": "0.2.0",
-    "@web5/crypto": "0.2.0",
-    "@web5/dids": "0.2.0",
-    "@web5/user-agent": "0.2.0",
+    "@web5/agent": "0.1.7",
+    "@web5/crypto": "0.1.6",
+    "@web5/dids": "0.1.9",
+    "@web5/user-agent": "0.1.10",
     "level": "8.0.0",
     "ms": "2.1.3",
     "readable-stream": "4.4.2",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web5/common",
-  "version": "0.2.0",
+  "version": "0.1.1",
   "type": "module",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",

--- a/packages/credentials/package.json
+++ b/packages/credentials/package.json
@@ -67,7 +67,6 @@
   "engines": {
     "node": ">=18.0.0"
   },
-  "dependencies": {},
   "devDependencies": {
     "@playwright/test": "1.36.2",
     "@types/chai": "4.3.5",

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web5/crypto",
-  "version": "0.2.0",
+  "version": "0.1.6",
   "description": "TBD crypto library",
   "type": "module",
   "main": "./dist/cjs/index.js",
@@ -76,7 +76,7 @@
     "@noble/ciphers": "0.1.4",
     "@noble/curves": "1.1.0",
     "@noble/hashes": "1.3.1",
-    "@web5/common": "0.2.0"
+    "@web5/common": "0.1.1"
   },
   "devDependencies": {
     "@playwright/test": "1.36.2",

--- a/packages/dids/package.json
+++ b/packages/dids/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web5/dids",
-  "version": "0.2.0",
+  "version": "0.1.9",
   "description": "TBD DIDs library",
   "type": "module",
   "main": "./dist/cjs/index.js",
@@ -76,8 +76,8 @@
   "dependencies": {
     "@decentralized-identity/ion-pow-sdk": "1.0.17",
     "@decentralized-identity/ion-sdk": "1.0.1",
-    "@web5/common": "0.2.0",
-    "@web5/crypto": "0.2.0",
+    "@web5/common": "0.1.1",
+    "@web5/crypto": "0.1.6",
     "canonicalize": "2.0.0",
     "did-resolver": "4.1.0",
     "level": "8.0.0"

--- a/packages/identity-agent/package.json
+++ b/packages/identity-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web5/identity-agent",
-  "version": "0.2.0",
+  "version": "0.1.0",
   "type": "module",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
@@ -67,8 +67,8 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
-    "@web5/agent": "0.2.0",
-    "@web5/api": "0.8.1"
+    "@web5/agent": "0.1.7",
+    "@web5/api": "0.8.0"
   },
   "devDependencies": {
     "@playwright/test": "1.36.2",

--- a/packages/proxy-agent/package.json
+++ b/packages/proxy-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web5/proxy-agent",
-  "version": "0.2.0",
+  "version": "0.1.10",
   "type": "module",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
@@ -67,10 +67,10 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
-    "@web5/agent": "0.2.0",
-    "@web5/common": "0.2.0",
-    "@web5/crypto": "0.2.0",
-    "@web5/dids": "0.2.0"
+    "@web5/agent": "0.1.7",
+    "@web5/common": "0.1.1",
+    "@web5/crypto": "0.1.6",
+    "@web5/dids": "0.1.9"
   },
   "devDependencies": {
     "@playwright/test": "1.36.2",

--- a/packages/user-agent/package.json
+++ b/packages/user-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web5/user-agent",
-  "version": "0.2.0",
+  "version": "0.1.10",
   "type": "module",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
@@ -67,10 +67,10 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
-    "@web5/agent": "0.2.0",
-    "@web5/common": "0.2.0",
-    "@web5/crypto": "0.2.0",
-    "@web5/dids": "0.2.0"
+    "@web5/agent": "0.1.7",
+    "@web5/common": "0.1.1",
+    "@web5/crypto": "0.1.6",
+    "@web5/dids": "0.1.9"
   },
   "devDependencies": {
     "@playwright/test": "1.36.2",

--- a/scripts/bump-workspace.mjs
+++ b/scripts/bump-workspace.mjs
@@ -65,8 +65,8 @@ async function updateDependencies(workspaces, packageVersions) {
   for (const workspace of workspaces) {
     const packageJson = await PackageJson.load(workspace);
 
-    const dependencies = packageJson.content.dependencies;
-    const devDependencies = packageJson.content.devDependencies;
+    const dependencies = packageJson.content.dependencies ?? [];
+    const devDependencies = packageJson.content.devDependencies ?? [];
 
     for (const packageName in packageVersions) {
       // If the package is a dependency, update to the latest version.


### PR DESCRIPTION
This PR adjusts all of the `@web5/*` package versions to match what is currently published to NPM Registry.  This is necessary to enable the alpha publishing workflow to work due to the `npm version` step automatically attempting to pull the package manifest.