### PR TITLE
adding required property 'published' to protocols.configure example

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,7 @@ const { protocol } = await web5.dwn.protocols.configure({
   message: {
     definition: {
       protocol: "https://photos.org/protocol",
+      published: true,
       types: {
         album: {
           schema: "https://photos.org/protocol/album",

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -328,6 +328,7 @@ const { protocol } = await web5.dwn.protocols.configure({
   message: {
     definition: {
       protocol: "https://photos.org/protocol",
+      published: true,
       types: {
         album: {
           schema: "https://photos.org/protocol/album",


### PR DESCRIPTION
without the `published` property on a protocol definition, the following error occurs:

Error: /descriptor/definition: must have required property 'published'