### PR TITLE
sendDwnRequest returning web Readable

### DIFF
--- a/packages/agent/src/rpc-client.ts
+++ b/packages/agent/src/rpc-client.ts
@@ -4,6 +4,7 @@ import type { DwnRpc, DwnRpcRequest, DwnRpcResponse } from './types/agent.js';
 import { randomUuid } from '@web5/crypto/utils';
 
 import { createJsonRpcRequest, parseJson } from './json-rpc.js';
+import { webReadableToIsomorphicNodeReadable } from './utils.js';
 
 /**
  * Client used to communicate with Dwn Servers
@@ -88,7 +89,7 @@ class HttpDwnRpcClient implements DwnRpc {
         throw new Error(`failed to parse json rpc response. dwn url: ${request.dwnUrl}`);
       }
 
-      dataStream = resp.body;
+      dataStream = resp.body !== null ? webReadableToIsomorphicNodeReadable(resp.body) : resp.body;
       dwnRpcResponse = jsonRpcResponse;
     } else {
       // TODO: wonder if i need to try/catch this?

--- a/packages/agent/tests/dwn-manager.spec.ts
+++ b/packages/agent/tests/dwn-manager.spec.ts
@@ -16,6 +16,7 @@ import {
   RecordsWriteMessage,
   RecordsDeleteMessage,
   ProtocolsConfigureMessage,
+  DataStream,
 } from '@tbd54566975/dwn-sdk-js';
 
 import { testDwnUrl } from './test-config.js';
@@ -552,6 +553,51 @@ describe('DwnManager', () => {
 
         const { value } = await record.data.getReader().read();
         expect(dataBytes).to.eql(value);
+      });
+
+      it('handles RecordsWrite and RecordRead with large payload', async () => {
+        // Create test data to write.
+        const dataBytes = Array(10_000).fill('d').join('');
+
+        // Attempt to process the RecordsWrite
+        let writeResponse = await testAgent.agent.dwnManager.sendRequest({
+          author         : identity.did,
+          target         : identity.did,
+          messageType    : 'RecordsWrite',
+          messageOptions : {
+            dataFormat: 'text/plain'
+          },
+          dataStream: new Blob([dataBytes])
+        });
+
+        // Verify the response.
+        expect(writeResponse).to.have.property('message');
+        expect(writeResponse).to.have.property('messageCid');
+        expect(writeResponse).to.have.property('reply');
+
+        const writeMessage = writeResponse.message as RecordsWriteMessage;
+        expect(writeMessage).to.have.property('authorization');
+        expect(writeMessage).to.have.property('descriptor');
+        expect(writeMessage).to.have.property('recordId');
+
+        const writeReply = writeResponse.reply;
+        expect(writeReply).to.have.property('status');
+        expect(writeReply.status.code).to.equal(202);
+
+
+        const readResponse = await testAgent.agent.dwnManager.sendRequest({
+          author : identity.did,
+          target : identity.did,
+          messageType: 'RecordsRead',
+          messageOptions: { recordId: writeMessage.recordId }
+        });
+        expect(readResponse.reply.status.code).to.equal(200);
+        const reply = readResponse.reply as RecordsReadReply;
+        expect(reply.record).to.not.be.undefined;
+        expect(reply.record!.data).to.not.be.undefined;
+        const data = await DataStream.toBytes(reply.record!.data);
+        expect(data).to.eq(dataBytes);
+
       });
 
       it('throws an error when DwnRequest fails validation', async () => {


### PR DESCRIPTION
`DWNManager` has `sendRequest` and `processRequest` both return the `DwnResponse` type.

However `sendRequest` returns a web Readable as the `data` property while `processRequest` returns an isomorphic Readable.

This was causing confusion for me during testing as dealing with the data is different between the two.

I added some tests that around large data payloads in order to test data streams.