### PR TITLE
adding subscriptions to web5-js

### DIFF
--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -367,6 +367,7 @@ Request follows the following format:
     - `type?`: An optional event type. If not specified, assumes a `Records` event type.
     - `recordsFilter`: Mirrors the `RecordFilter` object in the dwn-sdk-js and has filters around records path. It may NOT be applied to other event types.
     - `protocolsFilter`: Mirrors the `ProtocolsFilter` object in the dwn-sdk-js and has filters around protocols path. It may NOT be applied to other event types.
+- **`options`** - Optional subscription configuration such as retry policies for the socket connection.
 - **`callback`** - The callback function you wish to apply on the incoming event. It takes in an `EventMessage` and returns a Promise.
 
 #### Response

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -319,6 +319,42 @@ The `delete` request object is composed as follows:
 - **`message`** - _`object`_: The properties of the DWeb Node Message Descriptor that will be used to construct a valid DWeb Node message.
   - **`recordId`** - _`string`_: the required record ID string that identifies the record being deleted.
 
+### **`web5.dwn.subscription.create(request)`**
+
+Method for subscribing to an event stream of a local or remote note. 
+Note: for remote servers, only a `WebSocket` connection is available.
+
+You MUST request a permission using the `Permissions` interface with a `SubscriptionRequest` 
+before getting access to a subscription. 
+
+The `subscription` request object is composed as follows:
+
+- **`target`** - _`DID string`_ (_optional_): The target DWN you want to sync with.
+- **`filter`** - The filtered scope that you wish to get. It MUST be scoped to a permission that has been scoped in the initial Permission scope.
+- **`callback`** - The callback function you wish to apply on the incoming event.
+
+```javascript
+const subscription = await web5.dwn.subscription.create(
+    target: "did:example:12345",
+    filter: {
+     "request": {
+        "filter": {
+           "type": "record",
+           "recordFilters": {
+                "protocolPath": "/my/protocol/path"
+             }
+         }
+      }
+   },
+   callback: (e: EventMessage) => {
+     console.log("I got a message!");
+   }
+})
+```
+
+Note, the `subscription` object also returns an event stream and a socket connection. 
+You may use that directly if that is your preference.
+
 ### **`web5.dwn.protocols.configure(request)`**
 
 Method for configuring a protocol definition in the DWeb Node of the user's local DWeb Node, remote DWeb Nodes, or another party's DWeb Nodes (if permitted).

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -337,14 +337,10 @@ The `subscription` request object is composed as follows:
 const subscription = await web5.dwn.subscription.create({
     target: "did:example:12345",
     filter: {
-     "request": {
-        "filter": {
-           "type": "record",
-           "recordFilters": {
-                "protocolPath": "/my/protocol/path"
-             }
-         }
-      }
+      "type": "record",
+      "recordFilters": {
+           "protocolPath": "/my/protocol/path"
+       }
    },
    callback: (e: EventMessage) => {
      console.log(`Received message: ${JSON.stringify(e)}`)

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -334,7 +334,7 @@ The `subscription` request object is composed as follows:
 - **`callback`** - The callback function you wish to apply on the incoming event.
 
 ```javascript
-const subscription = await web5.dwn.subscription.create(
+const subscription = await web5.dwn.subscription.create({
     target: "did:example:12345",
     filter: {
      "request": {
@@ -347,13 +347,42 @@ const subscription = await web5.dwn.subscription.create(
       }
    },
    callback: (e: EventMessage) => {
-     console.log("I got a message!");
+     console.log(`Received message: ${JSON.stringify(e)}`)
    }
 })
 ```
 
 Note, the `subscription` object also returns an event stream and a socket connection. 
 You may use that directly if that is your preference.
+
+A **`SubscriptionCreateResponse`** is returned, which contains an event stream associated with it. 
+You can listen in on the subscription, or perform additional operations (like sync) on it if needed.
+
+#### Request
+
+Request follows the following format:
+
+- **`target`** - _`DID string`_ (_optional_): The target DWN you want to sync with.
+- **`filter`** - The filtered scope that you wish to get. It MUST be scoped to a permission that has been scoped in the initial Permission scope. Filers MAY support many different filtration mechanisms depending on the event tyep provided.
+    - `type?`: An optional event type. If not specified, assumes a `Records` event type.
+    - `recordsFilter`: Mirrors the `RecordFilter` object in the dwn-sdk-js and has filters around records path. It may NOT be applied to other event types.
+    - `protocolsFilter`: Mirrors the `ProtocolsFilter` object in the dwn-sdk-js and has filters around protocols path. It may NOT be applied to other event types.
+- **`callback`** - The callback function you wish to apply on the incoming event. It takes in an `EventMessage` and returns a Promise.
+
+#### Response
+
+As a response, an SubscriptionCreateResponse is provided:
+
+- **`socket`** - _`DID string`_ (_optional_): The socket connection used for the subscription. You can call it directly if you need to close it out. `socket.close()`.
+- **`stream`** - The event stream of the messages. You can listen in on them with the `.on((e: EventMessage) => Promise<void>)` callback.
+- **`subscriptionId`** - An Optional subscription ID from the request returned by the dwn you are subscribing to over a server.
+- **`grantedFrom`** - The did of the source of the subscription
+- **`grantedTo`** - The did of the sink of the subscription 
+- **`attestation`** - The JWS attestation of the message.
+- **`filter`** - The filters applied to the subscription
+- **`error`**: - If not successful, a subscription error is provided as a boolean.
+- **`code`** - If not successful, a subscription error code is provided. Otherwise, 200 is returned.
+- **`message`** - If not successful, a subscription error message is provided.
 
 ### **`web5.dwn.protocols.configure(request)`**
 

--- a/packages/api/src/subscriptions.ts
+++ b/packages/api/src/subscriptions.ts
@@ -1,0 +1,40 @@
+import type { ProtocolsConfigure, SubscriptionRequest } from '@tbd54566975/dwn-sdk-js';
+
+import type { Web5Agent } from '@web5/agent';
+
+export type SubscriptionRequestMessage = SubscriptionRequest['message'];
+type SubscriptionMetadata = {
+  author: string;
+  messageCid?: string;
+};
+
+export class Subscription {
+  private _agent: Web5Agent;
+  private _metadata: SubscriptionMetadata;
+  private _subscriptionRequestMessage: SubscriptionRequestMessage;
+
+  get definition() {
+    return this._subscriptionRequestMessage.descriptor.definition;
+  }
+
+  constructor(agent: Web5Agent, subscriptionRequestMessage: SubscriptionRequestMessage, metadata: SubscriptionMetadata) {
+    this._agent = agent;
+    this._metadata = metadata;
+    this._subscriptionRequestMessage = subscriptionRequestMessage;
+  }
+
+  toJSON() {
+    return this._subscriptionRequestMessage;
+  }
+
+  async send(target: string) {
+    const { reply } = await this._agent.sendDwnRequest({
+      author      : this._metadata.author,
+      messageCid  : this._metadata.messageCid,
+      messageType : 'subscriptionRequest',
+      target      : target,
+    });
+
+    return { status: reply.status };
+  }
+}

--- a/packages/old/web5/tests/web5-dwn.spec.ts
+++ b/packages/old/web5/tests/web5-dwn.spec.ts
@@ -87,8 +87,8 @@ describe('web5.dwn', () => {
 
           // Query for the protocol just configured.
           const response = await dwn.protocols.query({
-            from    : bobDid,
-            message : {
+            from: bobDid,
+            message: {
               filter: {
                 protocol: 'https://doesnotexist.com/protocol'
               }
@@ -109,10 +109,10 @@ describe('web5.dwn', () => {
         it('writes a record with string data', async () => {
           const dataString = 'Hello, world!';
           const result = await dwn.records.write({
-            data    : dataString,
-            message : {
-              schema     : 'foo/bar',
-              dataFormat : 'text/plain'
+            data: dataString,
+            message: {
+              schema: 'foo/bar',
+              dataFormat: 'text/plain'
             }
           });
 
@@ -123,12 +123,12 @@ describe('web5.dwn', () => {
         });
 
         it('writes a record with JSON data', async () => {
-          const dataJson = { hello: 'world!'};
+          const dataJson = { hello: 'world!' };
           const result = await dwn.records.write({
-            data    : dataJson,
-            message : {
-              schema     : 'foo/bar',
-              dataFormat : 'application/json'
+            data: dataJson,
+            message: {
+              schema: 'foo/bar',
+              dataFormat: 'application/json'
             }
           });
 
@@ -143,11 +143,11 @@ describe('web5.dwn', () => {
         it('does not persist record to agent DWN', async () => {
           const dataString = 'Hello, world!';
           const writeResult = await dwn.records.write({
-            store   : false,
-            data    : dataString,
-            message : {
-              schema     : 'foo/bar',
-              dataFormat : 'text/plain'
+            store: false,
+            data: dataString,
+            message: {
+              schema: 'foo/bar',
+              dataFormat: 'text/plain'
             }
           });
 
@@ -172,11 +172,11 @@ describe('web5.dwn', () => {
         it('has no effect if `store: true`', async () => {
           const dataString = 'Hello, world!';
           const writeResult = await dwn.records.write({
-            store   : true,
-            data    : dataString,
-            message : {
-              schema     : 'foo/bar',
-              dataFormat : 'text/plain'
+            store: true,
+            data: dataString,
+            message: {
+              schema: 'foo/bar',
+              dataFormat: 'text/plain'
             }
           });
 
@@ -206,10 +206,10 @@ describe('web5.dwn', () => {
       describe('agent', () => {
         it('returns an array of records that match the filter provided', async () => {
           const writeResult = await dwn.records.write({
-            data    : 'Hello, world!',
-            message : {
-              schema     : 'foo/bar',
-              dataFormat : 'text/plain'
+            data: 'Hello, world!',
+            message: {
+              schema: 'foo/bar',
+              dataFormat: 'text/plain'
             }
           });
 
@@ -234,9 +234,9 @@ describe('web5.dwn', () => {
 
       describe('from: did', () => {
         it('returns empty records array when no records match the filter provided', async () => {
-        // // Write the record to the connected agent's DWN.
-        //   const { record, status } = await dwn.records.write({ data: 'hi' });
-        //   expect(status.code).to.equal(202);
+          // // Write the record to the connected agent's DWN.
+          //   const { record, status } = await dwn.records.write({ data: 'hi' });
+          //   expect(status.code).to.equal(202);
 
           // Create a new DID to represent an external entity who has a remote DWN server defined in their DID document.
           const ionCreateOptions = await testProfile.ionCreateOptions.services.dwn.authorization.keys();
@@ -244,8 +244,8 @@ describe('web5.dwn', () => {
 
           // Attempt to query Bob's DWN using the ID of a record that does not exist.
           const result = await dwn.records.query({
-            from    : bobDid,
-            message : {
+            from: bobDid,
+            message: {
               filter: {
                 recordId: 'abcd1234'
               }
@@ -264,10 +264,10 @@ describe('web5.dwn', () => {
       describe('agent', () => {
         it('returns a record', async () => {
           const writeResult = await dwn.records.write({
-            data    : 'Hello, world!',
-            message : {
-              schema     : 'foo/bar',
-              dataFormat : 'text/plain'
+            data: 'Hello, world!',
+            message: {
+              schema: 'foo/bar',
+              dataFormat: 'text/plain'
             }
           });
 
@@ -287,10 +287,10 @@ describe('web5.dwn', () => {
 
         it('returns a 404 when a record cannot be found', async () => {
           const writeResult = await dwn.records.write({
-            data    : 'Hello, world!',
-            message : {
-              schema     : 'foo/bar',
-              dataFormat : 'text/plain'
+            data: 'Hello, world!',
+            message: {
+              schema: 'foo/bar',
+              dataFormat: 'text/plain'
             }
           });
 
@@ -313,7 +313,7 @@ describe('web5.dwn', () => {
 
       describe('from: did', () => {
         it('returns undefined record when requested record does not exit', async () => {
-        // Generate a recordId that will not be present on the did endpoint being read from.
+          // Generate a recordId that will not be present on the did endpoint being read from.
           const { record, status } = await dwn.records.write({ data: 'hi' });
           expect(status.code).to.equal(202);
 
@@ -323,8 +323,8 @@ describe('web5.dwn', () => {
 
           // Attempt to read a record from Bob's DWN using the ID of a record that only exists in the connected agent's DWN.
           const result = await dwn.records.read({
-            from    : bobDid,
-            message : {
+            from: bobDid,
+            message: {
               recordId: record!.id
             }
           });
@@ -340,10 +340,10 @@ describe('web5.dwn', () => {
       describe('agent', () => {
         it('deletes a record', async () => {
           const writeResult = await dwn.records.write({
-            data    : 'Hello, world!',
-            message : {
-              schema     : 'foo/bar',
-              dataFormat : 'text/plain'
+            data: 'Hello, world!',
+            message: {
+              schema: 'foo/bar',
+              dataFormat: 'text/plain'
             }
           });
 
@@ -377,8 +377,8 @@ describe('web5.dwn', () => {
 
           // Attempt to delete a record from Bob's DWN specifying a recordId that does not exist.
           const deleteResult = await dwn.records.delete({
-            from    : bobDid,
-            message : {
+            from: bobDid,
+            message: {
               recordId: 'abcd1234'
             }
           });
@@ -390,4 +390,107 @@ describe('web5.dwn', () => {
       });
     });
   });
-});
+
+  describe('subscription', () => {
+    describe('create', () => {
+      describe('agent', () => {
+        it('create a subscription', async () => {
+          const dataString = 'Hello, world!';
+          const result = await dwn.records.write({
+            data: dataString,
+            message: {
+              schema: 'foo/bar',
+              dataFormat: 'text/plain'
+            }
+          });
+
+          expect(result.status.code).to.equal(202);
+          expect(result.status.detail).to.equal('Accepted');
+          expect(result.record).to.exist;
+          expect(await result.record?.data.text()).to.equal(dataString);
+        });
+      });
+
+      describe('agent store: false', () => {
+        it('does not persist subscription to agent DWN', async () => {
+          const dataString = 'Hello, world!';
+          const writeResult = await dwn.records.write({
+            store: false,
+            data: dataString,
+            message: {
+              schema: 'foo/bar',
+              dataFormat: 'text/plain'
+            }
+          });
+
+          expect(writeResult.status.code).to.equal(202);
+          expect(writeResult.status.detail).to.equal('Accepted');
+          expect(writeResult.record).to.exist;
+          expect(await writeResult.record?.data.text()).to.equal(dataString);
+
+          const queryResult = await dwn.records.query({
+            message: {
+              filter: {
+                schema: 'foo/bar'
+              }
+            }
+          });
+
+          expect(queryResult.status.code).to.equal(200);
+          expect(queryResult.records).to.exist;
+          expect(queryResult.records!.length).to.equal(0);
+        });
+      });
+    });
+
+    describe('query', () => {
+      describe('agent', () => {
+        it('returns subscriptions installed', async () => {
+        });
+      });
+
+      describe('read', () => {
+        describe('agent', () => {
+          it('returns a subscription record', async () => {
+            console.log('TODO')
+          });
+
+          it('returns a 404 when a subscription record cannot be found', async () => {
+            const writeResult = await dwn.records.write({
+              data: 'Hello, world!',
+              message: {
+                schema: 'foo/bar',
+                dataFormat: 'text/plain'
+              }
+            });
+
+            expect(writeResult.status.code).to.equal(202);
+            expect(writeResult.status.detail).to.equal('Accepted');
+            expect(writeResult.record).to.exist;
+
+            await writeResult.record!.delete();
+
+            const result = await dwn.records.read({
+              message: {
+                recordId: writeResult.record!.id
+              }
+            });
+
+            expect(result.status.code).to.equal(404);
+            expect(result.record).to.not.exist;
+          });
+        });
+      });
+
+      describe('delete', () => {
+        describe('agent', () => {
+          it('deletes a subscription record', async () => {
+            // TODO: 200
+          });
+
+          it('returns a 404 when the specified subscription record does not exist', async () => {
+            // TODO: 404
+          });
+        });
+      })
+    });


### PR DESCRIPTION
initial subscriptions PR. Do **NOT** merge, but used for transparency to show some of the API's and interfaces design for users when using the subscriptions interface. Open for feedback and discussion. Will have some updates in the near future.

See the documentation here: https://github.com/getZION/web5-js/tree/ask/subscription/packages/api#web5dwnsubscriptioncreaterequest for intended use.