### PR TITLE
Add PBKDF2 to `@web5/crypto`

### DIFF
--- a/packages/agent/src/types/managed-key.ts
+++ b/packages/agent/src/types/managed-key.ts
@@ -73,7 +73,7 @@ export type DeriveBitsOptions = {
   /**
    * An object defining the derivation algorithm to use and its parameters.
    */
-  algorithm: Web5Crypto.AlgorithmIdentifier | Web5Crypto.EcdhDeriveKeyOptions;
+  algorithm: Web5Crypto.AlgorithmIdentifier | Web5Crypto.EcdhDeriveKeyOptions | Web5Crypto.Pbkdf2Options;
 
   /**
    * An identifier of the ManagedKey that will be the input to the
@@ -228,7 +228,7 @@ export interface ManagedKey {
    * An object detailing the algorithm for which the key can be used along
    * with additional algorithm-specific parameters.
    */
-  algorithm: Web5Crypto.GenerateKeyOptions;
+  algorithm: Web5Crypto.KeyAlgorithm | Web5Crypto.GenerateKeyOptions;
 
   /**
    * An alternate identifier used to identify the key in a KMS.

--- a/packages/crypto/src/algorithms-api/crypto-key.ts
+++ b/packages/crypto/src/algorithms-api/crypto-key.ts
@@ -1,13 +1,13 @@
 import type { Web5Crypto } from '../types/web5-crypto.js';
 
 export class CryptoKey implements Web5Crypto.CryptoKey {
-  public algorithm: Web5Crypto.GenerateKeyOptions;
+  public algorithm: Web5Crypto.KeyAlgorithm | Web5Crypto.GenerateKeyOptions;
   public extractable: boolean;
   public material: Uint8Array;
   public type: Web5Crypto.KeyType;
   public usages: Web5Crypto.KeyUsage[];
 
-  constructor (algorithm: Web5Crypto.GenerateKeyOptions, extractable: boolean, material: Uint8Array, type: Web5Crypto.KeyType, usages: Web5Crypto.KeyUsage[]) {
+  constructor (algorithm: Web5Crypto.Algorithm | Web5Crypto.GenerateKeyOptions, extractable: boolean, material: Uint8Array, type: Web5Crypto.KeyType, usages: Web5Crypto.KeyUsage[]) {
     this.algorithm = algorithm;
     this.extractable = extractable;
     this.material = material;

--- a/packages/crypto/src/algorithms-api/index.ts
+++ b/packages/crypto/src/algorithms-api/index.ts
@@ -2,4 +2,5 @@ export * from './errors.js';
 export * from './ec/index.js';
 export * from './aes/index.js';
 export * from './crypto-key.js';
+export * from './pbkdf/index.js';
 export * from './crypto-algorithm.js';

--- a/packages/crypto/src/algorithms-api/pbkdf/index.ts
+++ b/packages/crypto/src/algorithms-api/pbkdf/index.ts
@@ -1,0 +1,1 @@
+export * from './pbkdf2.js';

--- a/packages/crypto/src/algorithms-api/pbkdf/pbkdf2.ts
+++ b/packages/crypto/src/algorithms-api/pbkdf/pbkdf2.ts
@@ -11,10 +11,7 @@ export abstract class BasePbkdf2Algorithm extends CryptoAlgorithm {
 
   public readonly abstract hashAlgorithms: string[];
 
-  public keyUsages: Web5Crypto.KeyPairUsage = {
-    privateKey : ['deriveBits', 'deriveKey'],
-    publicKey  : ['deriveBits', 'deriveKey'],
-  };
+  public readonly keyUsages: Web5Crypto.KeyUsage[] = ['deriveBits', 'deriveKey'];
 
   public checkAlgorithmOptions(options: {
     algorithm: Web5Crypto.Pbkdf2Options,
@@ -30,8 +27,8 @@ export abstract class BasePbkdf2Algorithm extends CryptoAlgorithm {
     // The algorithm object must contain a iterations property.
     checkRequiredProperty({ property: 'iterations', inObject: algorithm });
     // The iterations value must a number.
-    if (!(universalTypeOf(algorithm.salt) === 'Number')) {
-      throw new TypeError(`Algorithm 'salt' is not of type: Number.`);
+    if (!(universalTypeOf(algorithm.iterations) === 'Number')) {
+      throw new TypeError(`Algorithm 'iterations' is not of type: Number.`);
     }
     // The iterations value must be greater than 0.
     if (algorithm.iterations < 1) {

--- a/packages/crypto/src/algorithms-api/pbkdf/pbkdf2.ts
+++ b/packages/crypto/src/algorithms-api/pbkdf/pbkdf2.ts
@@ -1,0 +1,94 @@
+import type { Web5Crypto } from '../../types/web5-crypto.js';
+
+import { InvalidAccessError, OperationError } from '../errors.js';
+import { CryptoAlgorithm } from '../crypto-algorithm.js';
+import { checkRequiredProperty, checkValidProperty } from '../../utils.js';
+import { universalTypeOf } from '@web5/common';
+
+export abstract class BasePbkdf2Algorithm extends CryptoAlgorithm {
+
+  public readonly name: string = 'PBKDF2';
+
+  public readonly abstract hashAlgorithms: string[];
+
+  public keyUsages: Web5Crypto.KeyPairUsage = {
+    privateKey : ['deriveBits', 'deriveKey'],
+    publicKey  : ['deriveBits', 'deriveKey'],
+  };
+
+  public checkAlgorithmOptions(options: {
+    algorithm: Web5Crypto.Pbkdf2Options,
+    baseKey: Web5Crypto.CryptoKey
+  }): void {
+    const { algorithm, baseKey } = options;
+    // Algorithm specified in the operation must match the algorithm implementation processing the operation.
+    this.checkAlgorithmName({ algorithmName: algorithm.name });
+    // The algorithm object must contain a hash property.
+    checkRequiredProperty({ property: 'hash', inObject: algorithm });
+    // The hash algorithm specified must be supported by the algorithm implementation processing the operation.
+    checkValidProperty({ property: algorithm.hash, allowedProperties: this.hashAlgorithms });
+    // The algorithm object must contain a iterations property.
+    checkRequiredProperty({ property: 'iterations', inObject: algorithm });
+    // The iterations value must a number.
+    if (!(universalTypeOf(algorithm.salt) === 'Number')) {
+      throw new TypeError(`Algorithm 'salt' is not of type: Number.`);
+    }
+    // The iterations value must be greater than 0.
+    if (algorithm.iterations < 1) {
+      throw new OperationError(`Algorithm 'iterations' must be > 0.`);
+    }
+    // The algorithm object must contain a salt property.
+    checkRequiredProperty({ property: 'salt', inObject: algorithm });
+    // The salt must a Uint8Array.
+    if (!(universalTypeOf(algorithm.salt) === 'Uint8Array')) {
+      throw new TypeError(`Algorithm 'salt' is not of type: Uint8Array.`);
+    }
+    // The options object must contain a baseKey property.
+    checkRequiredProperty({ property: 'baseKey', inObject: options });
+    // The baseKey object must be a CryptoKey.
+    this.checkCryptoKey({ key: baseKey });
+    // The baseKey algorithm must match the algorithm implementation processing the operation.
+    this.checkKeyAlgorithm({ keyAlgorithmName: baseKey.algorithm.name });
+  }
+
+  public checkImportKey(options: {
+    algorithm: Web5Crypto.Algorithm,
+    format: Web5Crypto.KeyFormat,
+    extractable: boolean,
+    keyUsages: Web5Crypto.KeyUsage[]
+  }): void {
+    const { algorithm, format, extractable, keyUsages } = options;
+    // Algorithm specified in the operation must match the algorithm implementation processing the operation.
+    this.checkAlgorithmName({ algorithmName: algorithm.name });
+    // The format specified must be 'raw'.
+    if (format !== 'raw') {
+      throw new SyntaxError(`Format '${format}' not supported. Only 'raw' is supported.`);
+    }
+    // The extractable value specified must be false.
+    if (extractable !== false) {
+      throw new SyntaxError(`Extractable '${extractable}' not supported. Only 'false' is supported.`);
+    }
+    // The key usages specified must be permitted by the algorithm implementation processing the operation.
+    this.checkKeyUsages({ keyUsages, allowedKeyUsages: this.keyUsages });
+  }
+
+  public override async decrypt(): Promise<Uint8Array> {
+    throw new InvalidAccessError(`Requested operation 'decrypt' is not valid for ${this.name} keys.`);
+  }
+
+  public override async encrypt(): Promise<Uint8Array> {
+    throw new InvalidAccessError(`Requested operation 'encrypt' is not valid for ${this.name} keys.`);
+  }
+
+  public override async generateKey(): Promise<Web5Crypto.CryptoKey> {
+    throw new InvalidAccessError(`Requested operation 'generateKey' is not valid for ${this.name} keys.`);
+  }
+
+  public override async sign(): Promise<Uint8Array> {
+    throw new InvalidAccessError(`Requested operation 'sign' is not valid for ${this.name} keys.`);
+  }
+
+  public override async verify(): Promise<boolean> {
+    throw new InvalidAccessError(`Requested operation 'verify' is not valid for ${this.name} keys.`);
+  }
+}

--- a/packages/crypto/src/crypto-algorithms/index.ts
+++ b/packages/crypto/src/crypto-algorithms/index.ts
@@ -1,4 +1,5 @@
 export * from './ecdh.js';
 export * from './ecdsa.js';
 export * from './eddsa.js';
+export * from './pbkdf2.js';
 export * from './aes-ctr.js';

--- a/packages/crypto/src/crypto-algorithms/pbkdf2.ts
+++ b/packages/crypto/src/crypto-algorithms/pbkdf2.ts
@@ -1,0 +1,50 @@
+import type { Web5Crypto } from '../types/web5-crypto.js';
+
+import { BasePbkdf2Algorithm, CryptoKey, OperationError } from '../algorithms-api/index.js';
+import { Pbkdf2 } from '../crypto-primitives/pbkdf2.js';
+
+export class Pbkdf2Algorithm extends BasePbkdf2Algorithm {
+  public readonly hashAlgorithms = ['SHA-256', 'SHA-384', 'SHA-512'];
+
+  public async deriveBits(options: {
+    algorithm: Web5Crypto.Pbkdf2Options,
+    baseKey: Web5Crypto.CryptoKey,
+    length: number
+  }): Promise<Uint8Array> {
+    const { algorithm, baseKey, length } = options;
+
+    this.checkAlgorithmOptions({ algorithm, baseKey });
+    // The base key must be allowed to be used for deriveBits operations.
+    this.checkKeyUsages({ keyUsages: ['deriveBits'], allowedKeyUsages: baseKey.usages });
+    // If the length is not a multiple of 8, throw.
+    if (length && length % 8 !== 0) {
+      throw new OperationError(`To be compatible with all browsers, 'length' must be a multiple of 8.`);
+    }
+
+    const derivedBits = Pbkdf2.deriveKey({
+      hash       : algorithm.hash as 'SHA-256' | 'SHA-384' | 'SHA-512',
+      iterations : algorithm.iterations,
+      length     : length,
+      password   : baseKey.material,
+      salt       : algorithm.salt
+    });
+
+    return derivedBits;
+  }
+
+  public async importKey(options: {
+    format: Web5Crypto.KeyFormat,
+    keyData: Uint8Array,
+    algorithm: Web5Crypto.Algorithm,
+    extractable: boolean,
+    keyUsages: Web5Crypto.KeyUsage[]
+  }): Promise<Web5Crypto.CryptoKey> {
+    const { format, keyData, algorithm, extractable, keyUsages } = options;
+
+    this.checkImportKey({ algorithm, format, extractable, keyUsages });
+
+    const cryptoKey = new CryptoKey(algorithm, extractable, keyData, 'secret', keyUsages);
+
+    return cryptoKey;
+  }
+}

--- a/packages/crypto/src/crypto-algorithms/pbkdf2.ts
+++ b/packages/crypto/src/crypto-algorithms/pbkdf2.ts
@@ -16,6 +16,10 @@ export class Pbkdf2Algorithm extends BasePbkdf2Algorithm {
     this.checkAlgorithmOptions({ algorithm, baseKey });
     // The base key must be allowed to be used for deriveBits operations.
     this.checkKeyUsages({ keyUsages: ['deriveBits'], allowedKeyUsages: baseKey.usages });
+    // If the length is 0, throw.
+    if (typeof length !== 'undefined' && length === 0) {
+      throw new OperationError(`The value of 'length' cannot be zero.`);
+    }
     // If the length is not a multiple of 8, throw.
     if (length && length % 8 !== 0) {
       throw new OperationError(`To be compatible with all browsers, 'length' must be a multiple of 8.`);

--- a/packages/crypto/src/crypto-primitives/index.ts
+++ b/packages/crypto/src/crypto-primitives/index.ts
@@ -1,3 +1,4 @@
+export * from './pbkdf2.js';
 export * from './x25519.js';
 export * from './aes-ctr.js';
 export * from './aes-gcm.js';

--- a/packages/crypto/src/crypto-primitives/pbkdf2.ts
+++ b/packages/crypto/src/crypto-primitives/pbkdf2.ts
@@ -1,0 +1,80 @@
+import { crypto } from '@noble/hashes/crypto';
+
+import { isWebCryptoSupported } from '../utils.js';
+
+type DeriveKeyOptions = {
+  hash: 'SHA-256' | 'SHA-384' | 'SHA-512',
+  password: Uint8Array,
+  salt: Uint8Array,
+  iterations: number,
+  length: number
+};
+
+export class Pbkdf2 {
+  public static async deriveKey(options: DeriveKeyOptions): Promise<Uint8Array> {
+    if (isWebCryptoSupported()) {
+      return Pbkdf2.deriveKeyWithWebCrypto(options);
+    } else {
+      return Pbkdf2.deriveKeyWithNodeCrypto(options);
+    }
+  }
+
+  private static async deriveKeyWithNodeCrypto(options: DeriveKeyOptions): Promise<Uint8Array> {
+    const { password, salt, iterations } = options;
+
+    // Map the hash string to the node:crypto equivalent.
+    const hashToNodeCryptoMap = {
+      'SHA-256' : 'sha256',
+      'SHA-384' : 'sha384',
+      'SHA-512' : 'sha512'
+    };
+    const hash = hashToNodeCryptoMap[options.hash];
+
+    // Convert length from bits to bytes.
+    const length = options.length / 8;
+
+    // Dynamically import node:crypto.
+    const { pbkdf2 } = await import('node:crypto');
+
+    return new Promise((resolve, reject) => {
+      pbkdf2(
+        password,
+        salt,
+        iterations,
+        length,
+        hash,
+        (err, derivedKey) => {
+          if (err) {
+            reject(err);
+          } else {
+            resolve(new Uint8Array(derivedKey));
+          }
+        }
+      );
+    });
+  }
+
+  private static async deriveKeyWithWebCrypto(options: DeriveKeyOptions): Promise<Uint8Array> {
+    const { hash, password, salt, iterations, length } = options;
+
+    // Import the password as a raw key for use with the Web Crypto API.
+    const webCryptoKey = await crypto.subtle.importKey(
+      'raw',
+      password,
+      { name: 'PBKDF2' },
+      false,
+      ['deriveBits']
+    );
+
+    const derivedKeyBuffer = await crypto.subtle.deriveBits(
+      { name: 'PBKDF2', hash, salt, iterations },
+      webCryptoKey,
+      length
+    );
+
+    // Convert from ArrayBuffer to Uint8Array.
+    const derivedKey = new Uint8Array(derivedKeyBuffer);
+
+    return derivedKey;
+  }
+}

--- a/packages/crypto/src/crypto-primitives/pbkdf2.ts
+++ b/packages/crypto/src/crypto-primitives/pbkdf2.ts
@@ -33,10 +33,10 @@ export class Pbkdf2 {
     // Convert length from bits to bytes.
     const length = options.length / 8;
 
-    // Dynamically import node:crypto.
+    // Dynamically import the `crypto` package.
     const { pbkdf2 } = await import('node:crypto');
 
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve) => {
       pbkdf2(
         password,
         salt,
@@ -44,9 +44,7 @@ export class Pbkdf2 {
         length,
         hash,
         (err, derivedKey) => {
-          if (err) {
-            reject(err);
-          } else {
+          if (!err) {
             resolve(new Uint8Array(derivedKey));
           }
         }

--- a/packages/crypto/src/jose.ts
+++ b/packages/crypto/src/jose.ts
@@ -880,7 +880,7 @@ export class Jose {
   }
 
   public static webCryptoToJose(options:
-    Web5Crypto.GenerateKeyOptions
+    Web5Crypto.Algorithm | Web5Crypto.GenerateKeyOptions
   ): Partial<JsonWebKey> {
     const params: string[] = [];
 
@@ -900,7 +900,7 @@ export class Jose {
      * All symmetric encryption (AES) WebCrypto algorithms
      * set a value for the "length" parameter.
      */
-    } else if (options.length !== undefined) {
+    } else if ('length' in options && options.length !== undefined) {
       params.push(options.length.toString());
 
     /**

--- a/packages/crypto/src/types/web5-crypto.ts
+++ b/packages/crypto/src/types/web5-crypto.ts
@@ -21,7 +21,7 @@ export namespace Web5Crypto {
   export type AlgorithmIdentifier = Algorithm;
 
   export interface CryptoKey {
-    algorithm: Web5Crypto.GenerateKeyOptions;
+    algorithm: Web5Crypto.Algorithm;
     extractable: boolean;
     material: Uint8Array;
     type: KeyType;
@@ -64,6 +64,8 @@ export namespace Web5Crypto {
     name: string;
   }
 
+  export type KeyFormat = 'jwk' | 'pkcs8' | 'raw' | 'spki';
+
   export interface KeyPairUsage {
     privateKey: KeyUsage[];
     publicKey: KeyUsage[];
@@ -105,6 +107,12 @@ export namespace Web5Crypto {
   export type KeyUsage = 'encrypt' | 'decrypt' | 'sign' | 'verify' | 'deriveKey' | 'deriveBits' | 'wrapKey' | 'unwrapKey';
 
   export type NamedCurve = string;
+
+  export interface Pbkdf2Options extends Algorithm {
+    hash: string;
+    iterations: number;
+    salt: Uint8Array;
+  }
 
   export type PrivateKeyType = 'private' | 'secret';
 }

--- a/packages/crypto/src/utils.ts
+++ b/packages/crypto/src/utils.ts
@@ -88,6 +88,25 @@ export function keyToMultibaseId(options: {
   return multibaseKeyId;
 }
 
+export function isWebCryptoSupported(): boolean {
+  if (typeof window !== 'undefined' && window.crypto && window.crypto.subtle) {
+    // Web browser environment.
+    return true;
+  } else if (typeof global !== 'undefined' && global.crypto && global.crypto.subtle) {
+    // Node.js environment.
+    return true;
+  } else if (typeof self !== 'undefined' && self.crypto && self.crypto.subtle) {
+    // React Native environment.
+    return true;
+  } else if (typeof crypto !== 'undefined' && crypto.subtle) {
+    // Other environment (e.g. Web Worker).
+    return true;
+  } else {
+    // Web Crypto API is not supported.
+    return false;
+  }
+}
+
 export function multibaseIdToKey(options: {
   multibaseKeyId: string
 }): { key: Uint8Array, multicodecCode: number, multicodecName: string } {

--- a/packages/crypto/src/utils.ts
+++ b/packages/crypto/src/utils.ts
@@ -95,9 +95,6 @@ export function isWebCryptoSupported(): boolean {
   } else if (typeof global !== 'undefined' && global.crypto && global.crypto.subtle) {
     // Node.js environment.
     return true;
-  } else if (typeof self !== 'undefined' && self.crypto && self.crypto.subtle) {
-    // React Native environment.
-    return true;
   } else if (typeof crypto !== 'undefined' && crypto.subtle) {
     // Other environment (e.g. Web Worker).
     return true;

--- a/packages/crypto/src/utils.ts
+++ b/packages/crypto/src/utils.ts
@@ -88,18 +88,37 @@ export function keyToMultibaseId(options: {
   return multibaseKeyId;
 }
 
+/**
+ * Checks if the Web Crypto API is supported in the current runtime environment.
+ *
+ * The function uses `globalThis` to provide a universal reference to the global
+ * scope, regardless of the environment. `globalThis` is a standard feature introduced
+ * in ECMAScript 2020 that is agnostic to the underlying JavaScript environment, making
+ * the code portable across browser, Node.js, and Web Workers environments.
+ *
+ * In a web browser, `globalThis` is equivalent to the `window` object. In Node.js, it
+ * is equivalent to the `global` object, and in Web Workers, it corresponds to `self`.
+ *
+ * This method checks for the `crypto` object and its `subtle` property on the global scope
+ * to determine the availability of the Web Crypto API. If both are present, the API is
+ * supported; otherwise, it is not.
+ *
+ * @returns A boolean indicating whether the Web Crypto API is supported in the current environment.
+ *
+ * Example usage:
+ *
+ * ```ts
+ * if (isWebCryptoSupported()) {
+ *   console.log('Crypto operations can be performed');
+ * } else {
+ *   console.log('Crypto operations are not supported in this environment');
+ * }
+ * ```
+ */
 export function isWebCryptoSupported(): boolean {
-  if (typeof window !== 'undefined' && window.crypto && window.crypto.subtle) {
-    // Web browser environment.
-    return true;
-  } else if (typeof global !== 'undefined' && global.crypto && global.crypto.subtle) {
-    // Node.js environment.
-    return true;
-  } else if (typeof crypto !== 'undefined' && crypto.subtle) {
-    // Other environment (e.g. Web Worker).
+  if (globalThis.crypto && globalThis.crypto.subtle) {
     return true;
   } else {
-    // Web Crypto API is not supported.
     return false;
   }
 }

--- a/packages/crypto/tests/crypto-primitives.spec.ts
+++ b/packages/crypto/tests/crypto-primitives.spec.ts
@@ -1,5 +1,6 @@
 import type { BytesKeyPair } from '../src/types/crypto-key.js';
 
+import sinon from 'sinon';
 import chai, { expect } from 'chai';
 import { Convert } from '@web5/common';
 import chaiAsPromised from 'chai-as-promised';
@@ -13,6 +14,7 @@ import {
   AesGcm,
   ConcatKdf,
   Ed25519,
+  Pbkdf2,
   Secp256k1,
   X25519,
   XChaCha20,
@@ -521,6 +523,125 @@ describe('Cryptographic Primitive Implementations', () => {
         // Verification should return false with the public key from key pair A.
         isValid = await Ed25519.verify({ key: keyPairA.publicKey, signature: signatureB, data });
         expect(isValid).to.be.false;
+      });
+    });
+  });
+
+  describe('Pbkdf2', () => {
+    const password = Convert.string('password').toUint8Array();
+    const salt = Convert.string('salt').toUint8Array();
+    const iterations = 1;
+    const length = 256; // 32 bytes
+
+    describe('deriveKey', () => {
+      it('successfully derives a key using WebCrypto, if available', async () => {
+        const subtleDeriveBitsSpy = sinon.spy(crypto.subtle, 'deriveBits');
+
+        const derivedKey = await Pbkdf2.deriveKey({ hash: 'SHA-256', password, salt, iterations, length });
+
+        expect(derivedKey).to.be.instanceOf(Uint8Array);
+        expect(derivedKey.byteLength).to.equal(length / 8);
+        expect(subtleDeriveBitsSpy.called).to.be.true;
+
+        subtleDeriveBitsSpy.restore();
+      });
+
+      it('successfully derives a key using node:crypto when WebCrypto is not supported', async function () {
+        // Skip test in web browsers since node:crypto is not available.
+        if (typeof window !== 'undefined') this.skip();
+
+        // Ensure that WebCrypto is not available for this test.
+        sinon.stub(crypto, 'subtle').value(null);
+
+        // @ts-expect-error because we're spying on a private method.
+        const nodeCryptoDeriveKeySpy = sinon.spy(Pbkdf2, 'deriveKeyWithNodeCrypto');
+
+        const derivedKey = await Pbkdf2.deriveKey({ hash: 'SHA-256', password, salt, iterations, length });
+
+        expect(derivedKey).to.be.instanceOf(Uint8Array);
+        expect(derivedKey.byteLength).to.equal(length / 8);
+        expect(nodeCryptoDeriveKeySpy.called).to.be.true;
+
+        nodeCryptoDeriveKeySpy.restore();
+        sinon.restore();
+      });
+
+      it('derives the same value with node:crypto and WebCrypto', async function () {
+        // Skip test in web browsers since node:crypto is not available.
+        if (typeof window !== 'undefined') this.skip();
+
+        const options = { hash: 'SHA-256', password, salt, iterations, length };
+
+        // @ts-expect-error because we're testing a private method.
+        const webCryptoDerivedKey = await Pbkdf2.deriveKeyWithNodeCrypto(options);
+        // @ts-expect-error because we're testing a private method.
+        const nodeCryptoDerivedKey = await Pbkdf2.deriveKeyWithWebCrypto(options);
+
+        expect(webCryptoDerivedKey).to.deep.equal(nodeCryptoDerivedKey);
+      });
+
+      const hashFunctions: ('SHA-256' | 'SHA-384' | 'SHA-512')[] = ['SHA-256', 'SHA-384', 'SHA-512'];
+      hashFunctions.forEach(hash => {
+        it(`handles ${hash} hash function`, async () => {
+          const options = { hash, password, salt, iterations, length };
+
+          const derivedKey = await Pbkdf2.deriveKey(options);
+          expect(derivedKey).to.be.instanceOf(Uint8Array);
+          expect(derivedKey.byteLength).to.equal(length / 8);
+        });
+      });
+
+      it('throws an error when an invalid hash function is used with WebCrypto', async () => {
+        const options = {
+          hash: 'SHA-2' as const, password, salt, iterations, length
+        };
+
+        // @ts-expect-error for testing purposes
+        await expect(Pbkdf2.deriveKey(options)).to.eventually.be.rejectedWith(Error);
+      });
+
+      it('throws an error when an invalid hash function is used with node:crypto', async function () {
+        // Skip test in web browsers since node:crypto is not available.
+        if (typeof window !== 'undefined') this.skip();
+
+        // Ensure that WebCrypto is not available for this test.
+        sinon.stub(crypto, 'subtle').value(null);
+
+        const options = {
+          hash: 'SHA-2' as const, password, salt, iterations, length
+        };
+
+        // @ts-expect-error for testing purposes
+        await expect(Pbkdf2.deriveKey(options)).to.eventually.be.rejectedWith(Error);
+
+        sinon.restore();
+      });
+
+      it('throws an error when iterations count is not a positive number with WebCrypto', async () => {
+        const options = {
+          hash       : 'SHA-256' as const, password, salt,
+          iterations : -1, length
+        };
+
+        // Every browser throws a different error message so a specific message cannot be checked.
+        await expect(Pbkdf2.deriveKey(options)).to.eventually.be.rejectedWith(Error);
+      });
+
+      it('throws an error when iterations count is not a positive number with node:crypto', async function () {
+        // Skip test in web browsers since node:crypto is not available.
+        if (typeof window !== 'undefined') this.skip();
+
+        // Ensure that WebCrypto is not available for this test.
+        sinon.stub(crypto, 'subtle').value(null);
+
+        const options = {
+          hash       : 'SHA-256' as const, password, salt,
+          iterations : -1, length
+        };
+
+        await expect(Pbkdf2.deriveKey(options)).to.eventually.be.rejectedWith(Error, 'out of range');
+
+        sinon.restore();
       });
     });
   });

