### PR TITLE
`Secp256k1` - disable malleability check when verifying

### DIFF
--- a/packages/crypto/src/crypto-primitives/secp256k1.ts
+++ b/packages/crypto/src/crypto-primitives/secp256k1.ts
@@ -311,8 +311,11 @@ export class Secp256k1 {
     const hashFunction = this.hashAlgorithms[hash];
     const digest = hashFunction(data);
 
-    // Verify operation.
-    const isValid = secp256k1.verify(signature, digest, key);
+    // Verify operation with malleability check disabled. Guaranteed support for low-s
+    // signatures across languages is unlikely especially in the context of SSI. 
+    // Notable Cloud KMS providers do not natively support it either. 
+    // low-s signatures are a requirement for Bitcoin
+    const isValid = secp256k1.verify(signature, digest, key, { lowS: false });
 
     return isValid;
   }

--- a/packages/crypto/src/crypto-primitives/secp256k1.ts
+++ b/packages/crypto/src/crypto-primitives/secp256k1.ts
@@ -312,8 +312,8 @@ export class Secp256k1 {
     const digest = hashFunction(data);
 
     // Verify operation with malleability check disabled. Guaranteed support for low-s
-    // signatures across languages is unlikely especially in the context of SSI. 
-    // Notable Cloud KMS providers do not natively support it either. 
+    // signatures across languages is unlikely especially in the context of SSI.
+    // Notable Cloud KMS providers do not natively support it either.
     // low-s signatures are a requirement for Bitcoin
     const isValid = secp256k1.verify(signature, digest, key, { lowS: false });
 


### PR DESCRIPTION
relevant context here: https://github.com/TBD54566975/web5-kt/pull/87

the best course of action may be to provide callers with the option to enable/disable the malleability check. Just didn't have the time to plumb this optionality down through the crypto algorithms interface. Wanted to get this PR out so that Verifiable Credential signature verification doesn't 💩 out for creds signed in environments that don't guarantee a `low-s` signature.

cc: @andresuribe87 