### PR TITLE
Generate VUK with crypto.subtle

### DIFF
--- a/packages/agent/src/vuk-generator.ts
+++ b/packages/agent/src/vuk-generator.ts
@@ -1,0 +1,76 @@
+/** VUK Generation Options */
+export interface VukOptions {
+  /** The passphrase to use to generate the VUK */
+  passphrase: string;
+
+  /** The salt to use to generate the VUK */
+  salt: Uint8Array;
+
+  /** The key derivation work factor to use to generate the VUK */
+  keyDerivationWorkFactor: number;
+}
+
+/** Generates the VUK with Crypto Subtle if present, otherwise fallback to node:crypto */
+export const generateVaultUnlockKey = (options: VukOptions): Promise<Uint8Array> => {
+  if (crypto && typeof crypto.subtle === 'object' && crypto.subtle != null) {
+    return generateVaultUnlockKeyWithSubtleCrypto(options);
+  } else {
+    return generateVaultUnlockKeyWithNodeCrypto(options);
+  }
+};
+
+/** Generates the VUK with Crypto Subtle */
+export const generateVaultUnlockKeyWithSubtleCrypto = async (options: VukOptions): Promise<Uint8Array> => {
+  const { passphrase, salt, keyDerivationWorkFactor } = options;
+
+  const passwordBuffer = new TextEncoder().encode(passphrase);
+
+  const importedKey = await crypto.subtle.importKey(
+    'raw',
+    passwordBuffer,
+    'PBKDF2',
+    false,
+    ['deriveBits']
+  );
+
+  const vaultUnlockKey = await crypto.subtle.deriveBits(
+    {
+      name       : 'PBKDF2',
+      hash       : 'SHA-512',
+      salt       : salt,
+      iterations : keyDerivationWorkFactor,
+    },
+    importedKey,
+    32 * 8, // 32 bytes
+  );
+
+  return new Uint8Array(vaultUnlockKey);
+};
+
+/** Generates the VUK with node:crypto */
+export const generateVaultUnlockKeyWithNodeCrypto = async (options: VukOptions): Promise<Uint8Array> => {
+  const { passphrase, salt, keyDerivationWorkFactor } = options;
+
+  const { pbkdf2 } = await dynamicImports.getNodeCrypto();
+
+  return new Promise((resolve, reject) => {
+    pbkdf2(
+      passphrase,
+      salt,
+      keyDerivationWorkFactor,
+      32,
+      'sha512',
+      (err, derivedKey) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(new Uint8Array(derivedKey));
+        }
+      }
+    );
+  });
+};
+
+export const dynamicImports = {
+  getNodeCrypto: async () => await import('node:crypto'),
+};

--- a/packages/agent/tests/vuk-generator.spec.ts
+++ b/packages/agent/tests/vuk-generator.spec.ts
@@ -1,0 +1,80 @@
+import * as sinon from 'sinon';
+import chai, { expect } from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+
+import { sha512 } from '@noble/hashes/sha512';
+import { pbkdf2Async } from '@noble/hashes/pbkdf2';
+
+chai.use(chaiAsPromised);
+
+import {
+  generateVaultUnlockKey,
+  generateVaultUnlockKeyWithNodeCrypto,
+  generateVaultUnlockKeyWithSubtleCrypto,
+  dynamicImports,
+} from '../src/vuk-generator.js';
+
+const keyDerivationWorkFactor = 650_000;
+
+describe('VUK Generator', () => {
+  it('should use crypto subtle by default', async () => {
+    const subtleImportKeySpy = sinon.spy(crypto.subtle, 'importKey');
+    const subtleDeriveBitsSpy = sinon.spy(crypto.subtle, 'deriveBits');
+
+    const passphrase = 'dumbbell-krakatoa-ditty';
+    const salt = new Uint8Array(32);
+
+    const vuk = await generateVaultUnlockKey({
+      passphrase,
+      salt,
+      keyDerivationWorkFactor
+    });
+
+    expect(vuk.length).to.equal(32);
+
+    expect(subtleImportKeySpy.called).to.be.true;
+    expect(subtleDeriveBitsSpy.called).to.be.true;
+
+    subtleImportKeySpy.restore();
+    subtleDeriveBitsSpy.restore();
+  });
+
+  it('should fallback to node:crypto if subtle is not present', async () => {
+    sinon.stub(crypto, 'subtle').value(null);
+    const getNodeCrypto = sinon.spy(dynamicImports, 'getNodeCrypto');
+
+    const passphrase = 'dumbbell-krakatoa-ditty';
+    const salt = new Uint8Array(32);
+
+    const vuk = await generateVaultUnlockKey({ passphrase, salt, keyDerivationWorkFactor });
+    expect(vuk.length).to.equal(32);
+
+    expect(getNodeCrypto.called).to.be.true;
+
+    getNodeCrypto.restore();
+    sinon.restore();
+  });
+
+  it('vuks are the same regardless of algorithm', async () => {
+    const passphrase = 'dumbbell-krakatoa-ditty';
+    const salt = new Uint8Array(32);
+    const options = { passphrase, salt, keyDerivationWorkFactor: 10_000 };
+
+    const subtleVuk = await generateVaultUnlockKeyWithNodeCrypto(options);
+    const nodeCryptoVuk = await generateVaultUnlockKeyWithSubtleCrypto(options);
+    expect(subtleVuk).to.deep.equal(nodeCryptoVuk);
+
+    // asserts that the previously used noble algo matches too
+    const nobleVuk = await pbkdf2Async(
+      sha512,
+      passphrase,
+      salt,
+      {
+        c     : options.keyDerivationWorkFactor,
+        dkLen : 32
+      }
+    );
+
+    expect(nobleVuk).to.deep.equal(subtleVuk);
+  });
+});


### PR DESCRIPTION
## Problem
I'm experiencing a slow initialization of the `Web5.connect()` fn, to the point where the browser freezes for ~4-5 seconds.

It can be reproduced here: https://bucolic-cendol-324631.netlify.app/ -- just click in sign in and then press **Use Browser In-App** Agent. You will notice that the loading spinning animation even freezes while the connect is running. After being logged in you can also just refresh the page and you will notice how slow it takes to load the page, this is because if I recognize a session was initiated I just call `Web5.connect()` before rendering the page.

## Fix

I was debugging the `connect()` fn stepping each line and I narrowed it down to the [`AppDataVault#generateVaultUnlockKey()`](https://github.com/TBD54566975/web5-js/blob/main/packages/agent/src/app-data-store.ts#L146-L157).

From the conversation (link below) it seems that `@noble/hashes/pbkdf2` does not use the native browser crypto subtle which runs way faster. So I just did that.

I tested in my web5-music app and it reduces from 5 seconds to less than 2 seconds and it's non blocking now (the browser does not freeze).

## Reference
The whole context about this issue can be found in our Discord #web5 in [this conversation](https://discord.com/channels/937858703112155166/969272658501976117/1153777451013513257)