### PR TITLE
Bump package versions for first published 0.8.x release

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,14 @@ const { web5, did: myDid } = await Web5.connect();
 
 An object which may specify any of the following properties:
 
+- **`agent`** - _`Web5Agent instance`_ _(optional)_: an instance of a `Web5Agent` implementation. Defaults to creating a local `Web5UserAgent` if not provided.
+
+- **`appData`** - _`AppDataStore instance`_ _(optional)_: an instance of an `AppDataStore` implementation. Defaults to a LevelDB-backed store with an insecure, static unlock passphrase if not provided. To allow the end user to enter a secure passphrase of their choosing, provide an initialized `AppDataVault`.
+
+- **`connectedDid`** - _`string`_ _(optional)_: an existing DID to connect to.
+
+- **`sync`** - _`string`_ _(optional)_: enable or disable synchronization of DWN records between local and remote DWNs. Sync defaults to running every 2 minutes and can be set to any value accepted by [`ms`](https://www.npmjs.com/package/ms). To disable sync set to `'off'`.
+
 - **`techPreview`** - _`object`_ _(optional)_: an object that specifies configuration parameters that are relevant during the Tech Preview period of Web5 JS and may be deprecated in the future with advance notice.
 
   - **`dwnEndpoints`** - _`array`_ _(optional)_: a list of DWeb Node endpoints to define in the DID created and returned by `Web5.connect()`. If this property is omitted, during the Tech Preview two nodes will be included by default (e.g., `['https://dwn.tbddev.org/dwn0', 'https://dwn.tbddev.org/dwn3']`).

--- a/package-lock.json
+++ b/package-lock.json
@@ -8685,13 +8685,13 @@
     },
     "packages/agent": {
       "name": "@web5/agent",
-      "version": "0.1.7",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@tbd54566975/dwn-sdk-js": "0.2.1",
-        "@web5/common": "0.1.1",
-        "@web5/crypto": "0.1.6",
-        "@web5/dids": "0.1.9",
+        "@web5/common": "0.2.0",
+        "@web5/crypto": "0.2.0",
+        "@web5/dids": "0.2.0",
         "level": "8.0.0",
         "readable-stream": "4.4.2",
         "readable-web-to-node-stream": "3.0.2"
@@ -8731,14 +8731,14 @@
     },
     "packages/api": {
       "name": "@web5/api",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@tbd54566975/dwn-sdk-js": "0.2.1",
-        "@web5/agent": "0.1.7",
-        "@web5/crypto": "0.1.6",
-        "@web5/dids": "0.1.9",
-        "@web5/user-agent": "0.1.10",
+        "@web5/agent": "0.2.0",
+        "@web5/crypto": "0.2.0",
+        "@web5/dids": "0.2.0",
+        "@web5/user-agent": "0.2.0",
         "level": "8.0.0",
         "ms": "2.1.3",
         "readable-stream": "4.4.2",
@@ -8783,7 +8783,7 @@
     },
     "packages/common": {
       "name": "@web5/common",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "level": "8.0.0",
@@ -8855,13 +8855,13 @@
     },
     "packages/crypto": {
       "name": "@web5/crypto",
-      "version": "0.1.6",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/ciphers": "0.1.4",
         "@noble/curves": "1.1.0",
         "@noble/hashes": "1.3.1",
-        "@web5/common": "0.1.1"
+        "@web5/common": "0.2.0"
       },
       "devDependencies": {
         "@playwright/test": "1.36.2",
@@ -8901,13 +8901,13 @@
     },
     "packages/dids": {
       "name": "@web5/dids",
-      "version": "0.1.9",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@decentralized-identity/ion-pow-sdk": "1.0.17",
         "@decentralized-identity/ion-sdk": "1.0.1",
-        "@web5/common": "0.1.1",
-        "@web5/crypto": "0.1.6",
+        "@web5/common": "0.2.0",
+        "@web5/crypto": "0.2.0",
         "canonicalize": "2.0.0",
         "did-resolver": "4.1.0",
         "level": "8.0.0",
@@ -8949,11 +8949,11 @@
     },
     "packages/identity-agent": {
       "name": "@web5/identity-agent",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@web5/agent": "0.1.7",
-        "@web5/api": "0.8.0"
+        "@web5/agent": "0.2.0",
+        "@web5/api": "0.8.1"
       },
       "devDependencies": {
         "@playwright/test": "1.36.2",
@@ -8989,13 +8989,13 @@
     },
     "packages/proxy-agent": {
       "name": "@web5/proxy-agent",
-      "version": "0.1.10",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@web5/agent": "0.1.7",
-        "@web5/common": "0.1.1",
-        "@web5/crypto": "0.1.6",
-        "@web5/dids": "0.1.9"
+        "@web5/agent": "0.2.0",
+        "@web5/common": "0.2.0",
+        "@web5/crypto": "0.2.0",
+        "@web5/dids": "0.2.0"
       },
       "devDependencies": {
         "@playwright/test": "1.36.2",
@@ -9031,13 +9031,13 @@
     },
     "packages/user-agent": {
       "name": "@web5/user-agent",
-      "version": "0.1.10",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@web5/agent": "0.1.7",
-        "@web5/common": "0.1.1",
-        "@web5/crypto": "0.1.6",
-        "@web5/dids": "0.1.9"
+        "@web5/agent": "0.2.0",
+        "@web5/common": "0.2.0",
+        "@web5/crypto": "0.2.0",
+        "@web5/dids": "0.2.0"
       },
       "devDependencies": {
         "@playwright/test": "1.36.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -74,9 +74,9 @@
       }
     },
     "node_modules/@decentralized-identity/ion-sdk/node_modules/multiformats": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.0.tgz",
