### PR TITLE
Add SyncManager to Web5 Managed Agent

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -846,19 +846,19 @@
       }
     },
     "node_modules/@npmcli/git": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@npmcli/git/-/git-5.0.1.tgz",
-      "integrity": "sha512-9zUEqmRMZU5bmqWVu83wFVHH9kwLEQeMuDUDSYsBK/L4qbBl8Shdoc5EWfANzAdy5kFuPbBn7ToXTakbVdlCZg==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@npmcli/git/-/git-5.0.3.tgz",
+      "integrity": "sha512-UZp9NwK+AynTrKvHn5k3KviW/hA5eENmFsu3iAPe7sWRt0lFUdsY/wXIYjpDFe7cdSNwOIzbObfwgt6eL5/2zw==",
       "dev": true,
       "dependencies": {
-        "@npmcli/promise-spawn": "^6.0.0",
+        "@npmcli/promise-spawn": "^7.0.0",
         "lru-cache": "^10.0.1",
         "npm-pick-manifest": "^9.0.0",
         "proc-log": "^3.0.0",
         "promise-inflight": "^1.0.1",
         "promise-retry": "^2.0.1",
         "semver": "^7.3.5",
-        "which": "^3.0.0"
+        "which": "^4.0.0"
       },
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
@@ -883,15 +883,15 @@
       }
     },
     "node_modules/@npmcli/promise-spawn": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@npmcli/promise-spawn/-/promise-spawn-6.0.2.tgz",
-      "integrity": "sha512-gGq0NJkIGSwdbUt4yhdF8ZrmkGKVz9vAdVzpOfnom+V8PLSmSOVhZwbNvZZS1EYcJN5hzzKBxmmVVAInM6HQLg==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/promise-spawn/-/promise-spawn-7.0.0.tgz",
+      "integrity": "sha512-wBqcGsMELZna0jDblGd7UXgOby45TQaMWmbFwWX+SEotk4HV6zG2t6rT9siyLhPk4P6YYqgfL1UO8nMWDBVJXQ==",
       "dev": true,
       "dependencies": {
-        "which": "^3.0.0"
+        "which": "^4.0.0"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^16.14.0 || >=18.0.0"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -2368,9 +2368,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001524",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001524.tgz",
-      "integrity": "sha512-Jj917pJtYg9HSJBF95HVX3Cdr89JUyLT4IZ8SvM5aDRni95swKgYi3TgYLH5hnGfPE/U1dg6IfZ50UsIlLkwSA==",
+      "version": "1.0.30001525",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001525.tgz",
+      "integrity": "sha512-/3z+wB4icFt3r0USMwxujAqRvaD/B7rvGTsKhbhSQErVrJvkZCLhgNLJxU8MevahQVH6hCU9FsHdNUFbiwmE7Q==",
       "dev": true,
       "funding": [
         {
@@ -2837,6 +2837,12 @@
         "node": ">= 8"
       }
     },
+    "node_modules/cross-spawn/node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true
+    },
     "node_modules/cross-spawn/node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -3091,9 +3097,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.505",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.505.tgz",
-      "integrity": "sha512-0A50eL5BCCKdxig2SsCXhpuztnB9PfUgRMojj5tMvt8O54lbwz3t6wNgnpiTRosw5QjlJB7ixhVyeg8daLQwSQ==",
+      "version": "1.4.507",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.507.tgz",
+      "integrity": "sha512-brvPFnO1lu3UYBpBht2qWw9qqhdG4htTjT90/9oOJmxQ77VvTxL9+ghErFqQzgj7n8268ONAmlebqjBR/S+qgA==",
       "dev": true,
       "peer": true
     },
@@ -3526,7 +3532,8 @@
     "node_modules/eventemitter3": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "dev": true
     },
     "node_modules/events": {
       "version": "3.3.0",
@@ -3895,9 +3902,9 @@
       }
     },
     "node_modules/glob": {
-      "version": "10.3.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.3.tgz",
-      "integrity": "sha512-92vPiMb/iqpmEgsOoIDvTjc50wf9CCCvMzsi6W0JLPeUKE8TWP1a73PgqSrqy7iAZxaSD1YdzU7QZR5LF51MJw==",
+      "version": "10.3.4",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.4.tgz",
+      "integrity": "sha512-6LFElP3A+i/Q8XQKEvZjkEWEOTgAIALR9AO2rwT8bgPhDd1anmqDJDZ6lLddI4ehxxxR1S5RIqKe1uapMQfYaQ==",
       "dev": true,
       "dependencies": {
         "foreground-child": "^3.1.0",
@@ -4658,10 +4665,13 @@
       }
     },
     "node_modules/isexe": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
+      "integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/isomorphic-timers-promises": {
       "version": "1.0.1",
@@ -4972,6 +4982,12 @@
         "which": "^1.2.1"
       }
     },
+    "node_modules/karma-chrome-launcher/node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true
+    },
     "node_modules/karma-chrome-launcher/node_modules/which": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
@@ -5006,6 +5022,12 @@
         "is-wsl": "^2.2.0",
         "which": "^2.0.1"
       }
+    },
+    "node_modules/karma-firefox-launcher/node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true
     },
     "node_modules/karma-firefox-launcher/node_modules/which": {
       "version": "2.0.2",
@@ -6411,11 +6433,11 @@
       }
     },
     "node_modules/p-queue": {
-      "version": "7.3.4",
-      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-7.3.4.tgz",
-      "integrity": "sha512-esox8CWt0j9EZECFvkFl2WNPat8LN4t7WWeXq73D9ha0V96qPRufApZi4ZhPwXAln1uVVal429HVVKPa2X0yQg==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-7.4.0.tgz",
+      "integrity": "sha512-1FYFpop2WjLUfhSpKb0pi01JL+Z+H0Z8F2XPn2g04WxGynU/X8mx8s/66fb7jZ39pS2ZliAWCX97EoTSIdMmtw==",
       "dependencies": {
-        "eventemitter3": "^4.0.7",
+        "eventemitter3": "^5.0.1",
         "p-timeout": "^5.0.2"
       },
       "engines": {
@@ -6424,6 +6446,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/p-queue/node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
     },
     "node_modules/p-timeout": {
       "version": "5.1.0",
@@ -8380,18 +8407,18 @@
       }
     },
     "node_modules/which": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/which/-/which-3.0.1.tgz",
