### PR TITLE
Expose DWN PermissionsGrant Message

### DIFF
--- a/packages/agent/src/types/agent.ts
+++ b/packages/agent/src/types/agent.ts
@@ -8,6 +8,7 @@ import type {
   RecordsDeleteMessage,
   ProtocolsQueryMessage,
   ProtocolsConfigureMessage,
+  GenericMessage,
 } from '@tbd54566975/dwn-sdk-js';
 
 import { DidResolver } from '@web5/dids';
@@ -57,7 +58,9 @@ export type ProcessDwnRequest = DwnRequest & {
   store?: boolean;
 };
 
-export type SendDwnRequest = DwnRequest & (ProcessDwnRequest | { messageCid: string })
+export type SendDwnRequest = DwnRequest & (
+  ProcessDwnRequest | { messageCid: string } | { message: GenericMessage, dataStream?: Blob | ReadableStream | Readable }
+);
 
 /**
  * TODO: add JSDoc

--- a/packages/api/src/dwn-api.ts
+++ b/packages/api/src/dwn-api.ts
@@ -1,6 +1,9 @@
 import type { DwnResponse, Web5Agent } from '@web5/agent';
 import {
   UnionMessageReply,
+  PermissionsGrant,
+  PermissionsGrantMessage,
+  PermissionsGrantOptions,
   RecordsReadOptions,
   RecordsQueryOptions,
   RecordsWriteMessage,
@@ -20,9 +23,6 @@ import { DwnInterfaceName, DwnMethodName } from '@tbd54566975/dwn-sdk-js';
 import { Record } from './record.js';
 import { Protocol } from './protocol.js';
 import { dataToBlob } from './utils.js';
-import { PermissionsGrant } from '@tbd54566975/dwn-sdk-js';
-import { PermissionsGrantMessage } from '@tbd54566975/dwn-sdk-js';
-import { PermissionsGrantOptions } from '@tbd54566975/dwn-sdk-js';
 
 export type PermissionsGrantRequest = {
   target?: string;
@@ -104,11 +104,6 @@ export type RecordsWriteRequest = {
   data: unknown;
   message?: Omit<Partial<RecordsWriteOptions>, 'authorizationSigner'>;
   store?: boolean;
-}
-
-export type PermissionGrantRequest = {
-  target?: string;
-  message?: Omit<Partial<PermissionsGrantOptions>, 'authorizationSigner'>;
 }
 
 export type RecordsWriteResponse = {

--- a/packages/api/tests/dwn-api.spec.ts
+++ b/packages/api/tests/dwn-api.spec.ts
@@ -577,7 +577,7 @@ describe('DwnApi', () => {
       it('returns a PermissionsGrant that can be invoked', async () => {
         const { did: bobDid } = await testAgent.createIdentity({ testDwnUrls });
 
-        const { status, permissionsGrant } = await dwn.permissions.grant({
+        const { status, permissionsGrant, permissionsGrantId } = await dwn.permissions.grant({
           message: {
             dateExpires : Temporal.Now.instant().toString({ smallestUnit: 'microseconds' }),
             grantedBy   : aliceDid.did,
@@ -585,13 +585,14 @@ describe('DwnApi', () => {
             grantedTo   : bobDid.did,
             scope       : {
               interface : DwnInterfaceName.Records,
-              method    : DwnMethodName.Read,
+              method    : DwnMethodName.Write,
             }
           },
         });
 
         expect(status.code).to.eq(202);
         expect(permissionsGrant).not.to.be.undefined;
+        expect(permissionsGrantId).not.to.be.undefined;
 
         // send to Alice's remote DWN
         const { status: statusSend } = await dwn.permissions.send(aliceDid.did, permissionsGrant);
@@ -600,8 +601,27 @@ describe('DwnApi', () => {
       });
     });
 
-    describe('target: did', () => {
+    describe('target: did', async () => {
+      it('returns a PermissionsGrant that can be invoked', async () => {
+        const { did: bobDid } = await testAgent.createIdentity({ testDwnUrls });
 
+        const { status, permissionsGrant } = await dwn.permissions.grant({
+          target  : bobDid.did,
+          message : {
+            dateExpires : Temporal.Now.instant().toString({ smallestUnit: 'microseconds' }),
+            grantedBy   : aliceDid.did,
+            grantedFor  : aliceDid.did,
+            grantedTo   : bobDid.did,
+            scope       : {
+              interface : DwnInterfaceName.Records,
+              method    : DwnMethodName.Write,
+            }
+          },
+        });
+
+        expect(status.code).to.eq(202);
+        expect(permissionsGrant).not.to.be.undefined;
+      });
     });
   });
 });


### PR DESCRIPTION
Minimum permissions interface to expose to unblock delegated permissions grants.

`dwn.permissions.send()` will be extended in a future PR to to send other `Permissions` interface messages.