-      "integrity": "sha512-/qTOKKnU8nwcVURjRcS+UN0QYgdS5BPZzY10Aiciu2SqncyCVMGV8KtD83EBFmsuJDsSEmT4sGvzcTkCoMw0sQ==",
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.1.tgz",
+      "integrity": "sha512-GBSToTmri2vJYs8wqcZQ8kB21dCaeTOzHTIAlr8J06C1eL6UbzqURXFZ5Fl0EYm9GAFz1IlYY8SxGOs9G9NJRg==",
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
@@ -603,9 +603,9 @@
       }
     },
     "node_modules/@ipld/dag-cbor/node_modules/multiformats": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.0.tgz",
-      "integrity": "sha512-/qTOKKnU8nwcVURjRcS+UN0QYgdS5BPZzY10Aiciu2SqncyCVMGV8KtD83EBFmsuJDsSEmT4sGvzcTkCoMw0sQ==",
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.1.tgz",
+      "integrity": "sha512-GBSToTmri2vJYs8wqcZQ8kB21dCaeTOzHTIAlr8J06C1eL6UbzqURXFZ5Fl0EYm9GAFz1IlYY8SxGOs9G9NJRg==",
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
@@ -624,9 +624,9 @@
       }
     },
     "node_modules/@ipld/dag-pb/node_modules/multiformats": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.0.tgz",
-      "integrity": "sha512-/qTOKKnU8nwcVURjRcS+UN0QYgdS5BPZzY10Aiciu2SqncyCVMGV8KtD83EBFmsuJDsSEmT4sGvzcTkCoMw0sQ==",
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.1.tgz",
+      "integrity": "sha512-GBSToTmri2vJYs8wqcZQ8kB21dCaeTOzHTIAlr8J06C1eL6UbzqURXFZ5Fl0EYm9GAFz1IlYY8SxGOs9G9NJRg==",
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
@@ -750,9 +750,9 @@
       }
     },
     "node_modules/@multiformats/murmur3/node_modules/multiformats": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.0.tgz",