-      "integrity": "sha512-XA1b62dzQzLfaEOSQFTCOd5KFf/1VSzZo7/7TUjnya6u0vGGKzU96UQBZTAThCb2j4/xjBAyii1OhRLJEivHvg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
+      "integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
       "dev": true,
       "dependencies": {
-        "isexe": "^2.0.0"
+        "isexe": "^3.1.1"
       },
       "bin": {
         "node-which": "bin/which.js"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/which-typed-array": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1201,15 +1201,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-<<<<<<< HEAD
-      "version": "20.5.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.6.tgz",
-      "integrity": "sha512-Gi5wRGPbbyOTX+4Y2iULQ27oUPrefaB0PxGQJnfyWN3kvEDGM3mIB5M/gQLmitZf7A9FmLeaqxD3L1CXpm3VKQ=="
-=======
       "version": "20.5.7",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.7.tgz",
       "integrity": "sha512-dP7f3LdZIysZnmvP3ANJYTSwg+wLLl8p7RqniVlV7j+oXSXAbt9h0WIBFmJy5inWZoX9wZN6eXx+YXd9Rh3RBA=="
->>>>>>> 7aee676 (Resolve Sync cascading echoes issue and add to Web5.connect())
     },
     "node_modules/@types/readable-stream": {
       "version": "4.0.0",
@@ -2374,15 +2368,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-<<<<<<< HEAD
-      "version": "1.0.30001523",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001523.tgz",
-      "integrity": "sha512-I5q5cisATTPZ1mc588Z//pj/Ox80ERYDfR71YnvY7raS/NOk8xXlZcB0sF7JdqaV//kOaa6aus7lRfpdnt1eBA==",
-=======
       "version": "1.0.30001524",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001524.tgz",
       "integrity": "sha512-Jj917pJtYg9HSJBF95HVX3Cdr89JUyLT4IZ8SvM5aDRni95swKgYi3TgYLH5hnGfPE/U1dg6IfZ50UsIlLkwSA==",
->>>>>>> 7aee676 (Resolve Sync cascading echoes issue and add to Web5.connect())
       "dev": true,
       "funding": [
         {
@@ -3103,15 +3091,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-<<<<<<< HEAD
-      "version": "1.4.502",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.502.tgz",
-      "integrity": "sha512-xqeGw3Gr6o3uyHy/yKjdnDQHY2RQvXcGC2cfHjccK1IGkH6cX1WQBN8EeC/YpwPhGkBaikDTecJ8+ssxSVRQlw==",
-=======
       "version": "1.4.505",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.505.tgz",
       "integrity": "sha512-0A50eL5BCCKdxig2SsCXhpuztnB9PfUgRMojj5tMvt8O54lbwz3t6wNgnpiTRosw5QjlJB7ixhVyeg8daLQwSQ==",
->>>>>>> 7aee676 (Resolve Sync cascading echoes issue and add to Web5.connect())
       "dev": true,
       "peer": true
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -74,9 +74,9 @@
       }
     },
     "node_modules/@decentralized-identity/ion-sdk/node_modules/multiformats": {
-      "version": "12.0.1",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.0.1.tgz",
-      "integrity": "sha512-s01wijBJoDUqESWSzePY0lvTw7J3PVO9x2Cc6ASI5AMZM2Gnhh7BC17+nlFhHKU7dDzaCaRfb+NiqNzOsgPUoQ==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.0.tgz",
+      "integrity": "sha512-/qTOKKnU8nwcVURjRcS+UN0QYgdS5BPZzY10Aiciu2SqncyCVMGV8KtD83EBFmsuJDsSEmT4sGvzcTkCoMw0sQ==",
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
@@ -526,18 +526,18 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "8.47.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.47.0.tgz",
-      "integrity": "sha512-P6omY1zv5MItm93kLM8s2vr1HICJH8v0dvddDhysbIuZ+vcjOHg5Zbkf1mTkcmi2JA9oBG2anOkRnW8WJTS8Og==",
+      "version": "8.48.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.48.0.tgz",
+      "integrity": "sha512-ZSjtmelB7IJfWD2Fvb7+Z+ChTIKWq6kjda95fLcQKNS5aheVHn4IkfgRQE3sIIzTcSLwLcLZUD9UBt+V7+h+Pw==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
-      "version": "0.11.10",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.10.tgz",
-      "integrity": "sha512-KVVjQmNUepDVGXNuoRRdmmEjruj0KfiGSbS8LVc12LMsWDQzRXJ0qdhN8L8uUigKpfEHRhlaQFY0ib1tnUbNeQ==",
+      "version": "0.11.11",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.11.tgz",
+      "integrity": "sha512-N2brEuAadi0CcdeMXUkhbZB84eskAc8MEX1By6qEchoVywSgXPIjou4rYsl0V3Hj0ZnuGycGCjdNgockbzeWNA==",
       "dev": true,
       "dependencies": {
         "@humanwhocodes/object-schema": "^1.2.1",
@@ -603,9 +603,9 @@
       }
     },
     "node_modules/@ipld/dag-cbor/node_modules/multiformats": {
-      "version": "12.0.1",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.0.1.tgz",
-      "integrity": "sha512-s01wijBJoDUqESWSzePY0lvTw7J3PVO9x2Cc6ASI5AMZM2Gnhh7BC17+nlFhHKU7dDzaCaRfb+NiqNzOsgPUoQ==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.0.tgz",
+      "integrity": "sha512-/qTOKKnU8nwcVURjRcS+UN0QYgdS5BPZzY10Aiciu2SqncyCVMGV8KtD83EBFmsuJDsSEmT4sGvzcTkCoMw0sQ==",
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
@@ -624,9 +624,9 @@
       }
     },
     "node_modules/@ipld/dag-pb/node_modules/multiformats": {
-      "version": "12.0.1",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.0.1.tgz",
-      "integrity": "sha512-s01wijBJoDUqESWSzePY0lvTw7J3PVO9x2Cc6ASI5AMZM2Gnhh7BC17+nlFhHKU7dDzaCaRfb+NiqNzOsgPUoQ==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.0.tgz",
+      "integrity": "sha512-/qTOKKnU8nwcVURjRcS+UN0QYgdS5BPZzY10Aiciu2SqncyCVMGV8KtD83EBFmsuJDsSEmT4sGvzcTkCoMw0sQ==",
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
@@ -750,9 +750,9 @@
       }
     },
     "node_modules/@multiformats/murmur3/node_modules/multiformats": {
-      "version": "12.0.1",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.0.1.tgz",
-      "integrity": "sha512-s01wijBJoDUqESWSzePY0lvTw7J3PVO9x2Cc6ASI5AMZM2Gnhh7BC17+nlFhHKU7dDzaCaRfb+NiqNzOsgPUoQ==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.0.tgz",
+      "integrity": "sha512-/qTOKKnU8nwcVURjRcS+UN0QYgdS5BPZzY10Aiciu2SqncyCVMGV8KtD83EBFmsuJDsSEmT4sGvzcTkCoMw0sQ==",
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
@@ -1201,9 +1201,15 @@
       "dev": true
     },
     "node_modules/@types/node": {
+<<<<<<< HEAD
       "version": "20.5.6",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.6.tgz",
       "integrity": "sha512-Gi5wRGPbbyOTX+4Y2iULQ27oUPrefaB0PxGQJnfyWN3kvEDGM3mIB5M/gQLmitZf7A9FmLeaqxD3L1CXpm3VKQ=="
+=======
+      "version": "20.5.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.7.tgz",
+      "integrity": "sha512-dP7f3LdZIysZnmvP3ANJYTSwg+wLLl8p7RqniVlV7j+oXSXAbt9h0WIBFmJy5inWZoX9wZN6eXx+YXd9Rh3RBA=="
+>>>>>>> 7aee676 (Resolve Sync cascading echoes issue and add to Web5.connect())
     },
     "node_modules/@types/readable-stream": {
       "version": "4.0.0",
@@ -1216,9 +1222,9 @@
       }
     },
     "node_modules/@types/semver": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.0.tgz",
-      "integrity": "sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==",
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.1.tgz",
+      "integrity": "sha512-cJRQXpObxfNKkFAZbJl2yjWtJCqELQIdShsogr1d2MilP8dKD9TE/nEKHkJgUNHdGKCQaf9HbIynuV2csLGVLg==",
       "dev": true
     },
     "node_modules/@types/sinon": {
@@ -2368,9 +2374,15 @@
       }
     },
     "node_modules/caniuse-lite": {
+<<<<<<< HEAD
       "version": "1.0.30001523",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001523.tgz",
       "integrity": "sha512-I5q5cisATTPZ1mc588Z//pj/Ox80ERYDfR71YnvY7raS/NOk8xXlZcB0sF7JdqaV//kOaa6aus7lRfpdnt1eBA==",
+=======
+      "version": "1.0.30001524",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001524.tgz",
+      "integrity": "sha512-Jj917pJtYg9HSJBF95HVX3Cdr89JUyLT4IZ8SvM5aDRni95swKgYi3TgYLH5hnGfPE/U1dg6IfZ50UsIlLkwSA==",
+>>>>>>> 7aee676 (Resolve Sync cascading echoes issue and add to Web5.connect())
       "dev": true,
       "funding": [
         {
@@ -3091,9 +3103,15 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
+<<<<<<< HEAD
       "version": "1.4.502",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.502.tgz",
       "integrity": "sha512-xqeGw3Gr6o3uyHy/yKjdnDQHY2RQvXcGC2cfHjccK1IGkH6cX1WQBN8EeC/YpwPhGkBaikDTecJ8+ssxSVRQlw==",
+=======
+      "version": "1.4.505",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.505.tgz",
+      "integrity": "sha512-0A50eL5BCCKdxig2SsCXhpuztnB9PfUgRMojj5tMvt8O54lbwz3t6wNgnpiTRosw5QjlJB7ixhVyeg8daLQwSQ==",
+>>>>>>> 7aee676 (Resolve Sync cascading echoes issue and add to Web5.connect())
       "dev": true,
       "peer": true
     },
@@ -3700,16 +3718,17 @@
       }
     },
     "node_modules/flat-cache": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
-      "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.1.0.tgz",
+      "integrity": "sha512-OHx4Qwrrt0E4jEIcI5/Xb+f+QmJYNj2rrK8wiIdQOIrB9WrrJL8cjZvXdXuBTkkEwEqLycb5BeZDV1o2i9bTew==",
       "dev": true,
       "dependencies": {
-        "flatted": "^3.1.0",
+        "flatted": "^3.2.7",
+        "keyv": "^4.5.3",
         "rimraf": "^3.0.2"
       },
       "engines": {
-        "node": "^10.12.0 || >=12.0.0"
+        "node": ">=12.0.0"
       }
     },
     "node_modules/flat-cache/node_modules/brace-expansion": {
@@ -4808,9 +4827,9 @@
       }
     },
     "node_modules/jackspeak": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-2.3.0.tgz",
-      "integrity": "sha512-uKmsITSsF4rUWQHzqaRUuyAir3fZfW3f202Ee34lz/gZCi970CPZwyQXLGNgWJvvZbvFyzeyGq0+4fcG/mBKZg==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-2.3.1.tgz",
+      "integrity": "sha512-4iSY3Bh1Htv+kLhiiZunUhQ+OYXIn0ze3ulq8JeWrFKmhPAJSySV2+kdtRh2pGcCeF0s6oR8Oc+pYZynJj4t8A==",
       "dev": true,
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
@@ -4872,6 +4891,12 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/jsbi/-/jsbi-4.3.0.tgz",
       "integrity": "sha512-SnZNcinB4RIcnEyZqFPdGPVgrg2AcnykiBy0sHVJQKHYeaLUvi3Exj+iaPpLnFVkDPZIV4U0yvgC9/R4uEAZ9g=="
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true
     },
     "node_modules/json-parse-even-better-errors": {
       "version": "3.0.0",
@@ -5320,6 +5345,15 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.3.tgz",
+      "integrity": "sha512-QCiSav9WaX1PgETJ+SpNnx2PRRapJ/oRSXM4VO5OGYGSjrxbKPVFVhB3l2OCbLCk329N8qyAtsJjSjvVBWzEug==",
+      "dev": true,
+      "dependencies": {
+        "json-buffer": "3.0.1"
       }
     },
     "node_modules/level": {
@@ -6099,9 +6133,9 @@
       }
     },
     "node_modules/node-gyp-build": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.0.tgz",
