### PR TITLE
Add named export for Docusaurus and improve alpha publishing workflow

### DIFF
--- a/.github/workflows/alpha-npm.yml
+++ b/.github/workflows/alpha-npm.yml
@@ -46,26 +46,18 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Build all workspace packages
-        run: npm run build
-
-      - name: Generate alpha version string and modify packages
+      - name: Generate alpha prerelease and bump package.json @web5/* versions
         env:
           NODE_AUTH_TOKEN: ${{secrets.npm_token}}
         run: |
           SHORT_COMMIT_SHA=$(git rev-parse --short HEAD)
           YYYYMMDD=$(date +'%Y%m%d')
-          for package in $PACKAGES; do
-            cd packages/$package
-            REPO_VERSION=$(node -p "require('./package.json').version")
-            ALPHA_VERSION="${REPO_VERSION}-alpha-$YYYYMMDD-$SHORT_COMMIT_SHA"
-            npm version $ALPHA_VERSION --no-git-tag-version
-            cd ../..
-          done
+          ALPHA_PRERELEASE="alpha-$YYYYMMDD-$SHORT_COMMIT_SHA"
+          node ./scripts/bump-workspace.mjs --prerelease=$ALPHA_PRERELEASE
         shell: bash
 
-      - name: Bump package.json @web5/* dependency versions
-        run: node ./scripts/bump-workspace.mjs
+      - name: Build all workspace packages
+        run: npm run build
 
       - name: Publish selected @web5/* packages
         env:
@@ -73,7 +65,6 @@ jobs:
         run: |
           for package in $PACKAGES; do
             cd packages/$package
-            cat package.json
             npm publish --tag alpha --no-git-tag-version --access public
             cd ../..
           done

--- a/.github/workflows/alpha-npm.yml
+++ b/.github/workflows/alpha-npm.yml
@@ -65,7 +65,7 @@ jobs:
         run: |
           for package in $PACKAGES; do
             cd packages/$package
-            npm publish --tag alpha --no-git-tag-version --access public
+            npm publish --tag alpha --no-git-tag-version --access public --provenance
             cd ../..
           done
         shell: bash

--- a/.github/workflows/alpha-npm.yml
+++ b/.github/workflows/alpha-npm.yml
@@ -33,8 +33,8 @@ jobs:
           node-version: 18
           registry-url: https://registry.npmjs.org/
 
-      # - name: Install latest npm
-      #   run: npm install -g npm@latest
+      - name: Install latest npm
+        run: npm install -g npm@latest
 
       # Note - this is not required but it gives a clean failure prior to attempting a release if
       # the GH workflow runner is not authenticated with NPMjs.com
@@ -74,7 +74,7 @@ jobs:
           for package in $PACKAGES; do
             cd packages/$package
             cat package.json
-            npm publish --tag alpha --no-git-tag-version --access public --provenance
+            npm publish --tag alpha --no-git-tag-version --access public
             cd ../..
           done
         shell: bash

--- a/.github/workflows/alpha-npm.yml
+++ b/.github/workflows/alpha-npm.yml
@@ -49,8 +49,8 @@ jobs:
         run: |
           SHORT_COMMIT_SHA=$(git rev-parse --short HEAD)
           YYYYMMDD=$(date +'%Y%m%d')
-          for dir in packages/*; do
-            cd $dir
+          for package in $PACKAGES; do
+            cd packages/$package
             REPO_VERSION=$(node -p "require('./package.json').version")
             ALPHA_VERSION="${REPO_VERSION}-alpha-$YYYYMMDD-$SHORT_COMMIT_SHA"
             npm version $ALPHA_VERSION --no-git-tag-version

--- a/.github/workflows/alpha-npm.yml
+++ b/.github/workflows/alpha-npm.yml
@@ -43,6 +43,12 @@ jobs:
           NODE_AUTH_TOKEN: ${{secrets.npm_token}}
         run: npm whoami
 
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build all workspace packages
+        run: npm run build
+
       - name: Generate alpha version string and modify packages
         env:
           NODE_AUTH_TOKEN: ${{secrets.npm_token}}
@@ -61,18 +67,13 @@ jobs:
       - name: Bump package.json @web5/* dependency versions
         run: node ./scripts/bump-workspace.mjs
 
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Build all workspace packages
-        run: npm run build
-
       - name: Publish selected @web5/* packages
         env:
           NODE_AUTH_TOKEN: ${{secrets.npm_token}}
         run: |
           for package in $PACKAGES; do
             cd packages/$package
+            cat package.json
             npm publish --tag alpha --no-git-tag-version --access public --provenance
             cd ../..
           done

--- a/.github/workflows/alpha-npm.yml
+++ b/.github/workflows/alpha-npm.yml
@@ -33,8 +33,8 @@ jobs:
           node-version: 18
           registry-url: https://registry.npmjs.org/
 
-      - name: Install latest npm
-        run: npm install -g npm@latest
+      # - name: Install latest npm
+      #   run: npm install -g npm@latest
 
       # Note - this is not required but it gives a clean failure prior to attempting a release if
       # the GH workflow runner is not authenticated with NPMjs.com

--- a/package-lock.json
+++ b/package-lock.json
@@ -450,9 +450,9 @@
       }
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.7.0.tgz",
-      "integrity": "sha512-+HencqxU7CFJnQb7IKtuNBqS6Yx3Tz4kOL8BJXo+JyeiBm5MEX6pO8onXDkjrkCRlfYXS1Axro15ZjVFe9YgsA==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.8.0.tgz",
+      "integrity": "sha512-JylOEEzDiOryeUnFbQz+oViCXS0KsvR1mvHkoMiu5+UiBvy+RYX7tzlIIIEstF/gVa2tj9AQXk3dgnxv6KxhFg==",
       "dev": true,
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
@@ -1201,9 +1201,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.5.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.3.tgz",
-      "integrity": "sha512-ITI7rbWczR8a/S6qjAW7DMqxqFMjjTo61qZVWJ1ubPvbIQsL5D/TvwjYEalM8Kthpe3hTzOGrF2TGbAu2uyqeA=="
+      "version": "20.5.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.6.tgz",
+      "integrity": "sha512-Gi5wRGPbbyOTX+4Y2iULQ27oUPrefaB0PxGQJnfyWN3kvEDGM3mIB5M/gQLmitZf7A9FmLeaqxD3L1CXpm3VKQ=="
     },
     "node_modules/@types/readable-stream": {
       "version": "4.0.0",
@@ -2368,9 +2368,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001522",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001522.tgz",
-      "integrity": "sha512-TKiyTVZxJGhsTszLuzb+6vUZSjVOAhClszBr2Ta2k9IwtNBT/4dzmL6aywt0HCgEZlmwJzXJd8yNiob6HgwTRg==",
+      "version": "1.0.30001523",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001523.tgz",
+      "integrity": "sha512-I5q5cisATTPZ1mc588Z//pj/Ox80ERYDfR71YnvY7raS/NOk8xXlZcB0sF7JdqaV//kOaa6aus7lRfpdnt1eBA==",
       "dev": true,
       "funding": [
         {
@@ -2402,9 +2402,9 @@
       }
     },
     "node_modules/cborg": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/cborg/-/cborg-2.0.4.tgz",
-      "integrity": "sha512-QradkXyNBLIyg1XNxcoXqUG4stcOhfuR1uexq+qNzL+EvFV5TXvN+c+LCh5XXxTv2fjBIkNB+3I6IO17EnKuKg==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/cborg/-/cborg-2.0.5.tgz",
+      "integrity": "sha512-xVW1rSIw1ZXbkwl2XhJ7o/jAv0vnVoQv/QlfQxV8a7V5PlA4UU/AcIiXqmpyybwNWy/GPQU1m/aBVNIWr7/T0w==",
       "bin": {
         "cborg": "cli.js"
       }
@@ -3091,9 +3091,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.499",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.499.tgz",
-      "integrity": "sha512-0NmjlYBLKVHva4GABWAaHuPJolnDuL0AhV3h1hES6rcLCWEIbRL6/8TghfsVwkx6TEroQVdliX7+aLysUpKvjw==",
+      "version": "1.4.502",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.502.tgz",
+      "integrity": "sha512-xqeGw3Gr6o3uyHy/yKjdnDQHY2RQvXcGC2cfHjccK1IGkH6cX1WQBN8EeC/YpwPhGkBaikDTecJ8+ssxSVRQlw==",
       "dev": true,
       "peer": true
     },
@@ -4327,9 +4327,9 @@
       }
     },
     "node_modules/ipfs-unixfs": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-11.0.1.tgz",
-      "integrity": "sha512-SD9dqn14bfgMfkPstsR/2Av3zCzYMj2ntQJab4HZucgX4nNV6K7guZh4Hf3kiL8ONff1Ogft1ekFU083DIKEdQ==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-11.1.0.tgz",
+      "integrity": "sha512-Lq37nKLJOpRFjx3rcg3y+ZwUxBX7jluKfIt5UPp6wb1L3dP0sj1yaLR0Yg2CdGYvHWyUpZD1iTnT8upL0ToDOw==",
       "dependencies": {
         "err-code": "^3.0.1",
         "protons-runtime": "^5.0.0",
@@ -8642,13 +8642,13 @@
     },
     "packages/agent": {
       "name": "@web5/agent",
-      "version": "0.2.0",
+      "version": "0.1.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@tbd54566975/dwn-sdk-js": "0.2.1",
-        "@web5/common": "0.2.0",
-        "@web5/crypto": "0.2.0",
-        "@web5/dids": "0.2.0",
+        "@web5/common": "0.1.1",
+        "@web5/crypto": "0.1.6",
+        "@web5/dids": "0.1.9",
         "level": "8.0.0",
         "readable-stream": "4.4.2",
         "readable-web-to-node-stream": "3.0.2"
@@ -8688,14 +8688,14 @@
     },
     "packages/api": {
       "name": "@web5/api",
-      "version": "0.8.1",
+      "version": "0.8.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@tbd54566975/dwn-sdk-js": "0.2.1",
-        "@web5/agent": "0.2.0",
-        "@web5/crypto": "0.2.0",
-        "@web5/dids": "0.2.0",
-        "@web5/user-agent": "0.2.0",
+        "@web5/agent": "0.1.7",
+        "@web5/crypto": "0.1.6",
+        "@web5/dids": "0.1.9",
+        "@web5/user-agent": "0.1.10",
         "level": "8.0.0",
         "ms": "2.1.3",
         "readable-stream": "4.4.2",
@@ -8740,7 +8740,7 @@
     },
     "packages/common": {
       "name": "@web5/common",
-      "version": "0.2.0",
+      "version": "0.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "level": "8.0.0",
@@ -8812,13 +8812,13 @@
     },
     "packages/crypto": {
       "name": "@web5/crypto",
-      "version": "0.2.0",
+      "version": "0.1.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/ciphers": "0.1.4",
         "@noble/curves": "1.1.0",
         "@noble/hashes": "1.3.1",
-        "@web5/common": "0.2.0"
+        "@web5/common": "0.1.1"
       },
       "devDependencies": {
         "@playwright/test": "1.36.2",
@@ -8858,13 +8858,13 @@
     },
     "packages/dids": {
       "name": "@web5/dids",
-      "version": "0.2.0",
+      "version": "0.1.9",
       "license": "Apache-2.0",
       "dependencies": {
         "@decentralized-identity/ion-pow-sdk": "1.0.17",
         "@decentralized-identity/ion-sdk": "1.0.1",
-        "@web5/common": "0.2.0",
-        "@web5/crypto": "0.2.0",
+        "@web5/common": "0.1.1",
+        "@web5/crypto": "0.1.6",
         "canonicalize": "2.0.0",
         "did-resolver": "4.1.0",
         "level": "8.0.0"
@@ -8905,11 +8905,11 @@
     },
     "packages/identity-agent": {
       "name": "@web5/identity-agent",
-      "version": "0.2.0",
+      "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@web5/agent": "0.2.0",
-        "@web5/api": "0.8.1"
+        "@web5/agent": "0.1.7",
+        "@web5/api": "0.8.0"
       },
       "devDependencies": {
         "@playwright/test": "1.36.2",
@@ -8945,13 +8945,13 @@
     },
     "packages/proxy-agent": {
       "name": "@web5/proxy-agent",
-      "version": "0.2.0",
+      "version": "0.1.10",
       "license": "Apache-2.0",
       "dependencies": {
-        "@web5/agent": "0.2.0",
-        "@web5/common": "0.2.0",
-        "@web5/crypto": "0.2.0",
-        "@web5/dids": "0.2.0"
+        "@web5/agent": "0.1.7",
+        "@web5/common": "0.1.1",
+        "@web5/crypto": "0.1.6",
+        "@web5/dids": "0.1.9"
       },
       "devDependencies": {
         "@playwright/test": "1.36.2",
@@ -8987,13 +8987,13 @@
     },
     "packages/user-agent": {
       "name": "@web5/user-agent",
-      "version": "0.2.0",
+      "version": "0.1.10",
       "license": "Apache-2.0",
       "dependencies": {
-        "@web5/agent": "0.2.0",
-        "@web5/common": "0.2.0",
-        "@web5/crypto": "0.2.0",
-        "@web5/dids": "0.2.0"
+        "@web5/agent": "0.1.7",
+        "@web5/common": "0.1.1",
+        "@web5/crypto": "0.1.6",
+        "@web5/dids": "0.1.9"
       },
       "devDependencies": {
         "@playwright/test": "1.36.2",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/TBD54566975/web5-js"
+    "url": "git+https://github.com/TBD54566975/web5-js.git"
   },
   "license": "Apache-2.0",
   "devDependencies": {

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -21,7 +21,7 @@
   "bugs": "https://github.com/TBD54566975/web5-js/issues",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/TBD54566975/web5-js",
+    "url": "git+https://github.com/TBD54566975/web5-js.git",
     "directory": "packages/agent"
   },
   "license": "Apache-2.0",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -22,7 +22,7 @@
   "bugs": "https://github.com/TBD54566975/web5-js/issues",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/TBD54566975/web5-js",
+    "url": "git+https://github.com/TBD54566975/web5-js.git",
     "directory": "packages/api"
   },
   "license": "Apache-2.0",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -49,6 +49,11 @@
       "types": "./dist/types/index.d.ts",
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js"
+    },
+    "./browser": {
+      "types": "./dist/types/index.d.ts",
+      "import": "./dist/browser.mjs",
+      "require": "./dist/browser.js"
     }
   },
   "react-native": "./dist/esm/index.js",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -21,7 +21,7 @@
   "bugs": "https://github.com/TBD54566975/web5-js/issues",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/TBD54566975/web5-js",
+    "url": "git+https://github.com/TBD54566975/web5-js.git",
     "directory": "packages/common"
   },
   "license": "Apache-2.0",

--- a/packages/credentials/package.json
+++ b/packages/credentials/package.json
@@ -22,7 +22,7 @@
   "bugs": "https://github.com/TBD54566975/web5-js/issues",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/TBD54566975/web5-js",
+    "url": "git+https://github.com/TBD54566975/web5-js.git",
     "directory": "packages/credentials"
   },
   "license": "Apache-2.0",

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -22,7 +22,7 @@
   "bugs": "https://github.com/TBD54566975/web5-js/issues",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/TBD54566975/web5-js",
+    "url": "git+https://github.com/TBD54566975/web5-js.git",
     "directory": "packages/crypto"
   },
   "license": "Apache-2.0",

--- a/packages/dids/package.json
+++ b/packages/dids/package.json
@@ -22,7 +22,7 @@
   "bugs": "https://github.com/TBD54566975/web5-js/issues",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/TBD54566975/web5-js",
+    "url": "git+https://github.com/TBD54566975/web5-js.git",
     "directory": "packages/dids"
   },
   "license": "Apache-2.0",

--- a/packages/identity-agent/package.json
+++ b/packages/identity-agent/package.json
@@ -21,7 +21,7 @@
   "bugs": "https://github.com/TBD54566975/web5-js/issues",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/TBD54566975/web5-js",
+    "url": "git+https://github.com/TBD54566975/web5-js.git",
     "directory": "packages/identity-agent"
   },
   "license": "Apache-2.0",

--- a/packages/proxy-agent/package.json
+++ b/packages/proxy-agent/package.json
@@ -21,7 +21,7 @@
   "bugs": "https://github.com/TBD54566975/web5-js/issues",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/TBD54566975/web5-js",
+    "url": "git+https://github.com/TBD54566975/web5-js.git",
     "directory": "packages/proxy-agent"
   },
   "license": "Apache-2.0",

--- a/packages/user-agent/package.json
+++ b/packages/user-agent/package.json
@@ -21,7 +21,7 @@
   "bugs": "https://github.com/TBD54566975/web5-js/issues",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/TBD54566975/web5-js",
+    "url": "git+https://github.com/TBD54566975/web5-js.git",
     "directory": "packages/user-agent"
   },
   "license": "Apache-2.0",

--- a/scripts/bump-workspace.mjs
+++ b/scripts/bump-workspace.mjs
@@ -35,19 +35,33 @@ async function getWorkspaces() {
 }
 
 /**
- * Retrieves the versions of packages for the given paths.
+ * Retrieves the versions of packages for the given paths, optionally appending
+ * a prerelease tag to the versions.
+ *
+ * This function reads the package versions from the specified paths and builds
+ * an object mapping package names to their corresponding versions. If a
+ * prerelease value is provided, it will be appended to the version string.
  *
  * @param {string[]} paths - An array of paths to the package.json files.
+ * @param {string} [prerelease] - An optional prerelease tag to append to the
+ * versions (e.g., 'alpha', 'beta').
  * @returns {Record<string, string>} An object mapping package names to their
  * corresponding versions.
  */