-      "integrity": "sha512-/qTOKKnU8nwcVURjRcS+UN0QYgdS5BPZzY10Aiciu2SqncyCVMGV8KtD83EBFmsuJDsSEmT4sGvzcTkCoMw0sQ==",
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.1.tgz",
+      "integrity": "sha512-GBSToTmri2vJYs8wqcZQ8kB21dCaeTOzHTIAlr8J06C1eL6UbzqURXFZ5Fl0EYm9GAFz1IlYY8SxGOs9G9NJRg==",
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
@@ -1132,9 +1132,9 @@
       "dev": true
     },
     "node_modules/@types/cors": {
-      "version": "2.8.13",
-      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.13.tgz",
-      "integrity": "sha512-RG8AStHlUiV5ysZQKq97copd2UmVYw3/pRMLefISZ3S1hK104Cwm7iLQ3fTKx+lsUH2CE8FlLaYeEA2LSeqYUA==",
+      "version": "2.8.14",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.14.tgz",
+      "integrity": "sha512-RXHUvNWYICtbP6s18PnOCaqToK8y14DnLd75c6HfyKf228dxy7pHNOQkxPtvXKp/hINFMDjbYzsj63nnpPMSRQ==",
       "dev": true,
       "dependencies": {
         "@types/node": "*"
@@ -1201,9 +1201,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.5.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.7.tgz",
-      "integrity": "sha512-dP7f3LdZIysZnmvP3ANJYTSwg+wLLl8p7RqniVlV7j+oXSXAbt9h0WIBFmJy5inWZoX9wZN6eXx+YXd9Rh3RBA=="
+      "version": "20.5.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.9.tgz",
+      "integrity": "sha512-PcGNd//40kHAS3sTlzKB9C9XL4K0sTup8nbG5lC14kzEteTNuAFh9u5nA0o5TWnSG2r/JNPRXFVcHJIIeRlmqQ=="
     },
     "node_modules/@types/readable-stream": {
       "version": "4.0.0",
@@ -2368,9 +2368,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001525",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001525.tgz",
-      "integrity": "sha512-/3z+wB4icFt3r0USMwxujAqRvaD/B7rvGTsKhbhSQErVrJvkZCLhgNLJxU8MevahQVH6hCU9FsHdNUFbiwmE7Q==",
+      "version": "1.0.30001527",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001527.tgz",
+      "integrity": "sha512-YkJi7RwPgWtXVSgK4lG9AHH57nSzvvOp9MesgXmw4Q7n0C3H04L0foHqfxcmSAm5AcWb8dW9AYj2tR7/5GnddQ==",
       "dev": true,
       "funding": [
         {
@@ -3097,9 +3097,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.507",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.507.tgz",
-      "integrity": "sha512-brvPFnO1lu3UYBpBht2qWw9qqhdG4htTjT90/9oOJmxQ77VvTxL9+ghErFqQzgj7n8268ONAmlebqjBR/S+qgA==",
+      "version": "1.4.508",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.508.tgz",
+      "integrity": "sha512-FFa8QKjQK/A5QuFr2167myhMesGrhlOBD+3cYNxO9/S4XzHEXesyTD/1/xF644gC8buFPz3ca6G1LOQD0tZrrg==",
       "dev": true,
       "peer": true
     },
@@ -4819,9 +4819,9 @@
       }
     },
     "node_modules/jackspeak": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-2.3.1.tgz",
-      "integrity": "sha512-4iSY3Bh1Htv+kLhiiZunUhQ+OYXIn0ze3ulq8JeWrFKmhPAJSySV2+kdtRh2pGcCeF0s6oR8Oc+pYZynJj4t8A==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-2.3.3.tgz",
+      "integrity": "sha512-R2bUw+kVZFS/h1AZqBKrSgDmdmjApzgY0AlCPumopFiAlbUxE2gf+SCuBzQ0cP5hHmUmFYF5yw55T97Th5Kstg==",
       "dev": true,
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
@@ -6275,9 +6275,9 @@
       }
     },
     "node_modules/npm-package-arg": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-11.0.0.tgz",
-      "integrity": "sha512-D8sItaQ8n6VlBUFed3DLz2sCpkabRAjaiLkTamDppvh8lmmAPirzNfBuhJd/2rlmoxZ2S9mOHmIEvzV2z2jOeA==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-11.0.1.tgz",
+      "integrity": "sha512-M7s1BD4NxdAvBKUPqqRW957Xwcl/4Zvo8Aj+ANrzvIPzGJZElrH7Z//rSaec2ORcND6FHHLnZeY8qgTpXDMFQQ==",
       "dev": true,
       "dependencies": {
         "hosted-git-info": "^7.0.0",
@@ -6433,9 +6433,9 @@
       }
     },
     "node_modules/p-queue": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-7.4.0.tgz",