-      "integrity": "sha512-NTZVKn9IylLwUzaKjkas1e4u2DLNcV4rdYagA4PWdPwW87Bi7z+BznyKSRwS/761tV/lzCGXplWsiaMjLqP2zQ==",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.1.tgz",
+      "integrity": "sha512-24vnklJmyRS8ViBNI8KbtK/r/DmXQMRiOMXTNz2nrTnAYUwjmEEbnnpB/+kt+yWRv73bPsSPRFddrcIbAxSiMQ==",
       "bin": {
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
@@ -7695,9 +7729,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.19.2",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.19.2.tgz",
-      "integrity": "sha512-qC5+dmecKJA4cpYxRa5aVkKehYsQKc+AHeKl0Oe62aYjBL8ZA33tTljktDHJSaxxMnbI5ZYw+o/S2DxxLu8OfA==",
+      "version": "5.19.3",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.19.3.tgz",
+      "integrity": "sha512-pQzJ9UJzM0IgmT4FAtYI6+VqFf0lj/to58AV0Xfgg0Up37RyPG7Al+1cepC6/BVuAxR9oNb41/DL4DEoHJvTdg==",
       "dev": true,
       "peer": true,
       "dependencies": {
@@ -8055,9 +8089,9 @@
       }
     },
     "node_modules/uint8arrays/node_modules/multiformats": {
-      "version": "12.0.1",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.0.1.tgz",
-      "integrity": "sha512-s01wijBJoDUqESWSzePY0lvTw7J3PVO9x2Cc6ASI5AMZM2Gnhh7BC17+nlFhHKU7dDzaCaRfb+NiqNzOsgPUoQ==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.0.tgz",
+      "integrity": "sha512-/qTOKKnU8nwcVURjRcS+UN0QYgdS5BPZzY10Aiciu2SqncyCVMGV8KtD83EBFmsuJDsSEmT4sGvzcTkCoMw0sQ==",
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -12,6 +12,7 @@ export * from './rpc-client.js';
 export * from './store-managed-did.js';
 export * from './store-managed-key.js';
 export * from './store-managed-identity.js';
+export * from './sync-manager.js';
 export * from './utils.js';
 
 export * from './test-managed-agent.js';

--- a/packages/agent/src/sync-manager.ts
+++ b/packages/agent/src/sync-manager.ts
@@ -1,0 +1,613 @@
+import type { BatchOperation } from 'level';
+import type {
+  EventsGetReply,
+  SignatureInput,
+  MessagesGetReply,
+  RecordsReadReply,
+  RecordsWriteMessage,
+  PrivateJwk as DwnPrivateKeyJwk,
+} from '@tbd54566975/dwn-sdk-js';
+
+import { Level } from 'level';
+import { Convert } from '@web5/common';
+import { utils as didUtils } from '@web5/dids';
+import { DataStream } from '@tbd54566975/dwn-sdk-js';
+
+import type { Web5ManagedAgent } from './types/agent.js';
+
+export interface SyncManager {
+  registerIdentity(options: { did: string }): Promise<void>;
+  push(): Promise<void>;
+  pull(): Promise<void>;
+}
+
+export type SyncManagerOptions = {
+  agent: Web5ManagedAgent;
+  dataPath?: string;
+};
+
+type SyncDirection = 'push' | 'pull';
+
+type SyncState = {
+  did: string;
+  dwnUrl: string;
+  watermark: string | undefined;
+}
+
+type DwnMessage = {
+  message: any;
+  data?: Blob;
+}
+
+type DbBatchOperation = BatchOperation<Level, string, string>;
+
+const is2xx = (code: number) => code >= 200 && code <= 299;
+const is4xx = (code: number) => code >= 400 && code <= 499;
+// const is5xx = (code: number) => code >= 500 && code <= 599;
+
+export class SyncManagerLevel implements SyncManager {
+  /**
+   * Holds the instance of a `Web5ManagedAgent` that represents the current
+   * execution context for the `KeyManager`. This agent is utilized
+   * to interact with other Web5 agent components. It's vital
+   * to ensure this instance is set to correctly contextualize
+   * operations within the broader Web5 agent framework.
+   */
+  private _agent?: Web5ManagedAgent;
+  private _db: Level;
+
+  constructor(options?: SyncManagerOptions) {
+    let { agent, dataPath = 'DATA/AGENT/SYNC_STORE' } = options ?? {};
+
+    this._agent = agent;
+    this._db = new Level(dataPath);
+  }
+
+  /**
+   * Retrieves the `Web5ManagedAgent` execution context.
+   * If the `agent` instance proprety is undefined, it will throw an error.
+   *
+   * @returns The `Web5ManagedAgent` instance that represents the current execution
+   * context.
+   *
+   * @throws Will throw an error if the `agent` instance property is undefined.
+   */
+  get agent(): Web5ManagedAgent {
+    if (this._agent === undefined) {
+      throw new Error('DidManager: Unable to determine agent execution context.');
+    }
+
+    return this._agent;
+  }
+
+  set agent(agent: Web5ManagedAgent) {
+    this._agent = agent;
+  }
+
+  public async clear(): Promise<void> {
+    await this._db.clear();
+  }
+
+  public async enqueuePush(): Promise<void> {
+    const registeredIdentities = await this._db.sublevel('registeredIdentities').keys().all();
+    const syncStates: SyncState[] = [];
+
+    for (let did of registeredIdentities) {
+      const { didDocument, didResolutionMetadata } = await this.agent.didResolver.resolve(did);
+      if (!didDocument) {
+        const errorCode = `${didResolutionMetadata?.error}: ` ?? '';
+        const defaultMessage = `Unable to resolve DID: ${did}`;
+        const errorMessage = didResolutionMetadata?.errorMessage ?? defaultMessage;
+        throw new Error(`SyncManager: ${errorCode}${errorMessage}`);
+      }
+
+      const [ service ] = didUtils.getServices({ didDocument, id: '#dwn' });
+
+      /** Silently ignore and do not try to perform Sync for any DID that does not have a DWN
+       * service endpoint published in its DID document. **/
+      if (!service) {
+        continue;
+      }
+
+      if (!didUtils.isDwnServiceEndpoint(service.serviceEndpoint)) {
+        throw new Error(`SyncManager: Malformed '#dwn' service endpoint. Expected array of node addresses.`);
+      }
+
+      const dwnEndpointUrls = service.serviceEndpoint.nodes;
+
+      for (let dwnUrl of dwnEndpointUrls) {
+        const watermark = await this.getWatermark(did, dwnUrl, 'push');
+        syncStates.push({ did, dwnUrl, watermark });
+      }
+    }
+
+    for (let syncState of syncStates) {
+      let agentResponse = await this.agent.dwnManager.processRequest({
+        author         : syncState.did,
+        target         : syncState.did,
+        messageType    : 'EventsGet',
+        messageOptions : {
+          watermark: syncState.watermark
+        }
+      });
+
+      const eventsReply = agentResponse.reply as EventsGetReply;
+      const putOps: DbBatchOperation[] = [];
+
+      for (let event of eventsReply.events ?? []) {
+        const pushKey = `${syncState.did}~${syncState.dwnUrl}~${event.messageCid}`;
+        const putOp: DbBatchOperation = { type: 'put', key: pushKey, value: event.watermark };
+
+        putOps.push(putOp);
+      }
+
+      const pushQueue = this.getPushQueue();
+      await pushQueue.batch(putOps as any);
+    }
+  }
+
+  // async getEvents(did: string, watermark: string | undefined, dwnUrl: string) {
+  //   const signatureInput = await this.getAuthorSignatureInput(did);
+  //   const eventsGet = await EventsGet.create({
+  //     watermark                   : watermark,
+  //     authorizationSignatureInput : signatureInput
+  //   });
+
+  //   let events: Event[];
+  //   if (dwnUrl === 'local') {
+  //     const reply = await this.dwn.processMessage(did, eventsGet.toJSON()) as EventsGetReply;
+  //     ({ events } = reply);
+  //   } else {
+  //     const reply = await this.dwnRpcClient.sendDwnRequest({
+  //       dwnUrl,
+  //       targetDid : did,
+  //       message   : eventsGet
+  //     }) as EventsGetReply;
+
+  //     ({ events } = reply);
+  //   }
+
+  //   return events;
+  // }
+
+  public async push(): Promise<void> {
+    await this.enqueuePush();
+
+    const pushQueue = this.getPushQueue();
+    const pushJobs = await pushQueue.iterator().all();
+    const errored: Set<string> = new Set();
+
+    const delOps: DbBatchOperation[] = [];
+
+    for (let job of pushJobs) {
+      const [key, watermark] = job;
+      const [did, dwnUrl, messageCid] = key.split('~');
+
+      if (errored.has(dwnUrl)) {
+        continue;
+      }
+
+      const dwnMessage = await this.getDwnMessage(did, messageCid);
+      if (!dwnMessage) {
+        delOps.push({ type: 'del', key: key });
+        await this.setWatermark(did, dwnUrl, 'push', watermark);
+        await this.addMessage(did, messageCid);
+
+        continue;
+      }
+
+      try {
+        const reply = await this.agent.rpcClient.sendDwnRequest({
+          dwnUrl,
+          targetDid : did,
+          data      : dwnMessage.data,
+          message   : dwnMessage.message
+        });
+
+        if (reply.status.code === 202 || reply.status.code === 409) {
+          delOps.push({ type: 'del', key: key });
+          await this.setWatermark(did, dwnUrl, 'push', watermark);
+          await this.addMessage(did, messageCid);
+        }
+      } catch {
+        // Error is intentionally ignored; 'errored' set is updated with 'dwnUrl'.
+        errored.add(dwnUrl);
+      }
+    }
+
+    await pushQueue.batch(delOps as any);
+  }
+
+  // async enqueuePull() {
+  //   const registeredIdentities = await this._db.sublevel('registeredIdentities').keys().all();
+  //   const syncStates: SyncState[] = [];
+
+  //   for (let did of registeredIdentities) {
+  //     // TODO: try/catch
+  //     const { didDocument } = await this.didResolver.resolve(did);
+  //     const [ service ] = didUtils.getServices(didDocument, { id: '#dwn', type: 'DecentralizedWebNode' });
+
+  //     if (!didUtils.isDwnServiceEndpoint(didDwnService.serviceEndpoint)) throw Error('Type guard');
+
+  //     // did has no dwn service endpoints listed in DID Doc. ignore
+  //     if (!service) {
+  //       continue;
+  //     }
+
+  //     const { nodes } = <DwnServiceEndpoint>service.serviceEndpoint;
+  //     for (let node of nodes) {
+  //       const watermark = await this.getWatermark(did, node, 'pull');
+  //       syncStates.push({ did, dwnUrl: node, watermark });
+  //     }
+  //   }
+
+  //   const pullOps: DbBatchOperation[] = [];
+
+  //   for (let syncState of syncStates) {
+  //     const signatureInput = await this.getAuthorSignatureInput(syncState.did);
+  //     const eventsGet = await EventsGet.create({
+  //       watermark                   : syncState.watermark,
+  //       authorizationSignatureInput : signatureInput
+  //     });
+
+  //     let reply: EventsGetReply;
+
+  //     try {
+  //       reply = await this.dwnRpcClient.sendDwnRequest({
+  //         dwnUrl    : syncState.dwnUrl,
+  //         targetDid : syncState.did,
+  //         message   : eventsGet
+  //       }) as EventsGetReply;
+  //     } catch(e) {
+  //       continue;
+  //     }
+
+  //     for (let event of reply.events) {
+  //       const pullKey = `${syncState.did}~${syncState.dwnUrl}~${event.messageCid}`;
+  //       const pullOp: DbBatchOperation = { type: 'put', key: pullKey, value: event.watermark };
+
+  //       pullOps.push(pullOp);
+  //     }
+
+  //     if (pullOps.length > 0) {
+  //       const pullQueue = this.getPullQueue();
+  //       pullQueue.batch(pullOps as any);
+  //     }
+  //   }
+  // }
+
+  async pull() {
+  //   await this.enqueuePull();
+
+    //   const pullQueue = this.getPullQueue();
+    //   const pullJobs = await pullQueue.iterator().all();
+    //   const delOps: DbBatchOperation[] = [];
+    //   const errored: Set<string> = new Set();
+
+    //   for (let job of pullJobs) {
+    //     const [key, watermark] = job;
+    //     const [did, dwnUrl, messageCid] = key.split('~');
+
+    //     if (errored.has(dwnUrl)) {
+    //       continue;
+    //     }
+
+    //     const messageExists = await this.messageExists(did, messageCid);
+    //     if (messageExists) {
+    //       await this.setWatermark(did, dwnUrl, 'pull', watermark);
+    //       delOps.push({ type: 'del', key });
+
+    //       continue;
+    //     }
+
+    //     const signatureInput = await this.getAuthorSignatureInput(did);
+    //     const messagesGet = await MessagesGet.create({
+    //       messageCids                 : [messageCid],
+    //       authorizationSignatureInput : signatureInput
+    //     });
+
+    //     let reply: MessagesGetReply;
+
+    //     try {
+    //       reply = await this.dwnRpcClient.sendDwnRequest({
+    //         dwnUrl,
+    //         targetDid : did,
+    //         message   : messagesGet
+    //       }) as MessagesGetReply;
+    //     } catch(e) {
+    //       errored.add(dwnUrl);
+    //       continue;
+    //     }
+
+    //     for (let entry of reply.messages) {
+    //       if (entry.error || !entry.message) {
+    //         console.warn(`message ${messageCid} not found. entry: ${JSON.stringify(entry, null, 2)} ignoring..`);
+
+    //         await this.setWatermark(did, dwnUrl, 'pull', watermark);
+    //         await this.addMessage(did, messageCid);
+    //         delOps.push({ type: 'del', key });
+
+    //         continue;
+    //       }
+
+    //       const messageType = this.getDwnMessageType(entry.message);
+    //       let dataStream;
+
+    //       if (messageType === 'RecordsWrite') {
+    //         const { encodedData } = entry;
+    //         const message = entry.message as RecordsWriteMessage;
+
+    //         if (encodedData) {
+    //           const dataBytes = Encoder.base64UrlToBytes(encodedData);
+    //           dataStream = DataStream.fromBytes(dataBytes);
+    //         } else {
+    //           const recordsRead = await RecordsRead.create({
+    //             authorizationSignatureInput : signatureInput,
+    //             recordId                    : message['recordId']
+    //           });
+
+    //           const recordsReadReply = await this.dwnRpcClient.sendDwnRequest({
+    //             targetDid : did,
+    //             dwnUrl,
+    //             message   : recordsRead
+    //           }) as RecordsReadReply;
+
+    //           if (recordsReadReply.status.code >= 400) {
+    //             const pruneReply = await this.dwn.synchronizePrunedInitialRecordsWrite(did, message);
+
+    //             if (pruneReply.status.code === 202 || pruneReply.status.code === 409) {
+    //               await this.setWatermark(did, dwnUrl, 'pull', watermark);
+    //               await this.addMessage(did, messageCid);
+    //               delOps.push({ type: 'del', key });
+
+    //               continue;
+    //             } else {
+    //               throw new Error(`Failed to sync tombstone. message cid: ${messageCid}`);
+    //             }
+    //           } else {
+    //             dataStream = webReadableToIsomorphicNodeReadable(recordsReadReply.record.data as any);
+    //           }
+    //         }
+    //       }
+
+    //       const pullReply = await this.dwn.processMessage(did, entry.message, dataStream);
+
+    //       if (pullReply.status.code === 202 || pullReply.status.code === 409) {
+    //         await this.setWatermark(did, dwnUrl, 'pull', watermark);
+    //         await this.addMessage(did, messageCid);
+    //         delOps.push({ type: 'del', key });
+    //       }
+    //     }
+    //   }
+
+  //   await pullQueue.batch(delOps as any);
+  }
+
+  public async registerIdentity(options: {
+    did: string
+  }): Promise<void> {
+    const { did } = options;
+
+    const registeredIdentities = this._db.sublevel('registeredIdentities');
+
+    await registeredIdentities.put(did, '');
+  }
+
+  private async getDwnMessage(
+    author: string,
+    messageCid: string
+  ): Promise<DwnMessage | undefined> {
+    let messagesGetResponse = await this.agent.dwnManager.processRequest({
+      author         : author,
+      target         : author,
+      messageType    : 'MessagesGet',
+      messageOptions : {
+        messageCids: [messageCid]
+      }
+    });
+
+    const reply: MessagesGetReply = messagesGetResponse.reply;
+
+    /** Absence of a messageEntry or message within messageEntry can happen because updating a
+     * Record creates another RecordsWrite with the same recordId. Only the first and
+     * most recent RecordsWrite messages are kept for a given recordId. Any RecordsWrite messages
+     * that aren't the first or most recent are discarded by the DWN. */
+    if (!(reply.messages && reply.messages.length === 1)) {
+      return undefined;
+    }
+
+    const [ messageEntry ] = reply.messages;
+
+    let { message } = messageEntry;
+    if (!message) {
+      return undefined;
+    }
+
+    let dwnMessage: DwnMessage = { message };
+    const messageType = `${message.descriptor.interface}${message.descriptor.method}`;
+
+    // if the message is a RecordsWrite, either data will be present, OR we have to get it using a RecordsRead
+    if (messageType === 'RecordsWrite') {
+      const { encodedData } = messageEntry;
+      const writeMessage = message as RecordsWriteMessage;
+
+      if (encodedData) {
+        const dataBytes = Convert.base64Url(encodedData).toUint8Array();
+        dwnMessage.data = new Blob([dataBytes]);
+      } else {
+        let readResponse = await this.agent.dwnManager.processRequest({
+          author         : author,
+          target         : author,
+          messageType    : 'RecordsRead',
+          messageOptions : {
+            recordId: writeMessage.recordId
+          }
+        });
+        const reply = readResponse.reply as RecordsReadReply;
+
+        if (is2xx(reply.status.code) && reply.record) {
+          // If status code is 200-299, return the data.
+          const dataBytes = await DataStream.toBytes(reply.record.data);
+          dwnMessage.data = new Blob([dataBytes]);
+
+        } else if (is4xx(reply.status.code)) {
+          /** If status code is 400-499, typically 404 indicating the data no longer exists, it is
+           * likely that a `RecordsDelete` took place. `RecordsDelete` keeps a `RecordsWrite` and
+           * deletes the associated data, effectively acting as a "tombstone."  Sync still needs to
+           * _push_ this tombstone so that the `RecordsDelete` can be processed successfully. */
+
+        } else {
+          // If status code is anything else (likely 5xx), throw an error.
+          const { status } = reply;
+          throw new Error(`SyncManager: Failed to read data associated with record ${writeMessage.recordId}. (${status.code}) ${status.detail}}`);
+        }
+      }
+    }
+
+    return dwnMessage;
+  }
+
+  // /**
+  //  * constructs signature input required to sign DWeb Messages
+  //  * @param authorDid
+  //  * @returns {SignatureInput}
+  //  */
+  // async getAuthorSignatureInput(authorDid: string): Promise<SignatureInput> {
+  //   const profile = await this.profileManager.getProfile(authorDid);
+
+  //   if (!profile) {
+  //     throw new Error('profile not found for author.');
+  //   }
+
+  //   const { keys } = profile.did;
+  //   const [ key ] = keys;
+  //   const { privateKeyJwk } = key;
+
+  //   // TODO: make far less naive
+  //   const kidFragment = privateKeyJwk.kid || key.id;
+  //   const kid = `${profile.did.id}#${kidFragment}`;
+
+  //   const dwnSignatureInput: SignatureInput = {
+  //     privateJwk      : <DwnPrivateKeyJwk>privateKeyJwk,
+  //     protectedHeader : { alg: privateKeyJwk.crv, kid }
+  //   };
+
+  //   return dwnSignatureInput;
+  // }
+
+  private async getWatermark(did: string, dwnUrl: string, direction: SyncDirection) {
+    const wmKey = `${did}~${dwnUrl}~${direction}`;
+    const watermarkStore = this.getWatermarkStore();
+
+    try {
+      return await watermarkStore.get(wmKey);
+    } catch(error: any) {
+      // Don't throw when a key wasn't found.
+      if (error.code === 'LEVEL_NOT_FOUND') {
+        return undefined;
+      }
+    }
+  }
+
+  private async setWatermark(did: string, dwnUrl: string, direction: SyncDirection, watermark: string) {
+    const wmKey = `${did}~${dwnUrl}~${direction}`;
+    const watermarkStore = this.getWatermarkStore();
+
+    return watermarkStore.put(wmKey, watermark);
+  }
+
+  private async messageExists(did: string, messageCid: string) {
+    const messageStore = this.getMessageStore(did);
+    const hashedKey = new Set([messageCid]);
+
+    const itr = messageStore.keys({ lte: messageCid, limit: 1 });
+    for await (let key of itr) {
+      if (hashedKey.has(key)) {
+        return true;
+      } else {
+        return false;
+      }
+    }
+  }
+
+  private async addMessage(did: string, messageCid: string) {
+    const messageStore = this.getMessageStore(did);
+
+    return messageStore.put(messageCid, '');
+  }
+
+  private getMessageStore(did: string) {
+    return this._db.sublevel('history').sublevel(did).sublevel('messages');
+  }
+
+  private getWatermarkStore() {
+    return this._db.sublevel('watermarks');
+  }
+
+  private getPushQueue() {
+    return this._db.sublevel('pushQueue');
+  }
+
+  private getPullQueue() {
+    return this._db.sublevel('pullQueue');
+  }
+
+  // TODO: export BaseMessage from dwn-sdk.
+  private getDwnMessageType(message: any) {
+    return `${message.descriptor.interface}${message.descriptor.method}`;
+  }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  /**
+   * TEMPORARY
+   * REMOVE ONCE SYNC MANAGER IS REFACTORED TO USE DWNMANAGER
+   */
+  private async getAuthorSigningKeyId(options: {
+    did: string
+  }): Promise<string> {
+    const { did } = options;
+
+    // Get the agent instance.
+    const agent = this.agent;
+
+    // Get the method-specific default signing key.
+    const signingKeyId = await agent.didManager.getDefaultSigningKey({ did });
+
+    if (!signingKeyId) {
+      throw new Error (`DwnManager: Unable to determine signing key for author: '${did}'`);
+    }
+
+    return signingKeyId;
+  }
+
+  private getTempSignatureInput({ signingKeyId }: { signingKeyId: string }): SignatureInput {
+    const privateJwk: DwnPrivateKeyJwk = {
+      alg : 'placeholder',
+      d   : 'placeholder',
+      crv : 'Ed25519',
+      kty : 'placeholder',
+      x   : 'placeholder'
+    };
+
+    const protectedHeader = {
+      alg : 'placeholder',
+      kid : signingKeyId
+    };
+
+    const dwnSignatureInput: SignatureInput = { privateJwk, protectedHeader };
+
+    return dwnSignatureInput;
+  }
+}

--- a/packages/agent/src/test-managed-agent.ts
+++ b/packages/agent/src/test-managed-agent.ts
@@ -1,6 +1,7 @@
 import type { KeyValueStore } from '@web5/common';
 import type { DidResolutionResult, DidResolverCache, PortableDid } from '@web5/dids';
 
+import { Level } from 'level';
 import { Jose } from '@web5/crypto';
 import { Dwn } from '@tbd54566975/dwn-sdk-js';
 import { LevelStore, MemoryStore } from '@web5/common';
@@ -20,6 +21,7 @@ import { DidStoreDwn, DidStoreMemory } from './store-managed-did.js';
 import { IdentityManager, ManagedIdentity } from './identity-manager.js';
 import { IdentityStoreDwn, IdentityStoreMemory } from './store-managed-identity.js';
 import { KeyStoreDwn, KeyStoreMemory, PrivateKeyStoreDwn, PrivateKeyStoreMemory } from './store-managed-key.js';
+import { SyncManagerLevel } from './sync-manager.js';
 
 type CreateMethodOptions = {
   agentClass: new (options: any) => Web5ManagedAgent
@@ -37,6 +39,7 @@ type TestManagedAgentOptions = {
   dwnDataStore: DataStoreLevel;
   dwnEventLog: EventLogLevel;
   dwnMessageStore: MessageStoreLevel;
+  syncStore: Level;
 }
 
 export class TestManagedAgent {
@@ -49,6 +52,7 @@ export class TestManagedAgent {
   dwnDataStore: DataStoreLevel;
   dwnEventLog: EventLogLevel;
   dwnMessageStore: MessageStoreLevel;
+  syncStore: Level;
 
   constructor(options: TestManagedAgentOptions) {
     this.agent = options.agent;
@@ -59,6 +63,7 @@ export class TestManagedAgent {
     this.dwnDataStore = options.dwnDataStore;
     this.dwnEventLog = options.dwnEventLog;
     this.dwnMessageStore = options.dwnMessageStore;
+    this.syncStore = options.syncStore;
   }
 
   async clearStorage(): Promise<void> {
@@ -68,6 +73,7 @@ export class TestManagedAgent {
     await this.dwnDataStore.clear();
     await this.dwnEventLog.clear();
     await this.dwnMessageStore.clear();
+    await this.syncStore.clear();
 
     /** Easiest way to start with fresh in-memory stores is to
      * re-instantiate all of the managed agent components */
@@ -85,6 +91,7 @@ export class TestManagedAgent {
     await this.dwnDataStore.close();
     await this.dwnEventLog.close();
     await this.dwnMessageStore.close();
+    await this.syncStore.close();
   }
 
   static async create(options: CreateMethodOptions): Promise<TestManagedAgent> {
@@ -128,6 +135,10 @@ export class TestManagedAgent {
     // Instantiate an RPC Client.
     const rpcClient = new Web5RpcClient();
 
+    // Instantiate a custom SyncManager and LevelDB-backed store.
+    const syncStore = new Level(testDataPath('SYNC_STORE'));
+    const syncManager = new SyncManagerLevel({ db: syncStore });
+
     const agent = new agentClass({
       agentDid: '',
       appData,
@@ -137,6 +148,7 @@ export class TestManagedAgent {
       identityManager,
       keyManager,
       rpcClient,
+      syncManager
     });
 
     return new TestManagedAgent({
@@ -148,6 +160,7 @@ export class TestManagedAgent {
       dwnDataStore,
       dwnEventLog,
       dwnMessageStore,
+      syncStore,
     });
   }
 

--- a/packages/agent/src/test-managed-agent.ts
+++ b/packages/agent/src/test-managed-agent.ts
@@ -16,12 +16,12 @@ import { DwnManager } from './dwn-manager.js';
 import { KeyManager } from './key-manager.js';
 import { Web5RpcClient } from './rpc-client.js';
 import { AppDataVault } from './app-data-store.js';
+import { SyncManagerLevel } from './sync-manager.js';
 import { cryptoToPortableKeyPair } from './utils.js';
 import { DidStoreDwn, DidStoreMemory } from './store-managed-did.js';
 import { IdentityManager, ManagedIdentity } from './identity-manager.js';
 import { IdentityStoreDwn, IdentityStoreMemory } from './store-managed-identity.js';
 import { KeyStoreDwn, KeyStoreMemory, PrivateKeyStoreDwn, PrivateKeyStoreMemory } from './store-managed-key.js';
-import { SyncManagerLevel } from './sync-manager.js';
 
 type CreateMethodOptions = {
   agentClass: new (options: any) => Web5ManagedAgent

--- a/packages/agent/src/types/agent.ts
+++ b/packages/agent/src/types/agent.ts
@@ -15,6 +15,7 @@ import { DidResolver } from '@web5/dids';
 import { DidManager } from '../did-manager.js';
 import { DwnManager } from '../dwn-manager.js';
 import { KeyManager } from '../key-manager.js';
+import { SyncManager } from '../sync-manager.js';
 import { AppDataStore } from '../app-data-store.js';
 import { IdentityManager } from '../identity-manager.js';
 
@@ -141,6 +142,7 @@ export interface Web5ManagedAgent extends Web5Agent {
   identityManager: IdentityManager;
   keyManager: KeyManager;
   rpcClient: DwnRpc;
+  syncManager: SyncManager;
 
   firstLaunch(): Promise<boolean>;
   initialize(options: { passphrase: string }): Promise<void>;

--- a/packages/agent/tests/dwn-manager.spec.ts
+++ b/packages/agent/tests/dwn-manager.spec.ts
@@ -7,6 +7,7 @@ import {
   RecordsRead,
   EventsGetReply,
   EventsGetMessage,
+  MessagesGetReply,
   RecordsReadReply,
   RecordsQueryReply,
   UnionMessageReply,
@@ -14,7 +15,6 @@ import {
   RecordsQueryMessage,
   RecordsWriteMessage,
   RecordsDeleteMessage,
-  MessagesGetReply,
   ProtocolsConfigureMessage,
 } from '@tbd54566975/dwn-sdk-js';
 

--- a/packages/agent/tests/fixtures/protocol-definitions/email.json
+++ b/packages/agent/tests/fixtures/protocol-definitions/email.json
@@ -1,0 +1,48 @@
+{
+  "protocol": "http://email-protocol.xyz",
+  "published": false,
+  "types": {
+    "email": {
+      "schema": "http://email-protocol.xyz/schema/email",
+      "dataFormats": ["text/plain"]
+    }
+  },
+  "structure": {
+    "email": {
+      "$actions": [
+        {
+          "who": "anyone",
+          "can": "write"
+        },
+        {
+          "who": "author",
+          "of": "email",
+          "can": "read"
+        },
+        {
+          "who": "recipient",
+          "of": "email",
+          "can": "read"
+        }
+      ],
+      "email": {
+        "$actions": [
+          {
+            "who": "anyone",
+            "can": "write"
+          },
+          {
+            "who": "author",
+            "of": "email/email",
+            "can": "read"
+          },
+          {
+            "who": "recipient",
+            "of": "email/email",
+            "can": "read"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/packages/agent/tests/sync-manager.spec.ts
+++ b/packages/agent/tests/sync-manager.spec.ts
@@ -43,7 +43,6 @@ describe('SyncManagerLevel', () => {
   describe('with Web5ManagedAgent', () => {
     let alice: ManagedIdentity;
     let aliceDid: PortableDid;
-    // let syncManager: SyncManagerLevel;
     let testAgent: TestManagedAgent;
 
     before(async () => {

--- a/packages/agent/tests/sync-manager.spec.ts
+++ b/packages/agent/tests/sync-manager.spec.ts
@@ -1,0 +1,221 @@
+import type { PortableDid } from '@web5/dids';
+
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+
+import type { ManagedIdentity } from '../src/identity-manager.js';
+
+import { testDwnUrl } from './test-config.js';
+import { TestAgent } from './utils/test-agent.js';
+import { SyncManager, SyncManagerLevel } from '../src/sync-manager.js';
+import { TestManagedAgent } from '../src/test-managed-agent.js';
+import { Convert } from '@web5/common';
+import { RecordsQueryReply, RecordsWriteMessage } from '@tbd54566975/dwn-sdk-js';
+
+let testDwnUrls: string[] = [testDwnUrl];
+
+describe.only('SyncManagerLevel', () => {
+  describe('get agent', () => {
+    it(`returns the 'agent' instance property`, async () => {
+      // @ts-expect-error because we are only mocking a single property.
+      const mockAgent: Web5ManagedAgent = {
+        agentDid: 'did:method:abc123'
+      };
+      const syncManager = new SyncManagerLevel({ agent: mockAgent });
+      const agent = syncManager.agent;
+      expect(agent).to.exist;
+      expect(agent.agentDid).to.equal('did:method:abc123');
+    });
+
+    it(`throws an error if the 'agent' instance property is undefined`, () => {
+      const syncManager = new SyncManagerLevel();
+      expect(() =>
+        syncManager.agent
+      ).to.throw(Error, 'Unable to determine agent execution context');
+    });
+  });
+
+  {
+    let alice: ManagedIdentity;
+    let aliceDid: PortableDid;
+    let syncManager: SyncManagerLevel;
+    let testAgent: TestManagedAgent;
+
+    before(async () => {
+      testAgent = await TestManagedAgent.create({
+        agentClass  : TestAgent,
+        agentStores : 'dwn'
+      });
+
+      syncManager = new SyncManagerLevel({
+        agent    : testAgent.agent,
+        dataPath : '__TESTDATA__/SYNC_STORE'
+      });
+    });
+
+    beforeEach(async () => {
+      await testAgent.clearStorage();
+      // @ts-ignore
+      await syncManager._db.clear();
+      await testAgent.createAgentDid();
+
+      // Create a new Identity to author the DWN messages.
+      ({ did: aliceDid } = await testAgent.createIdentity({ testDwnUrls }));
+      alice = await testAgent.agent.identityManager.import({
+        did      : aliceDid,
+        identity : { name: 'Alice', did: aliceDid.did },
+        kms      : 'local'
+      });
+    });
+
+    afterEach(async () => {
+      await testAgent.clearStorage();
+      // @ts-ignore
+      await syncManager._db.clear();
+    });
+
+    after(async () => {
+      await testAgent.clearStorage();
+      // @ts-ignore
+      await syncManager._db.clear();
+      // @ts-ignore
+      await syncManager._db.close();
+      await testAgent.closeStorage();
+    });
+
+    describe('push()', () => {
+      it('takes no action if no identities are registered', async () => {
+        const didResolveSpy = sinon.spy(testAgent.agent.didResolver, 'resolve');
+        const processRequestSpy = sinon.spy(testAgent.agent.dwnManager, 'processRequest');
+
+        await syncManager.push();
+
+        // Verify DID resolution and DWN requests did not occur.
+        expect(didResolveSpy.notCalled).to.be.true;
+        expect(processRequestSpy.notCalled).to.be.true;
+
+        didResolveSpy.restore();
+        processRequestSpy.restore();
+      });
+
+      it('synchronizes records for 1 identity from local DWN to remote DWN', async () => {
+        // Write a record that we can use for this test.
+        let writeResponse = await testAgent.agent.dwnManager.processRequest({
+          author         : alice.did,
+          target         : alice.did,
+          messageType    : 'RecordsWrite',
+          messageOptions : {
+            dataFormat: 'text/plain'
+          },
+          dataStream: new Blob(['Hello, world!'])
+        });
+
+        // Get the record ID of the test record.
+        const testRecordId = (writeResponse.message as RecordsWriteMessage).recordId;
+
+        // Confirm the record does NOT exist on Alice's remote DWN.
+        let queryResponse = await testAgent.agent.dwnManager.sendRequest({
+          author         : alice.did,
+          target         : alice.did,
+          messageType    : 'RecordsQuery',
+          messageOptions : { filter: { recordId: testRecordId } }
+        });
+        let remoteDwnQueryReply = queryResponse.reply as RecordsQueryReply;
+        expect(remoteDwnQueryReply.status.code).to.equal(200); // Query was successfully executed.
+        expect(remoteDwnQueryReply.entries).to.have.length(0); // Record doesn't exist on remote DWN.
+
+        // Register Alice's DID to be synchronized.
+        await syncManager.registerIdentity({
+          did: alice.did
+        });
+
+        // Execute Sync to push all records from Alice's local DWN to Alice's remote DWN.
+        await syncManager.push();
+
+        // Confirm the record now DOES exist on Alice's remote DWN.
+        queryResponse = await testAgent.agent.dwnManager.sendRequest({
+          author         : alice.did,
+          target         : alice.did,
+          messageType    : 'RecordsQuery',
+          messageOptions : { filter: { recordId: testRecordId } }
+        });
+        remoteDwnQueryReply = queryResponse.reply as RecordsQueryReply;
+        expect(remoteDwnQueryReply.status.code).to.equal(200); // Query was successfully executed.
+        expect(remoteDwnQueryReply.entries).to.have.length(1); // Record does exist on remote DWN.
+      });
+
+      it('synchronizes records for 2 identities from local DWN to remote DWN', async () => {
+        // Create a second Identity to author the DWN messages.
+        const { did: bobDid } = await testAgent.createIdentity({ testDwnUrls });
+        const bob = await testAgent.agent.identityManager.import({
+          did      : bobDid,
+          identity : { name: 'Bob', did: bobDid.did },
+          kms      : 'local'
+        });
+
+        // Write a test record to Alice's local DWN.
+        let writeResponse = await testAgent.agent.dwnManager.processRequest({
+          author         : alice.did,
+          target         : alice.did,
+          messageType    : 'RecordsWrite',
+          messageOptions : {
+            dataFormat: 'text/plain'
+          },
+          dataStream: new Blob(['Hello, Bob!'])
+        });
+
+        // Get the record ID of Alice's test record.
+        const testRecordIdAlice = (writeResponse.message as RecordsWriteMessage).recordId;
+
+        // Write a test record to Bob's local DWN.
+        writeResponse = await testAgent.agent.dwnManager.processRequest({
+          author         : bob.did,
+          target         : bob.did,
+          messageType    : 'RecordsWrite',
+          messageOptions : {
+            dataFormat: 'text/plain'
+          },
+          dataStream: new Blob(['Hello, Alice!'])
+        });
+
+        // Get the record ID of Bob's test record.
+        const testRecordIdBob = (writeResponse.message as RecordsWriteMessage).recordId;
+
+        // Register Alice's DID to be synchronized.
+        await syncManager.registerIdentity({
+          did: alice.did
+        });
+
+        // Register Bob's DID to be synchronized.
+        await syncManager.registerIdentity({
+          did: bob.did
+        });
+
+        // Execute Sync to push all records from Alice's and Bob's local DWNs to their remote DWNs.
+        await syncManager.push();
+
+        // Confirm the Alice test record exist on Alice's remote DWN.
+        let queryResponse = await testAgent.agent.dwnManager.sendRequest({
+          author         : alice.did,
+          target         : alice.did,
+          messageType    : 'RecordsQuery',
+          messageOptions : { filter: { recordId: testRecordIdAlice } }
+        });
+        let remoteDwnQueryReply = queryResponse.reply as RecordsQueryReply;
+        expect(remoteDwnQueryReply.status.code).to.equal(200); // Query was successfully executed.
+        expect(remoteDwnQueryReply.entries).to.have.length(1); // Record does exist on remote DWN.
+
+        // Confirm the Bob test record exist on Bob's remote DWN.
+        queryResponse = await testAgent.agent.dwnManager.sendRequest({
+          author         : bob.did,
+          target         : bob.did,
+          messageType    : 'RecordsQuery',
+          messageOptions : { filter: { recordId: testRecordIdBob } }
+        });
+        remoteDwnQueryReply = queryResponse.reply as RecordsQueryReply;
+        expect(remoteDwnQueryReply.status.code).to.equal(200); // Query was successfully executed.
+        expect(remoteDwnQueryReply.entries).to.have.length(1); // Record does exist on remote DWN.
+      });
+    });
+  }
+});

--- a/packages/agent/tests/sync-manager.spec.ts
+++ b/packages/agent/tests/sync-manager.spec.ts
@@ -7,14 +7,14 @@ import type { ManagedIdentity } from '../src/identity-manager.js';
 
 import { testDwnUrl } from './test-config.js';
 import { TestAgent } from './utils/test-agent.js';
-import { SyncManager, SyncManagerLevel } from '../src/sync-manager.js';
+import { SyncManagerLevel } from '../src/sync-manager.js';
 import { TestManagedAgent } from '../src/test-managed-agent.js';
-import { Convert } from '@web5/common';
+
 import { RecordsQueryReply, RecordsWriteMessage } from '@tbd54566975/dwn-sdk-js';
 
 let testDwnUrls: string[] = [testDwnUrl];
 
-describe.only('SyncManagerLevel', () => {
+describe('SyncManagerLevel', () => {
   describe('get agent', () => {
     it(`returns the 'agent' instance property`, async () => {
       // @ts-expect-error because we are only mocking a single property.
@@ -83,6 +83,143 @@ describe.only('SyncManagerLevel', () => {
       await testAgent.closeStorage();
     });
 
+    describe('pull()', () => {
+      it('takes no action if no identities are registered', async () => {
+        const didResolveSpy = sinon.spy(testAgent.agent.didResolver, 'resolve');
+        const sendDwnRequestSpy = sinon.spy(testAgent.agent.rpcClient, 'sendDwnRequest');
+
+
+        await syncManager.pull();
+
+        // Verify DID resolution and DWN requests did not occur.
+        expect(didResolveSpy.notCalled).to.be.true;
+        expect(sendDwnRequestSpy.notCalled).to.be.true;
+
+        didResolveSpy.restore();
+        sendDwnRequestSpy.restore();
+      });
+
+      it('synchronizes records for 1 identity from remove DWN to local DWN', async () => {
+        // Write a test record to Alice's remote DWN.
+        let writeResponse = await testAgent.agent.dwnManager.sendRequest({
+          author         : alice.did,
+          target         : alice.did,
+          messageType    : 'RecordsWrite',
+          messageOptions : {
+            dataFormat: 'text/plain'
+          },
+          dataStream: new Blob(['Hello, world!'])
+        });
+
+        // Get the record ID of the test record.
+        const testRecordId = (writeResponse.message as RecordsWriteMessage).recordId;
+
+        // Confirm the record does NOT exist on Alice's local DWN.
+        let queryResponse = await testAgent.agent.dwnManager.processRequest({
+          author         : alice.did,
+          target         : alice.did,
+          messageType    : 'RecordsQuery',
+          messageOptions : { filter: { recordId: testRecordId } }
+        });
+        let localDwnQueryReply = queryResponse.reply as RecordsQueryReply;
+        expect(localDwnQueryReply.status.code).to.equal(200); // Query was successfully executed.
+        expect(localDwnQueryReply.entries).to.have.length(0); // Record doesn't exist on local DWN.
+
+        // Register Alice's DID to be synchronized.
+        await syncManager.registerIdentity({
+          did: alice.did
+        });
+
+        // Execute Sync to pull all records from Alice's remote DWN to Alice's local DWN.
+        await syncManager.pull();
+
+        // Confirm the record now DOES exist on Alice's local DWN.
+        queryResponse = await testAgent.agent.dwnManager.processRequest({
+          author         : alice.did,
+          target         : alice.did,
+          messageType    : 'RecordsQuery',
+          messageOptions : { filter: { recordId: testRecordId } }
+        });
+        localDwnQueryReply = queryResponse.reply as RecordsQueryReply;
+        expect(localDwnQueryReply.status.code).to.equal(200); // Query was successfully executed.
+        expect(localDwnQueryReply.entries).to.have.length(1); // Record does exist on local DWN.
+      });
+
+
+      it('synchronizes records for multiple identities from remote DWN to local DWN', async () => {
+        // Create a second Identity to author the DWN messages.
+        const { did: bobDid } = await testAgent.createIdentity({ testDwnUrls });
+        const bob = await testAgent.agent.identityManager.import({
+          did      : bobDid,
+          identity : { name: 'Bob', did: bobDid.did },
+          kms      : 'local'
+        });
+
+        // Write a test record to Alice's remote DWN.
+        let writeResponse = await testAgent.agent.dwnManager.sendRequest({
+          author         : alice.did,
+          target         : alice.did,
+          messageType    : 'RecordsWrite',
+          messageOptions : {
+            dataFormat: 'text/plain'
+          },
+          dataStream: new Blob(['Hello, Bob!'])
+        });
+
+        // Get the record ID of Alice's test record.
+        const testRecordIdAlice = (writeResponse.message as RecordsWriteMessage).recordId;
+
+        // Write a test record to Bob's remote DWN.
+        writeResponse = await testAgent.agent.dwnManager.sendRequest({
+          author         : bob.did,
+          target         : bob.did,
+          messageType    : 'RecordsWrite',
+          messageOptions : {
+            dataFormat: 'text/plain'
+          },
+          dataStream: new Blob(['Hello, Alice!'])
+        });
+
+        // Get the record ID of Bob's test record.
+        const testRecordIdBob = (writeResponse.message as RecordsWriteMessage).recordId;
+
+        // Register Alice's DID to be synchronized.
+        await syncManager.registerIdentity({
+          did: alice.did
+        });
+
+        // Register Bob's DID to be synchronized.
+        await syncManager.registerIdentity({
+          did: bob.did
+        });
+
+        // Execute Sync to pull all records from Alice's and Bob's remove DWNs to their local DWNs.
+        await syncManager.pull();
+
+        // Confirm the Alice test record exist on Alice's local DWN.
+        let queryResponse = await testAgent.agent.dwnManager.processRequest({
+          author         : alice.did,
+          target         : alice.did,
+          messageType    : 'RecordsQuery',
+          messageOptions : { filter: { recordId: testRecordIdAlice } }
+        });
+        let localDwnQueryReply = queryResponse.reply as RecordsQueryReply;
+        expect(localDwnQueryReply.status.code).to.equal(200); // Query was successfully executed.
+        expect(localDwnQueryReply.entries).to.have.length(1); // Record does exist on local DWN.
+
+        // Confirm the Bob test record exist on Bob's local DWN.
+        queryResponse = await testAgent.agent.dwnManager.sendRequest({
+          author         : bob.did,
+          target         : bob.did,
+          messageType    : 'RecordsQuery',
+          messageOptions : { filter: { recordId: testRecordIdBob } }
+        });
+        localDwnQueryReply = queryResponse.reply as RecordsQueryReply;
+        expect(localDwnQueryReply.status.code).to.equal(200); // Query was successfully executed.
+        expect(localDwnQueryReply.entries).to.have.length(1); // Record does exist on local DWN.
+      });
+    });
+
     describe('push()', () => {
       it('takes no action if no identities are registered', async () => {
         const didResolveSpy = sinon.spy(testAgent.agent.didResolver, 'resolve');
@@ -144,7 +281,7 @@ describe.only('SyncManagerLevel', () => {
         expect(remoteDwnQueryReply.entries).to.have.length(1); // Record does exist on remote DWN.
       });
 
-      it('synchronizes records for 2 identities from local DWN to remote DWN', async () => {
+      it('synchronizes records for multiple identities from local DWN to remote DWN', async () => {
         // Create a second Identity to author the DWN messages.
         const { did: bobDid } = await testAgent.createIdentity({ testDwnUrls });
         const bob = await testAgent.agent.identityManager.import({

--- a/packages/agent/tests/sync-manager.spec.ts
+++ b/packages/agent/tests/sync-manager.spec.ts
@@ -207,7 +207,7 @@ describe('SyncManagerLevel', () => {
         localDwnQueryReply = queryResponse.reply as RecordsQueryReply;
         expect(localDwnQueryReply.status.code).to.equal(200); // Query was successfully executed.
         expect(localDwnQueryReply.entries).to.have.length(1); // Record does exist on local DWN.
-      });
+      }).timeout(5000);
     });
 
     describe('push()', () => {
@@ -342,7 +342,7 @@ describe('SyncManagerLevel', () => {
         remoteDwnQueryReply = queryResponse.reply as RecordsQueryReply;
         expect(remoteDwnQueryReply.status.code).to.equal(200); // Query was successfully executed.
         expect(remoteDwnQueryReply.entries).to.have.length(1); // Record does exist on remote DWN.
-      });
+      }).timeout(5000);
     });
   });
 });

--- a/packages/agent/tests/tsconfig.json
+++ b/packages/agent/tests/tsconfig.json
@@ -4,6 +4,7 @@
     "outDir": "compiled",
     "declarationDir": "compiled/types",
     "sourceMap": true,
+    "resolveJsonModule": true
   },
   "include": [
     "../src",

--- a/packages/agent/tests/utils/test-agent.ts
+++ b/packages/agent/tests/utils/test-agent.ts
@@ -24,6 +24,7 @@ import { KeyManager } from '../../src/key-manager.js';
 import { Web5RpcClient } from '../../src/rpc-client.js';
 import { AppDataVault } from '../../src/app-data-store.js';
 import { IdentityManager } from '../../src/identity-manager.js';
+import { SyncManager, SyncManagerLevel } from '../../src/sync-manager.js';
 
 type CreateMethodOptions = {
   testDataLocation?: string;
@@ -37,6 +38,7 @@ type TestAgentOptions = {
   identityManager: IdentityManager;
   keyManager: KeyManager;
   rpcClient: DwnRpc;
+  syncManager: SyncManager;
 
   dwn: Dwn;
   dwnDataStore: DataStoreLevel;
@@ -53,6 +55,7 @@ export class TestAgent implements Web5ManagedAgent {
   identityManager: IdentityManager;
   keyManager: KeyManager;
   rpcClient: DwnRpc;
+  syncManager: SyncManager;
 
   /**
    * DWN-related properties.
@@ -70,12 +73,14 @@ export class TestAgent implements Web5ManagedAgent {
     this.identityManager = options.identityManager;
     this.keyManager = options.keyManager;
     this.rpcClient = options.rpcClient;
+    this.syncManager = options.syncManager;
 
     // Set this agent to be the default agent for each component.
     this.didManager.agent = this;
     this.dwnManager.agent = this;
     this.identityManager.agent = this;
     this.keyManager.agent = this;
+    this.syncManager.agent = this;
 
     // TestAgent-specific properties.
     this.dwn = options.dwn;
@@ -137,6 +142,9 @@ export class TestAgent implements Web5ManagedAgent {
     // Instantiate an RPC Client.
     const rpcClient = new Web5RpcClient();
 
+    // Instantiate a SyncManager.
+    const syncManager = new SyncManagerLevel({ dataPath: testDataPath('SYNC_STORE') });
+
     return new TestAgent({
       appData,
       didManager,
@@ -148,7 +156,8 @@ export class TestAgent implements Web5ManagedAgent {
       dwnManager,
       identityManager,
       keyManager,
-      rpcClient
+      rpcClient,
+      syncManager
     });
   }
 

--- a/packages/api/tests/protocol.spec.ts
+++ b/packages/api/tests/protocol.spec.ts
@@ -1,0 +1,99 @@
+import type { PortableDid } from '@web5/dids';
+import type { ManagedIdentity } from '@web5/agent';
+
+import chai, { expect } from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import { TestManagedAgent } from '@web5/agent';
+
+import { DwnApi } from '../src/dwn-api.js';
+import { testDwnUrl } from './test-config.js';
+import { TestUserAgent } from './utils/test-user-agent.js';
+import emailProtocolDefinition from './fixtures/protocol-definitions/email.json' assert { type: 'json' };
+
+chai.use(chaiAsPromised);
+
+// NOTE: @noble/secp256k1 requires globalThis.crypto polyfill for node.js <=18: https://github.com/paulmillr/noble-secp256k1/blob/main/README.md#usage
+// Remove when we move off of node.js v18 to v20, earliest possible time would be Oct 2023: https://github.com/nodejs/release#release-schedule
+// NOTE: @noble/secp256k1 requires globalThis.crypto polyfill for node.js <=18: https://github.com/paulmillr/noble-secp256k1/blob/main/README.md#usage
+// Remove when we move off of node.js v18 to v20, earliest possible time would be Oct 2023: https://github.com/nodejs/release#release-schedule
+import { webcrypto } from 'node:crypto';
+// @ts-ignore
+if (!globalThis.crypto) globalThis.crypto = webcrypto;
+
+// TODO: Come up with a better way of resolving the TS errors.
+let testDwnUrls: string[] = [testDwnUrl];
+
+describe('Protocol', () => {
+  let dwn: DwnApi;
+  let alice: ManagedIdentity;
+  let aliceDid: PortableDid;
+  let testAgent: TestManagedAgent;
+
+  before(async () => {
+    testAgent = await TestManagedAgent.create({
+      agentClass  : TestUserAgent,
+      agentStores : 'memory'
+    });
+  });
+
+  beforeEach(async () => {
+    await testAgent.clearStorage();
+
+    // Create an Agent DID.
+    await testAgent.createAgentDid();
+
+    // Create a new Identity to author the DWN messages.
+    ({ did: aliceDid } = await testAgent.createIdentity({ testDwnUrls }));
+    alice = await testAgent.agent.identityManager.import({
+      did      : aliceDid,
+      identity : { name: 'Alice', did: aliceDid.did },
+      kms      : 'local'
+    });
+
+    // Instantiate DwnApi.
+    dwn = new DwnApi({ agent: testAgent.agent, connectedDid: alice.did });
+  });
+
+  after(async () => {
+    await testAgent.clearStorage();
+    await testAgent.closeStorage();
+  });
+
+  describe('send()', () => {
+    it('configures protocols on remote DWNs for your own DID', async () => {
+      // Alice configures a protocol on her agent connected DWN.
+      const { status: aliceEmailStatus, protocol: aliceEmailProtocol } = await dwn.protocols.configure({
+        message: {
+          definition: emailProtocolDefinition
+        }
+      });
+
+      expect(aliceEmailStatus.code).to.equal(202);
+      expect(aliceEmailProtocol.definition).to.deep.equal(emailProtocolDefinition);
+
+      // Attempt to configure the protocol on Alice's remote DWN.
+      const { status } = await aliceEmailProtocol.send(alice.did);
+      expect(status.code).to.equal(202);
+
+      // Query Alices's remote DWN for `email` schema records.
+      const aliceRemoteQueryResult = await dwn.protocols.query({
+        from    : alice.did,
+        message : {
+          filter: {
+            protocol: emailProtocolDefinition.protocol
+          }
+        }
+      });
+
+      expect(aliceRemoteQueryResult.status.code).to.equal(200);
+      expect(aliceRemoteQueryResult.protocols).to.exist;
+      expect(aliceRemoteQueryResult.protocols.length).to.equal(1);
+      const [ aliceRemoteEmailProtocol ] = aliceRemoteQueryResult.protocols;
+      expect(aliceRemoteEmailProtocol.definition).to.deep.equal(emailProtocolDefinition);
+    });
+  });
+
+  describe('toJSON()', () => {
+    xit('should return all defined properties');
+  });
+});

--- a/packages/api/tests/utils/test-user-agent.ts
+++ b/packages/api/tests/utils/test-user-agent.ts
@@ -11,6 +11,7 @@ import type {
   Web5ManagedAgent,
   ProcessDidRequest,
   ProcessDwnRequest,
+  SyncManager,
 } from '@web5/agent';
 
 import { Dwn } from '@tbd54566975/dwn-sdk-js';
@@ -31,6 +32,7 @@ import {
   AppDataVault,
   Web5RpcClient,
   IdentityManager,
+  SyncManagerLevel,
 } from '@web5/agent';
 
 type CreateMethodOptions = {
@@ -45,6 +47,7 @@ type TestUserAgentOptions = {
   identityManager: IdentityManager;
   keyManager: KeyManager;
   rpcClient: DwnRpc;
+  syncManager: SyncManager;
 
   dwn: Dwn;
   dwnDataStore: DataStoreLevel;
@@ -61,6 +64,7 @@ export class TestUserAgent implements Web5ManagedAgent {
   identityManager: IdentityManager;
   keyManager: KeyManager;
   rpcClient: DwnRpc;
+  syncManager: SyncManager;
 
   /**
    * DWN-related properties.
@@ -78,12 +82,14 @@ export class TestUserAgent implements Web5ManagedAgent {
     this.identityManager = options.identityManager;
     this.keyManager = options.keyManager;
     this.rpcClient = options.rpcClient;
+    this.syncManager = options.syncManager;
 
     // Set this agent to be the default agent for each component.
     this.didManager.agent = this;
     this.dwnManager.agent = this;
     this.identityManager.agent = this;
     this.keyManager.agent = this;
+    this.syncManager.agent = this;
 
     // TestUserAgent-specific properties.
     this.dwn = options.dwn;
@@ -143,6 +149,9 @@ export class TestUserAgent implements Web5ManagedAgent {
     // Instantiate an RPC Client.
     const rpcClient = new Web5RpcClient();
 
+    // Instantiate a SyncManager.
+    const syncManager = new SyncManagerLevel({ dataPath: testDataPath('SYNC_STORE')});
+
     return new TestUserAgent({
       appData,
       didManager,
@@ -155,6 +164,7 @@ export class TestUserAgent implements Web5ManagedAgent {
       identityManager,
       keyManager,
       rpcClient,
+      syncManager,
     });
   }
 

--- a/packages/dids/src/types.ts
+++ b/packages/dids/src/types.ts
@@ -112,7 +112,7 @@ export interface DidServiceEndpoint {
 }
 
 export interface DwnServiceEndpoint extends DidServiceEndpoint {
-  encryptionKeys: string[];
+  encryptionKeys?: string[];
   nodes: string[];
   signingKeys: string[];
 }

--- a/packages/dids/src/utils.ts
+++ b/packages/dids/src/utils.ts
@@ -113,7 +113,6 @@ export function isDwnServiceEndpoint(endpoint: string | DidServiceEndpoint | Did
   return endpoint !== undefined &&
     typeof endpoint !== 'string' &&
     !Array.isArray(endpoint) &&
-    'encryptionKeys' in endpoint &&
     'nodes' in endpoint &&
     'signingKeys' in endpoint;
 }

--- a/packages/identity-agent/src/identity-agent.ts
+++ b/packages/identity-agent/src/identity-agent.ts
@@ -3,6 +3,7 @@ import type {
   VcResponse,
   DidResponse,
   DwnResponse,
+  SyncManager,
   AppDataStore,
   SendVcRequest,
   SendDidRequest,
@@ -27,6 +28,7 @@ import {
   Web5RpcClient,
   IdentityManager,
   IdentityStoreDwn,
+  SyncManagerLevel,
   PrivateKeyStoreDwn,
   cryptoToPortableKeyPair,
 } from '@web5/agent';
@@ -40,6 +42,7 @@ export type IdentityAgentOptions = {
   identityManager: IdentityManager;
   keyManager: KeyManager;
   rpcClient: DwnRpc;
+  syncManager: SyncManager;
 }
 
 export class IdentityAgent implements Web5ManagedAgent {
@@ -51,6 +54,7 @@ export class IdentityAgent implements Web5ManagedAgent {
   identityManager: IdentityManager;
   keyManager: KeyManager;
   rpcClient: DwnRpc;
+  syncManager: SyncManager;
 
   constructor(options: IdentityAgentOptions) {
     this.agentDid = options.agentDid;
@@ -61,16 +65,21 @@ export class IdentityAgent implements Web5ManagedAgent {
     this.identityManager = options.identityManager;
     this.keyManager = options.keyManager;
     this.rpcClient = options.rpcClient;
+    this.syncManager = options.syncManager;
 
     // Set this agent to be the default agent.
     this.didManager.agent = this;
     this.dwnManager.agent = this;
     this.identityManager.agent = this;
     this.keyManager.agent = this;
+    this.syncManager.agent = this;
   }
 
   static async create(options: Partial<IdentityAgentOptions> = {}): Promise<IdentityAgent> {
-    let { agentDid, appData, didManager, didResolver, dwnManager, identityManager, keyManager, rpcClient } = options;
+    let {
+      agentDid, appData, didManager, didResolver, dwnManager,
+      identityManager, keyManager, rpcClient, syncManager
+    } = options;
 
     if (agentDid === undefined) {
       // An Agent DID was not specified, so set to empty string.
@@ -140,6 +149,12 @@ export class IdentityAgent implements Web5ManagedAgent {
       rpcClient = new Web5RpcClient();
     }
 
+    if (syncManager === undefined) {
+      // A custom SyncManager implementation was not specified, so
+      // instantiate a LevelDB-backed default.
+      syncManager = new SyncManagerLevel();
+    }
+
     // Instantiate the Identity Agent.
     const agent = new IdentityAgent({
       agentDid,
@@ -149,7 +164,8 @@ export class IdentityAgent implements Web5ManagedAgent {
       dwnManager,
       identityManager,
       keyManager,
-      rpcClient
+      rpcClient,
+      syncManager
     });
 
     return agent;


### PR DESCRIPTION
This PR will:
- Re-introduce [this sync implementation](https://github.com/TBD54566975/web5-js/blob/main/packages/old/web5-user-agent/src/sync-api.ts) to restore sync capability.
- Resolves an issue with the original sync implementation with cascading echoes that would occur due to random lexicographical ordering of sync jobs.  Unresolved is a single echo after a pull operation, which is tracked in Issue #207.
- Resolves Issue #95.
- Previously sync had no tests so basic tests have been added for `push()` and `pull()`.  Testing for more scenarios and edge cases is needed, which is tracked in Issue #206
- Temporarily adds utility methods to `DwnManager` that should be refactored as tracked in Issue #205.
- Adds `SyncManager` to the tests / test agents.
- Improves test coverage in the `@web5/agent` package for `DwnManager` handling `EventsGet`, `MessagesGet`, `ProtocolsConfigure`, and `ProtocolsQuery`.
- Adds test coverage in the `@web5/api` package for `Protocol`.