### PR TITLE
Updated README.md to improve import statements for crypto polyfills. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,9 @@ import "react-native-get-random-values";
 import { hmac } from "@noble/hashes/hmac";
 import { sha256 } from "@noble/hashes/sha256";
 import { sha512 } from "@noble/hashes/sha512";
+import * as ed from '@noble/ed25519';
+import * as secp from '@noble/secp256k1';
+
 ed.etc.sha512Sync = (...m) => sha512(ed.etc.concatBytes(...m));
 ed.etc.sha512Async = (...m) => Promise.resolve(ed.etc.sha512Sync(...m));
 


### PR DESCRIPTION
Added some missing steps in ReactNative crypto.getRandomValues polyfill and sha512. Assuming https://github.com/paulmillr/noble-ed25519#this-library-belongs-to-noble-crypto is reasonable as a reference point.