### PR TITLE
add `EdDSA` to `JwsHeaderParams['alg']` type

### DIFF
--- a/packages/crypto/src/jose.ts
+++ b/packages/crypto/src/jose.ts
@@ -314,7 +314,9 @@ export interface JwsHeaderParams extends JoseHeaderParams {
     // ECDSA using P-384 and SHA-384
     | 'ES384'
     // ECDSA using P-521 and SHA-512
-    | 'ES512';
+    | 'ES512'
+    // EdDSA using subtype Ed25519 or Ed448
+    | 'EdDSA';
 
   // Indicates that extensions to JOSE RFCs are being used
   // that MUST be understood and processed.

--- a/packages/crypto/src/jose.ts
+++ b/packages/crypto/src/jose.ts
@@ -289,24 +289,28 @@ export type JwkKeyPair = {
 export type JsonWebKey = PrivateKeyJwk | PublicKeyJwk;
 
 export interface JoseHeaderParams {
+  // Content Type
   cty?: string;
+  // JWK Set URL
   jku?: string;
+  // JSON Web Key
   jwk?: PublicKeyJwk;
+  // Key ID
   kid?: string;
+  // Type
   typ?: string;
+  // X.509 Certificate Chain
   x5c?: string[];
+  // X.509 Certificate SHA-1 Thumbprint
   x5t?: string;
+  // X.509 URL
   x5u?: string;
 }
 
 export interface JwsHeaderParams extends JoseHeaderParams {
   alg:
-    // HMAC using SHA-256
-    | 'HS256'
-    // HMAC using SHA-384
-    | 'HS384'
-    // HMAC using SHA-512
-    | 'HS512'
+    // Edwards curve digital signature algorithm (e.g., Ed25519)
+    | 'EdDSA'
     // ECDSA using P-256 and SHA-256
     | 'ES256'
     // ECDSA using secp256k1 curve and SHA-256
@@ -315,8 +319,12 @@ export interface JwsHeaderParams extends JoseHeaderParams {
     | 'ES384'
     // ECDSA using P-521 and SHA-512
     | 'ES512'
-    // EdDSA using subtype Ed25519 or Ed448
-    | 'EdDSA';
+    // HMAC using SHA-256
+    | 'HS256'
+    // HMAC using SHA-384
+    | 'HS384'
+    // HMAC using SHA-512
+    | 'HS512';
 
   // Indicates that extensions to JOSE RFCs are being used
   // that MUST be understood and processed.


### PR DESCRIPTION
This PR adds `EdDSA` (mentioned in [RFC 8037](https://www.rfc-editor.org/rfc/rfc8037#section-3))  as an acceptable value for `JwsHeaderParams['alg']`. 

<img width="829" alt="image" src="https://github.com/TBD54566975/web5-js/assets/4887440/6ca8faca-e82c-49c1-b3e6-38e123de1dda">