-      "integrity": "sha512-1FYFpop2WjLUfhSpKb0pi01JL+Z+H0Z8F2XPn2g04WxGynU/X8mx8s/66fb7jZ39pS2ZliAWCX97EoTSIdMmtw==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-7.4.1.tgz",
+      "integrity": "sha512-vRpMXmIkYF2/1hLBKisKeVYJZ8S2tZ0zEAmIJgdVKP2nq0nh4qCdf8bgw+ZgKrkh71AOCaqzwbJJk1WtdcF3VA==",
       "dependencies": {
         "eventemitter3": "^5.0.1",
         "p-timeout": "^5.0.2"
@@ -7738,9 +7738,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.19.3",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.19.3.tgz",
-      "integrity": "sha512-pQzJ9UJzM0IgmT4FAtYI6+VqFf0lj/to58AV0Xfgg0Up37RyPG7Al+1cepC6/BVuAxR9oNb41/DL4DEoHJvTdg==",
+      "version": "5.19.4",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.19.4.tgz",
+      "integrity": "sha512-6p1DjHeuluwxDXcuT9VR8p64klWJKo1ILiy19s6C9+0Bh2+NWTX6nD9EPppiER4ICkHDVB1RkVpin/YW2nQn/g==",
       "dev": true,
       "peer": true,
       "dependencies": {
@@ -8098,9 +8098,9 @@
       }
     },
     "node_modules/uint8arrays/node_modules/multiformats": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.0.tgz",
-      "integrity": "sha512-/qTOKKnU8nwcVURjRcS+UN0QYgdS5BPZzY10Aiciu2SqncyCVMGV8KtD83EBFmsuJDsSEmT4sGvzcTkCoMw0sQ==",
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.1.tgz",
+      "integrity": "sha512-GBSToTmri2vJYs8wqcZQ8kB21dCaeTOzHTIAlr8J06C1eL6UbzqURXFZ5Fl0EYm9GAFz1IlYY8SxGOs9G9NJRg==",
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web5/agent",
-  "version": "0.1.7",
+  "version": "0.2.0",
   "type": "module",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