--- a/packages/crypto/tests/utils.spec.ts
+++ b/packages/crypto/tests/utils.spec.ts
@@ -1,7 +1,16 @@
 import { expect } from 'chai';
+import * as sinon from 'sinon';
 
 import { CryptoKey } from '../src/algorithms-api/crypto-key.js';
-import { checkValidProperty, checkRequiredProperty, isCryptoKeyPair, randomUuid, multibaseIdToKey, keyToMultibaseId } from '../src/utils.js';
+import {
+  randomUuid,
+  isCryptoKeyPair,
+  keyToMultibaseId,
+  multibaseIdToKey,
+  checkValidProperty,
+  isWebCryptoSupported,
+  checkRequiredProperty,
+} from '../src/utils.js';
 
 describe('Crypto Utils', () => {
   describe('checkValidProperty()', () => {
@@ -78,6 +87,24 @@ describe('Crypto Utils', () => {
 
       const result = isCryptoKeyPair(cryptoKey);
       expect(result).to.be.false;
+    });
+  });
+
+  describe('isWebCryptoSupported()', () => {
+    afterEach(() => {
+      // Restore the original state after each test
+      sinon.restore();
+    });
+
+    it('returns true if the Web Crypto API is supported', () => {
+      expect(isWebCryptoSupported()).to.be.true;
+    });
+
+    it('returns false if Web Crypto API is not supported', function () {
+      // Mock an unsupported environment
+      sinon.stub(globalThis, 'crypto').value({});
+
+      expect(isWebCryptoSupported()).to.be.false;
     });
   });
 


### PR DESCRIPTION
## PR Description

As noted by @leordev in PR #224 the [`@noble/hashes`](https://github.com/paulmillr/noble-hashes) implementation of PBKDF2 runs significantly slower than the native WebCrypto API and Node.js implementations.

I compared the average performance of the following implementations of PBKDF2:
-  `@noble/hashes` in both Node.js 18 and Chrome web browser
- WebCrypto API (aka "Subtle crypto") in the Chrome web browser
- `node:crypto` in Node.js 18

<img width="1356" alt="Screenshot 2023-11-06 at 8 44 28 AM" src="https://github.com/TBD54566975/web5-js/assets/134693/970107b2-8be7-412f-a3b1-ca50513800f7">


The performance difference is so drastic that I had to use log scale to even be able to see the `WebCrypto` and `node:crypto` values.  Even at a relatively modest (and unsafe) number of 100,000 iterations the `@noble` performance is 28 to 71 times slower.

At 500,000 iterations the `@noble` implementation is unusable, taking 3 to nearly 8 full seconds in web browser and Node.js, respectively.  Additionally, both @leordev and @csuwildcat have reported that it causes the browser to freeze and pause rendering.

Based on the great work done by @leordev in PR #224, this PR moves the PBKDF2 functionality into the `@web5/crypto` package, which enables it to be used both standalone and in a `CryptoManager` implementation.