-async function getPackageVersions(paths) {
+async function getPackageVersions(paths, prerelease) {
   const versions = {};
 
   for (const path of paths) {
     const packageJson = await PackageJson.load(path);
+    // Get the package name (e.g., '@web5/common')
     const packageName = packageJson.content.name;
-    const version = packageJson.content.version;
+    // Get the current major.minor.patch version (e.g., '0.2.0').
+    const [currentVersion] = packageJson.content.version.split('-');
+    // Prefix the prerelease value, if any, with a hyphen.
+    const versionSuffix = prerelease ? `-${prerelease}` : '';
+    // If a prelease value is defined, append it to the version string (e.g., '0.2.0-alpha').
+    const version = currentVersion + versionSuffix;
+    // Add to the versions object.
     versions[packageName] = version;
   }
 
@@ -55,7 +69,46 @@ async function getPackageVersions(paths) {
 }
 
 /**
- * Updates dependencies of the workspaces to the latest versions.
+ * Parses the command-line arguments provided to the script and returns
+ * them as a configuration object.
+ *
+ * The function expects arguments in the format of '--key=value' and extracts
+ * them into key-value pairs stored within the configuration object. This allows
+ * for flexible configuration of the script's behavior via the command line.
+ *
+ * @param {string[]} argv - An array of command-line arguments passed to the script.
+ * @returns {Record<string, string>} An object mapping argument names to their
+ * corresponding values.
+ *
+ * @example
+ *
+ * const config = parseCliArguments(['--prerelease=alpha']);
+ * // Returns: { prerelease: 'alpha' }
+ */
+function parseCliArguments(argv) {
+  const config = {};
+  argv.forEach((arg) => {
+    if (arg.startsWith('--')) {
+      // Remove the '--' prefix.
+      const argWithoutPrefix = arg.substring(2);
+      // Split argName=argValue.
+      const [argName, argValue] = argWithoutPrefix.split('=');
+      // Store in config object.
+      config[argName] = argValue;
+    }
+  });
+
+  return config;
+}
+
+/**
+ * Updates dependencies of the workspaces to the latest versions and updates
+ * the version of the package itself.
+ *
+ * This function iterates through the provided workspaces and updates both
+ * regular dependencies and devDependencies to their latest versions. Additionally,
+ * it updates the version of the package itself according to the corresponding
+ * entry in the `packageVersions` object.
  *
  * @param {string[]} workspaces - An array of workspace paths.
  * @param {Record<string, string>} packageVersions - An object mapping package
@@ -65,6 +118,7 @@ async function updateDependencies(workspaces, packageVersions) {
   for (const workspace of workspaces) {
     const packageJson = await PackageJson.load(workspace);
 
+    const version = packageVersions[packageJson.content.name];
     const dependencies = packageJson.content.dependencies ?? [];
     const devDependencies = packageJson.content.devDependencies ?? [];
 
@@ -80,7 +134,7 @@ async function updateDependencies(workspaces, packageVersions) {
     }
 
     // Write changes, if any, to each `package.json` file.
-    packageJson.update({ dependencies, devDependencies });
+    packageJson.update({ version, dependencies, devDependencies });
     await packageJson.save();
   }
 }
@@ -91,8 +145,9 @@ async function updateDependencies(workspaces, packageVersions) {
  * versions, if any, are updated.
  */
 async function main() {
+  const config = parseCliArguments(process.argv);
   const workspaces = await getWorkspaces();
-  const packageVersions = await getPackageVersions(workspaces);
+  const packageVersions = await getPackageVersions(workspaces, config.prerelease);
   await updateDependencies(workspaces, packageVersions);
 }
 


### PR DESCRIPTION
This PR will:
- Add a `/browser` named export to the `@web5/api` package so that TBD's Docusaurus [developer site](https://developer.tbd.website)  can include Web5 code examples in MDX pages.
- Fixes a bug in the alpha publishing GH Actions workflow and improves it by removing the dependence on `npm version`, which was duplicating package installs and throwing errors upon first publication of a new package.
- Fixes the `repository.url` entries in all `package.json` files in the workspace.

Docusaurus testing completed by @dayhaysoos