@@ -68,9 +68,9 @@
   },
   "dependencies": {
     "@tbd54566975/dwn-sdk-js": "0.2.1",
-    "@web5/common": "0.1.1",
-    "@web5/crypto": "0.1.6",
-    "@web5/dids": "0.1.9",
+    "@web5/common": "0.2.0",
+    "@web5/crypto": "0.2.0",
+    "@web5/dids": "0.2.0",
     "level": "8.0.0",
     "readable-stream": "4.4.2",
     "readable-web-to-node-stream": "3.0.2"

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -121,6 +121,14 @@ const { web5, did: myDid } = await Web5.connect();
 
 An object which may specify any of the following properties:
 
+- **`agent`** - _`Web5Agent instance`_ _(optional)_: an instance of a `Web5Agent` implementation. Defaults to creating a local `Web5UserAgent` if not provided.
+
+- **`appData`** - _`AppDataStore instance`_ _(optional)_: an instance of an `AppDataStore` implementation. Defaults to a LevelDB-backed store with an insecure, static unlock passphrase if not provided. To allow the end user to enter a secure passphrase of their choosing, provide an initialized `AppDataVault`.
+
+- **`connectedDid`** - _`string`_ _(optional)_: an existing DID to connect to.
+
+- **`sync`** - _`string`_ _(optional)_: enable or disable synchronization of DWN records between local and remote DWNs. Sync defaults to running every 2 minutes and can be set to any value accepted by [`ms`](https://www.npmjs.com/package/ms). To disable sync set to `'off'`.
+
 - **`techPreview`** - _`object`_ _(optional)_: an object that specifies configuration parameters that are relevant during the Tech Preview period of Web5 JS and may be deprecated in the future with advance notice.
 
   - **`dwnEndpoints`** - _`array`_ _(optional)_: a list of DWeb Node endpoints to define in the DID created and returned by `Web5.connect()`. If this property is omitted, during the Tech Preview two nodes will be included by default (e.g., `['https://dwn.tbddev.org/dwn0', 'https://dwn.tbddev.org/dwn3']`).

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web5/api",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "SDK for accessing the features and capabilities of Web5",
   "type": "module",
   "main": "./dist/cjs/index.js",
@@ -76,10 +76,10 @@
   },
   "dependencies": {
     "@tbd54566975/dwn-sdk-js": "0.2.1",
-    "@web5/agent": "0.1.7",
-    "@web5/crypto": "0.1.6",
-    "@web5/dids": "0.1.9",
-    "@web5/user-agent": "0.1.10",
+    "@web5/agent": "0.2.0",
+    "@web5/crypto": "0.2.0",
+    "@web5/dids": "0.2.0",
+    "@web5/user-agent": "0.2.0",
     "level": "8.0.0",
     "ms": "2.1.3",
     "readable-stream": "4.4.2",

--- a/packages/api/src/web5.ts
+++ b/packages/api/src/web5.ts
@@ -35,7 +35,7 @@ export type Web5ConnectOptions = {
   connectedDid?: string;
 
   /** Enable synchronization of DWN records between local and remote DWNs.
-   * Sync defaults to running every 2 minutes and get be set to any value accepted by `ms()`.
+   * Sync defaults to running every 2 minutes and can be set to any value accepted by `ms()`.
    * To disable sync set to 'off'. */
   sync?: string;
 

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web5/common",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "type": "module",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web5/crypto",
-  "version": "0.1.6",
+  "version": "0.2.0",
   "description": "TBD crypto library",
   "type": "module",
   "main": "./dist/cjs/index.js",
@@ -76,7 +76,7 @@
     "@noble/ciphers": "0.1.4",
     "@noble/curves": "1.1.0",
     "@noble/hashes": "1.3.1",
-    "@web5/common": "0.1.1"
+    "@web5/common": "0.2.0"
   },
   "devDependencies": {
     "@playwright/test": "1.36.2",

--- a/packages/dids/package.json
+++ b/packages/dids/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web5/dids",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "description": "TBD DIDs library",
   "type": "module",
   "main": "./dist/cjs/index.js",
@@ -76,8 +76,8 @@
   "dependencies": {
     "@decentralized-identity/ion-pow-sdk": "1.0.17",
     "@decentralized-identity/ion-sdk": "1.0.1",
-    "@web5/common": "0.1.1",
-    "@web5/crypto": "0.1.6",
+    "@web5/common": "0.2.0",
+    "@web5/crypto": "0.2.0",
     "canonicalize": "2.0.0",
     "did-resolver": "4.1.0",
     "level": "8.0.0",

--- a/packages/identity-agent/package.json
+++ b/packages/identity-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web5/identity-agent",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "type": "module",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
@@ -67,8 +67,8 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
-    "@web5/agent": "0.1.7",
-    "@web5/api": "0.8.0"
+    "@web5/agent": "0.2.0",
+    "@web5/api": "0.8.1"
   },
   "devDependencies": {
     "@playwright/test": "1.36.2",

--- a/packages/proxy-agent/package.json
+++ b/packages/proxy-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web5/proxy-agent",
-  "version": "0.1.10",
+  "version": "0.2.0",
   "type": "module",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
@@ -67,10 +67,10 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
-    "@web5/agent": "0.1.7",
-    "@web5/common": "0.1.1",
-    "@web5/crypto": "0.1.6",
-    "@web5/dids": "0.1.9"
+    "@web5/agent": "0.2.0",
+    "@web5/common": "0.2.0",
+    "@web5/crypto": "0.2.0",
+    "@web5/dids": "0.2.0"
   },
   "devDependencies": {
     "@playwright/test": "1.36.2",

--- a/packages/user-agent/package.json
+++ b/packages/user-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web5/user-agent",
-  "version": "0.1.10",
+  "version": "0.2.0",
   "type": "module",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
@@ -67,10 +67,10 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
-    "@web5/agent": "0.1.7",
-    "@web5/common": "0.1.1",
-    "@web5/crypto": "0.1.6",
-    "@web5/dids": "0.1.9"
+    "@web5/agent": "0.2.0",
+    "@web5/common": "0.2.0",
+    "@web5/crypto": "0.2.0",
+    "@web5/dids": "0.2.0"
   },
   "devDependencies": {
     "@playwright/test": "1.36.2",


### PR DESCRIPTION
This PR will:
- Bump package versions in preparation for 0.8.1 release.
- Update README files with new `Web5.connect()` options.