### PR TITLE
Re-introduce `resolve` Method in `DidApi` for DID Resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,11 +59,11 @@ npm install @web5/api
 _CDNs_
 
 ```yaml
-https://unpkg.com/@web5/api@0.8.1/dist/browser.js
+https://unpkg.com/@web5/api@0.8.2/dist/browser.js
 ```
 
 ```yaml
-https://cdn.jsdelivr.net/npm/@web5/api@0.8.1/dist/browser.mjs
+https://cdn.jsdelivr.net/npm/@web5/api@0.8.2/dist/browser.mjs
 ```
 
 ## Usage
@@ -279,7 +279,7 @@ const { record } = await web5.dwn.records.read({
   message: {
     filter: {
       recordId: "bfw35evr6e54c4cqa4c589h4cq3v7w4nc534c9w7h5",
-    }
+    },
   },
 });
 
@@ -291,7 +291,7 @@ const { record } = await web5.dwn.records.read({
   message: {
     filter: {
       recordId: "bfw35evr6e54c4cqa4c589h4cq3v7w4nc534c9w7h5",
-    }
+    },
   },
 });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -372,8 +372,7 @@
     },
     "node_modules/@leichtgewicht/ip-codec": {
       "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz",
-      "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A=="
+      "license": "MIT"
     },
     "node_modules/@multiformats/base-x": {
       "version": "4.0.1",
@@ -740,8 +739,7 @@
     },
     "node_modules/@tbd54566975/dwn-sdk-js": {
       "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@tbd54566975/dwn-sdk-js/-/dwn-sdk-js-0.2.4.tgz",
-      "integrity": "sha512-d2/8o0sA+kNqyyFovReyviczABPyi5wPNuaS7oPojrmMDN2GC+okifF/rqr4qO393Dk/m07ngk8eXnPPk/oiMQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@ipld/dag-cbor": "9.0.3",
         "@js-temporal/polyfill": "0.4.4",
@@ -774,24 +772,21 @@
     },
     "node_modules/@tbd54566975/dwn-sdk-js/node_modules/cross-fetch": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.0.0.tgz",
-      "integrity": "sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==",
+      "license": "MIT",
       "dependencies": {
         "node-fetch": "^2.6.12"
       }
     },
     "node_modules/@tbd54566975/dwn-sdk-js/node_modules/lru-cache": {
       "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-9.1.2.tgz",
-      "integrity": "sha512-ERJq3FOzJTxBbFjZ7iDs+NiK4VI9Wz+RdrrAB8dio1oV+YvdPzUEE4QNiT2VD51DkIbCYRUUzCRkssXCHqSnKQ==",
+      "license": "ISC",
       "engines": {
         "node": "14 || >=16.14"
       }
     },
     "node_modules/@tbd54566975/dwn-sdk-js/node_modules/node-fetch": {
       "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -809,8 +804,7 @@
     },
     "node_modules/@tbd54566975/dwn-sdk-js/node_modules/readable-stream": {
       "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.4.0.tgz",
-      "integrity": "sha512-kDMOq0qLtxV9f/SQv522h8cxZBqNZXuXNyjyezmfAAuribMyVXziljpQ/uQhfE1XLg2/TLTW2DsnoE4VAi/krg==",
+      "license": "MIT",
       "dependencies": {
         "abort-controller": "^3.0.0",
         "buffer": "^6.0.3",
@@ -849,9 +843,8 @@
     },
     "node_modules/@types/dns-packet": {
       "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/@types/dns-packet/-/dns-packet-5.6.2.tgz",
-      "integrity": "sha512-vgUZ0ilYvpnTDx7tBmmAUn1HsyzK3huAtulHaDbBBCW5UdaDrEei5XJjWHnD4s8r9/MSL1hJ8s+nvJdcvNKgMA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
@@ -1550,8 +1543,7 @@
     },
     "node_modules/b4a": {
       "version": "1.6.4",
-      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.4.tgz",
-      "integrity": "sha512-fpWrvyVHEKyeEvbKZTVOeZF3VSKKWtJxFIxX/jaVPf+cLbGUSitjb49pHLqPV2BUNNZ0LcoeEGfE/YCpyDYHIw=="
+      "license": "ISC"
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -1560,8 +1552,7 @@
     },
     "node_modules/base64-arraybuffer": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
-      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6.0"
       }
@@ -1598,8 +1589,7 @@
     },
     "node_modules/bencode": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/bencode/-/bencode-3.1.1.tgz",
-      "integrity": "sha512-btsxX9201yoWh45TdqYg6+OZ5O1xTYKTYSGvJndICDFtznE/9zXgow8yjMvvhOqKKuzuL7h+iiCMpfkG8+QuBA==",
+      "license": "MIT",
       "dependencies": {
         "uint8-util": "^2.1.6"
       },
@@ -1617,8 +1607,6 @@
     },
     "node_modules/bittorrent-dht": {
       "version": "11.0.5",
-      "resolved": "https://registry.npmjs.org/bittorrent-dht/-/bittorrent-dht-11.0.5.tgz",
-      "integrity": "sha512-R09D6uNaziRqsc+B/j5QzkjceTak+wH9vcNLnkmt8A52EWF9lQwBP0vvCKgSA3AJOYYl+41n3osA2KYYn/z5uQ==",
       "funding": [
         {
           "type": "github",
@@ -1633,6 +1621,7 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "bencode": "^4.0.0",
         "debug": "^4.3.4",
@@ -1649,8 +1638,7 @@
     },
     "node_modules/bittorrent-dht/node_modules/bencode": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/bencode/-/bencode-4.0.0.tgz",
-      "integrity": "sha512-AERXw18df0pF3ziGOCyUjqKZBVNH8HV3lBxnx5w0qtgMIk4a1wb9BkcCQbkp9Zstfrn/dzRwl7MmUHHocX3sRQ==",
+      "license": "MIT",
       "dependencies": {
         "uint8-util": "^2.2.2"
       },
@@ -1681,8 +1669,7 @@
     },
     "node_modules/blake2b": {
       "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/blake2b/-/blake2b-2.1.4.tgz",
-      "integrity": "sha512-AyBuuJNI64gIvwx13qiICz6H6hpmjvYS5DGkG6jbXMOT8Z3WUJ3V1X0FlhIoT1b/5JtHE3ki+xjtMvu1nn+t9A==",
+      "license": "ISC",
       "dependencies": {
         "blake2b-wasm": "^2.4.0",
         "nanoassert": "^2.0.0"
@@ -1690,8 +1677,7 @@
     },
     "node_modules/blake2b-wasm": {
       "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/blake2b-wasm/-/blake2b-wasm-2.4.0.tgz",
-      "integrity": "sha512-S1kwmW2ZhZFFFOghcx73+ZajEfKBqhP82JMssxtLVMxlaPea1p9uoLiUZ5WYyHn0KddwbLc+0vh4wR0KBNoT5w==",
+      "license": "MIT",
       "dependencies": {
         "b4a": "^1.0.1",
         "nanoassert": "^2.0.0"
@@ -1848,9 +1834,8 @@
     },
     "node_modules/browserify-sign": {
       "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.2.tgz",
-      "integrity": "sha512-1rudGyeYY42Dk6texmv7c4VcQ0EsvVbLwZkA+AQB7SxvXxmcD93jcHie8bzecJ+ChDlmAm2Qyu0+Ccg5uhZXCg==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "bn.js": "^5.2.1",
         "browserify-rsa": "^4.1.0",
@@ -2157,8 +2142,7 @@
     },
     "node_modules/chacha20-universal": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/chacha20-universal/-/chacha20-universal-1.0.4.tgz",
-      "integrity": "sha512-/IOxdWWNa7nRabfe7+oF+jVkGjlr2xUL4J8l/OvzZhj+c9RpMqoo3Dq+5nU1j/BflRV4BKnaQ4+4oH1yBpQG1Q==",
+      "license": "ISC",
       "dependencies": {
         "nanoassert": "^2.0.0"
       }
@@ -2270,8 +2254,6 @@
     },
     "node_modules/chrome-dgram": {
       "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/chrome-dgram/-/chrome-dgram-3.0.6.tgz",
-      "integrity": "sha512-bqBsUuaOiXiqxXt/zA/jukNJJ4oaOtc7ciwqJpZVEaaXwwxqgI2/ZdG02vXYWUhHGziDlvGMQWk0qObgJwVYKA==",
       "funding": [
         {
           "type": "github",
@@ -2286,6 +2268,7 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.4",
         "run-series": "^1.1.9"
@@ -2293,16 +2276,13 @@
     },
     "node_modules/chrome-dns": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/chrome-dns/-/chrome-dns-1.0.1.tgz",
-      "integrity": "sha512-HqsYJgIc8ljJJOqOzLphjAs79EUuWSX3nzZi2LNkzlw3GIzAeZbaSektC8iT/tKvLqZq8yl1GJu5o6doA4TRbg==",
+      "license": "MIT",
       "dependencies": {
         "chrome-net": "^3.3.2"
       }
     },
     "node_modules/chrome-net": {
       "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/chrome-net/-/chrome-net-3.3.4.tgz",
-      "integrity": "sha512-Jzy2EnzmE+ligqIZUsmWnck9RBXLuUy6CaKyuNMtowFG3ZvLt8d+WBJCTPEludV0DHpIKjAOlwjFmTaEdfdWCw==",
       "funding": [
         {
           "type": "github",
@@ -2317,6 +2297,7 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.1"
       }
@@ -2808,8 +2789,7 @@
     },
     "node_modules/dns-packet": {
       "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.6.1.tgz",
-      "integrity": "sha512-l4gcSouhcgIKRvyy99RNVOgxXiicE+2jZoNmaNmZ6JXiGajBOJAesk1OBlJuM5k2c+eudGdLxDqXuPCKIj6kpw==",
+      "license": "MIT",
       "dependencies": {
         "@leichtgewicht/ip-codec": "^2.0.1"
       },
@@ -3892,8 +3872,7 @@
     },
     "node_modules/graceful-goodbye": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/graceful-goodbye/-/graceful-goodbye-1.3.0.tgz",
-      "integrity": "sha512-hcZOs20emYlTM7MmUE0FpuZcjlk2GPsR+UYTHDeWxtGjXcbh2CawGi8vlzqsIvspqAbot7mRv3sC/uhgtKc4hQ==",
+      "license": "MIT",
       "dependencies": {
         "safety-catch": "^1.0.2"
       }
@@ -4885,16 +4864,14 @@
     },
     "node_modules/k-bucket": {
       "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/k-bucket/-/k-bucket-5.1.0.tgz",
-      "integrity": "sha512-Fac7iINEovXIWU20GPnOMLUbjctiS+cnmyjC4zAUgvs3XPf1vo9akfCHkigftSic/jiKqKl+KA3a/vFcJbHyCg==",
+      "license": "MIT",
       "dependencies": {
         "randombytes": "^2.1.0"
       }
     },
     "node_modules/k-rpc": {
       "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/k-rpc/-/k-rpc-5.1.0.tgz",
-      "integrity": "sha512-FGc+n70Hcjoa/X2JTwP+jMIOpBz+pkRffHnSl9yrYiwUxg3FIgD50+u1ePfJUOnRCnx6pbjmVk5aAeB1wIijuQ==",
+      "license": "MIT",
       "dependencies": {
         "k-bucket": "^5.0.0",
         "k-rpc-socket": "^1.7.2",
@@ -4903,8 +4880,7 @@
     },
     "node_modules/k-rpc-socket": {
       "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/k-rpc-socket/-/k-rpc-socket-1.11.1.tgz",
-      "integrity": "sha512-8xtA8oqbZ6v1Niryp2/g4GxW16EQh5MvrUylQoOG+zcrDff5CKttON2XUXvMwlIHq4/2zfPVFiinAccJ+WhxoA==",
+      "license": "MIT",
       "dependencies": {
         "bencode": "^2.0.0",
         "chrome-dgram": "^3.0.2",
@@ -4914,8 +4890,7 @@
     },
     "node_modules/k-rpc-socket/node_modules/bencode": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/bencode/-/bencode-2.0.3.tgz",
-      "integrity": "sha512-D/vrAD4dLVX23NalHwb8dSvsUsxeRPO8Y7ToKA015JQYq69MLDOMkC0uGZYA/MPpltLO8rt8eqFC2j8DxjTZ/w=="
+      "license": "MIT"
     },
     "node_modules/karma": {
       "version": "6.4.1",
@@ -5300,8 +5275,7 @@
     },
     "node_modules/last-one-wins": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/last-one-wins/-/last-one-wins-1.0.4.tgz",
-      "integrity": "sha512-t+KLJFkHPQk8lfN6WBOiGkiUXoub+gnb2XTYI2P3aiISL+94xgZ1vgz1SXN/N4hthuOoLXarXfBZPUruyjQtfA=="
+      "license": "MIT"
     },
     "node_modules/layerr": {
       "version": "2.0.1",
@@ -5493,8 +5467,7 @@
     },
     "node_modules/lru": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/lru/-/lru-3.1.0.tgz",
-      "integrity": "sha512-5OUtoiVIGU4VXBOshidmtOsvBIvcQR6FD/RzWSvaeHyxCGB+PCUCu+52lqMfdc0h/2CLvHhZS4TwUmMQrrMbBQ==",
+      "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.1"
       },
@@ -5963,8 +5936,7 @@
     },
     "node_modules/nanoassert": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/nanoassert/-/nanoassert-2.0.0.tgz",
-      "integrity": "sha512-7vO7n28+aYO4J+8w96AzhmU8G+Y/xpPDJz/se19ICsqj/momRbb9mh9ZUtkoJ5X3nTnPdhEJyc0qnM6yAsHBaA=="
+      "license": "ISC"
     },
     "node_modules/nanoid": {
       "version": "3.3.6",
@@ -6498,8 +6470,7 @@
     },
     "node_modules/pkarr": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/pkarr/-/pkarr-1.1.1.tgz",
-      "integrity": "sha512-X27LKqf83X3WuJd2Z9qdfVxkmfOu6HUbY0pm11LqeBbFmgmZRPgOxJG8bKiIsmmD6Vjc25j45KHYflF2lfodyQ==",
+      "license": "MIT",
       "dependencies": {
         "bencode": "^3.0.3",
         "bittorrent-dht": "^11.0.4",
@@ -6515,8 +6486,7 @@
     },
     "node_modules/pkarr/node_modules/chalk": {
       "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
-      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+      "license": "MIT",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -6835,8 +6805,7 @@
     },
     "node_modules/record-cache": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/record-cache/-/record-cache-1.2.0.tgz",
-      "integrity": "sha512-kyy3HWCez2WrotaL3O4fTn0rsIdfRKOdQQcEJ9KpvmKmbffKVvwsloX063EgRUlpJIXHiDQFhJcTbZequ2uTZw==",
+      "license": "MIT",
       "dependencies": {
         "b4a": "^1.3.1"
       }
@@ -7032,8 +7001,6 @@
     },
     "node_modules/run-series": {
       "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/run-series/-/run-series-1.1.9.tgz",
-      "integrity": "sha512-Arc4hUN896vjkqCYrUXquBFtRZdv1PfLbTYP71efP6butxyQ0kWpiNJyAgsxscmQg1cqvHY32/UCBzXedTpU2g==",
       "funding": [
         {
           "type": "github",
@@ -7047,7 +7014,8 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "license": "MIT"
     },
     "node_modules/safe-array-concat": {
       "version": "1.0.0",
@@ -7092,8 +7060,7 @@
     },
     "node_modules/safety-catch": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/safety-catch/-/safety-catch-1.0.2.tgz",
-      "integrity": "sha512-C1UYVZ4dtbBxEtvOcpjBaaD27nP8MlvyAQEp2fOTOEe6pfUpk1cDUxij6BR1jZup6rSyUTaBBplK7LanskrULA=="
+      "license": "MIT"
     },
     "node_modules/schema-utils": {
       "version": "3.3.0",
@@ -7201,8 +7168,7 @@
     },
     "node_modules/sha256-universal": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/sha256-universal/-/sha256-universal-1.2.1.tgz",
-      "integrity": "sha512-ghn3muhdn1ailCQqqceNxRgkOeZSVfSE13RQWEg6njB+itsFzGVSJv+O//2hvNXZuxVIRyNzrgsZ37SPDdGJJw==",
+      "license": "ISC",
       "dependencies": {
         "b4a": "^1.0.1",
         "sha256-wasm": "^2.2.1"
@@ -7210,8 +7176,7 @@
     },
     "node_modules/sha256-wasm": {
       "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/sha256-wasm/-/sha256-wasm-2.2.2.tgz",
-      "integrity": "sha512-qKSGARvao+JQlFiA+sjJZhJ/61gmW/3aNLblB2rsgIxDlDxsJPHo8a1seXj12oKtuHVgJSJJ7QEGBUYQN741lQ==",
+      "license": "ISC",
       "dependencies": {
         "b4a": "^1.0.1",
         "nanoassert": "^2.0.0"
@@ -7219,8 +7184,7 @@
     },
     "node_modules/sha512-universal": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/sha512-universal/-/sha512-universal-1.2.1.tgz",
-      "integrity": "sha512-kehYuigMoRkIngCv7rhgruLJNNHDnitGTBdkcYbCbooL8Cidj/bS78MDxByIjcc69M915WxcQTgZetZ1JbeQTQ==",
+      "license": "ISC",
       "dependencies": {
         "b4a": "^1.0.1",
         "sha512-wasm": "^2.3.1"
@@ -7228,8 +7192,7 @@
     },
     "node_modules/sha512-wasm": {
       "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/sha512-wasm/-/sha512-wasm-2.3.4.tgz",
-      "integrity": "sha512-akWoxJPGCB3aZCrZ+fm6VIFhJ/p8idBv7AWGFng/CZIrQo51oQNsvDbTSRXWAzIiZJvpy16oIDiCCPqTe21sKg==",
+      "license": "ISC",
       "dependencies": {
         "b4a": "^1.0.1",
         "nanoassert": "^2.0.0"
@@ -7304,8 +7267,7 @@
     },
     "node_modules/siphash24": {
       "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/siphash24/-/siphash24-1.3.1.tgz",
-      "integrity": "sha512-moemC3ZKiTzH29nbFo3Iw8fbemWWod4vNs/WgKbQ54oEs6mE6XVlguxvinYjB+UmaE0PThgyED9fUkWvirT8hA==",
+      "license": "MIT",
       "dependencies": {
         "nanoassert": "^2.0.0"
       }
@@ -7357,8 +7319,7 @@
     },
     "node_modules/sodium-javascript": {
       "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/sodium-javascript/-/sodium-javascript-0.8.0.tgz",
-      "integrity": "sha512-rEBzR5mPxPES+UjyMDvKPIXy9ImF17KOJ32nJNi9uIquWpS/nfj+h6m05J5yLJaGXjgM72LmQoUbWZVxh/rmGg==",
+      "license": "MIT",
       "dependencies": {
         "blake2b": "^2.1.1",
         "chacha20-universal": "^1.0.4",
@@ -7371,17 +7332,15 @@
     },
     "node_modules/sodium-native": {
       "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-4.0.4.tgz",
-      "integrity": "sha512-faqOKw4WQKK7r/ybn6Lqo1F9+L5T6NlBJJYvpxbZPetpWylUVqz449mvlwIBKBqxEHbWakWuOlUt8J3Qpc4sWw==",
       "hasInstallScript": true,
+      "license": "MIT",
       "dependencies": {
         "node-gyp-build": "^4.6.0"
       }
     },
     "node_modules/sodium-universal": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/sodium-universal/-/sodium-universal-4.0.0.tgz",
-      "integrity": "sha512-iKHl8XnBV96k1c75gwwzANFdephw/MDWSjQAjPmBE+du0y3P23Q8uf7AcdcfFsYAMwLg7WVBfSAIBtV/JvRsjA==",
+      "license": "MIT",
       "dependencies": {
         "blake2b": "^2.1.1",
         "chacha20-universal": "^1.0.4",
@@ -8140,8 +8099,7 @@
     },
     "node_modules/uint8-util": {
       "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/uint8-util/-/uint8-util-2.2.4.tgz",
-      "integrity": "sha512-uEI5lLozmKQPYEevfEhP9LY3Je5ZmrQhaWXrzTVqrLNQl36xsRh8NiAxYwB9J+2BAt99TRbmCkROQB2ZKhx4UA==",
+      "license": "MIT",
       "dependencies": {
         "base64-arraybuffer": "^1.0.2"
       }
@@ -8630,8 +8588,7 @@
     },
     "node_modules/xsalsa20": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/xsalsa20/-/xsalsa20-1.2.0.tgz",
-      "integrity": "sha512-FIr/DEeoHfj7ftfylnoFt3rAIRoWXpx2AoDfrT2qD2wtp7Dp+COajvs/Icb7uHqRW9m60f5iXZwdsJJO3kvb7w=="
+      "license": "MIT"
     },
     "node_modules/xtend": {
       "version": "4.0.2",
@@ -8743,8 +8700,7 @@
     },
     "node_modules/z32": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/z32/-/z32-1.0.1.tgz",
-      "integrity": "sha512-Uytfqf6VEVchHKZDw0NRdCViOARHP84uzvOw0CXCMLOwhgHZUL9XibpEPLLQN10mCVLxOlGCQWbkV7km7yNYcw==",
+      "license": "MIT",
       "dependencies": {
         "b4a": "^1.5.3"
       }
@@ -8756,7 +8712,7 @@
       "dependencies": {
         "@tbd54566975/dwn-sdk-js": "0.2.4",
         "@web5/common": "0.2.1",
-        "@web5/crypto": "0.2.1",
+        "@web5/crypto": "0.2.2",
         "@web5/dids": "0.2.2",
         "level": "8.0.0",
         "readable-stream": "4.4.2",
@@ -8802,7 +8758,7 @@
       "dependencies": {
         "@tbd54566975/dwn-sdk-js": "0.2.4",
         "@web5/agent": "0.2.3",
-        "@web5/crypto": "0.2.1",
+        "@web5/crypto": "0.2.2",
         "@web5/dids": "0.2.2",
         "@web5/user-agent": "0.2.3",
         "level": "8.0.0",
@@ -8903,7 +8859,7 @@
         "@typescript-eslint/eslint-plugin": "6.4.0",
         "@typescript-eslint/parser": "6.4.0",
         "@web5/common": "0.2.1",
-        "@web5/crypto": "0.2.1",
+        "@web5/crypto": "0.2.2",
         "@web5/dids": "0.2.2",
         "c8": "8.0.1",
         "chai": "4.3.10",
@@ -8936,7 +8892,7 @@
     },
     "packages/crypto": {
       "name": "@web5/crypto",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/ciphers": "0.1.4",
@@ -8988,7 +8944,7 @@
         "@decentralized-identity/ion-pow-sdk": "1.0.17",
         "@decentralized-identity/ion-sdk": "1.0.1",
         "@web5/common": "0.2.1",
-        "@web5/crypto": "0.2.1",
+        "@web5/crypto": "0.2.2",
         "did-resolver": "4.1.0",
         "dns-packet": "5.6.1",
         "level": "8.0.0",
@@ -9078,7 +9034,7 @@
       "dependencies": {
         "@web5/agent": "0.2.3",
         "@web5/common": "0.2.1",
-        "@web5/crypto": "0.2.1",
+        "@web5/crypto": "0.2.2",
         "@web5/dids": "0.2.2"
       },
       "devDependencies": {
@@ -9120,7 +9076,7 @@
       "dependencies": {
         "@web5/agent": "0.2.3",
         "@web5/common": "0.2.1",
-        "@web5/crypto": "0.2.1",
+        "@web5/crypto": "0.2.2",
         "@web5/dids": "0.2.2"
       },
       "devDependencies": {

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -69,7 +69,7 @@
   "dependencies": {
     "@tbd54566975/dwn-sdk-js": "0.2.4",
     "@web5/common": "0.2.1",
-    "@web5/crypto": "0.2.1",
+    "@web5/crypto": "0.2.2",
     "@web5/dids": "0.2.2",
     "level": "8.0.0",
     "readable-stream": "4.4.2",

--- a/packages/agent/src/did-manager.ts
+++ b/packages/agent/src/did-manager.ts
@@ -12,8 +12,8 @@ import type {
 import { Jose} from '@web5/crypto';
 import { utils } from '@web5/dids';
 
-import type { Web5ManagedAgent } from './types/agent.js';
 import type { ManagedDidStore } from './store-managed-did.js';
+import type { DidRequest, DidResponse, Web5ManagedAgent } from './types/agent.js';
 
 import { DidStoreMemory } from './store-managed-did.js';
 
@@ -28,6 +28,11 @@ export type CreateDidOptions<M extends keyof CreateDidMethodOptions> = CreateDid
   context?: string;
   kms?: string;
   metadata?: DidMetadata;
+}
+
+export enum DidMessage {
+  Create  = 'Create',
+  Resolve = 'Resolve',
 }
 
 export type ImportDidOptions = {
@@ -318,6 +323,21 @@ export class DidManager {
     }
 
     return keySet;
+  }
+
+  public async processRequest(request: DidRequest): Promise<DidResponse> {
+    const { messageOptions, messageType, store: _ } = request;
+
+    switch (messageType) {
+      case DidMessage.Create: {
+        const result = await this.create(messageOptions);
+        return { result };
+        break;
+      }
+      default: {
+        throw new Error(`DidManager: Unsupported request type: ${messageType}`);
+      }
+    }
   }
 
   /**

--- a/packages/agent/src/dwn-manager.ts
+++ b/packages/agent/src/dwn-manager.ts
@@ -1,11 +1,11 @@
 import {
+  Signer,
   GenericMessage,
   MessagesGetReply,
   RecordsReadReply,
   UnionMessageReply,
   RecordsWriteMessage,
   RecordsWriteOptions,
-  Signer,
 } from '@tbd54566975/dwn-sdk-js';
 
 import { Jose } from '@web5/crypto';
@@ -25,16 +25,17 @@ import {
   RecordsWrite,
   RecordsQuery,
   DwnMethodName,
+  EventLogLevel,
   RecordsDelete,
+  DataStoreLevel,
   ProtocolsQuery,
   DwnInterfaceName,
-  ProtocolsConfigure,
-  EventLogLevel,
-  DataStoreLevel,
   MessageStoreLevel,
+  ProtocolsConfigure,
 } from '@tbd54566975/dwn-sdk-js';
 
-import type { DwnRpcRequest, DwnResponse,ProcessDwnRequest, SendDwnRequest, Web5ManagedAgent } from './types/agent.js';
+import type { DwnRpcRequest } from './rpc-client.js';
+import type { DwnResponse,ProcessDwnRequest, SendDwnRequest, Web5ManagedAgent } from './types/agent.js';
 
 import { isManagedKeyPair } from './utils.js';
 import { blobToIsomorphicNodeReadable, webReadableToIsomorphicNodeReadable } from './utils.js';

--- a/packages/agent/src/types/agent.ts
+++ b/packages/agent/src/types/agent.ts
@@ -1,4 +1,5 @@
 import type { Readable } from 'readable-stream';
+import type { DidResolutionOptions, DidResolutionResult, PortableDid } from '@web5/dids';
 import type {
   EventsGetMessage,
   UnionMessageReply,
@@ -12,20 +13,40 @@ import type {
 
 import { DidResolver } from '@web5/dids';
 
-import { DidManager } from '../did-manager.js';
+import type { SyncManager } from '../sync-manager.js';
+import type { AppDataStore } from '../app-data-store.js';
+import type { DwnRpcResponse, Web5Rpc } from '../rpc-client.js';
+
+import { DidManager, DidMessage } from '../did-manager.js';
 import { DwnManager } from '../dwn-manager.js';
 import { KeyManager } from '../key-manager.js';
-import { SyncManager } from '../sync-manager.js';
-import { AppDataStore } from '../app-data-store.js';
 import { IdentityManager } from '../identity-manager.js';
 
 /**
  * DID Types
  */
 
-export type ProcessDidRequest = { /** empty */ }
-export type SendDidRequest = { /** empty */ }
-export type DidResponse = { /** empty */ }
+export type DidMessageType = keyof typeof DidMessage;
+
+export type DidRequest = {
+  messageType: DidMessageType;
+  messageOptions: any;
+  store?: boolean;
+}
+
+export type DidCreateMessage = {
+  didMethod: string;
+  didOptions?: any;
+}
+
+export type DidResolveMessage = {
+  didUrl: string;
+  resolutionOptions?: DidResolutionOptions;
+}
+
+export type DidResponse = {
+  result?: DidResolutionResult | PortableDid
+};
 
 /**
  * DWN Types
@@ -77,41 +98,6 @@ export interface SerializableDwnMessage {
   toJSON(): string;
 }
 
-
-// TODO: move what's below to dwn-server repo. i wrote this here for expediency
-
-/**
- * interface that can be implemented to communicate with Dwn Servers
- */
-export interface DwnRpc {
-  /**
-   * TODO: add jsdoc
-   */
-  get transportProtocols(): string[]
-
-  /**
-   * TODO: add jsdoc
-   * @param request
-   */
-  sendDwnRequest(request: DwnRpcRequest): Promise<DwnRpcResponse>
-}
-
-/**
- * TODO: add jsdoc
- */
-export type DwnRpcRequest = {
-  data?: any;
-  dwnUrl: string;
-  message: SerializableDwnMessage | any;
-  targetDid: string;
-}
-
-/**
- * TODO: add jsdoc
- */
-export type DwnRpcResponse = UnionMessageReply;
-
-
 /**
  * Verifiable Credential Types
  */
@@ -126,8 +112,8 @@ export type VcResponse = { /** empty */ }
 export interface Web5Agent {
   agentDid: string | undefined;
 
-  processDidRequest(request: ProcessDidRequest): Promise<DidResponse>
-  sendDidRequest(request: SendDidRequest): Promise<DidResponse>;
+  processDidRequest(request: DidRequest): Promise<DidResponse>
+  sendDidRequest(request: DidRequest): Promise<DidResponse>;
   processDwnRequest(request: ProcessDwnRequest): Promise<DwnResponse>
   sendDwnRequest(request: SendDwnRequest): Promise<DwnResponse>;
   processVcRequest(request: ProcessVcRequest): Promise<VcResponse>
@@ -141,7 +127,7 @@ export interface Web5ManagedAgent extends Web5Agent {
   dwnManager: DwnManager;
   identityManager: IdentityManager;
   keyManager: KeyManager;
-  rpcClient: DwnRpc;
+  rpcClient: Web5Rpc;
   syncManager: SyncManager;
 
   firstLaunch(): Promise<boolean>;

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -52,11 +52,11 @@ npm install @web5/api
 _CDNs_
 
 ```yaml
-https://unpkg.com/0.8.1/dist/browser.js
+https://unpkg.com/0.8.2/dist/browser.js
 ```
 
 ```yaml
-https://cdn.jsdelivr.net/npm/@web5/api@0.8.1/dist/browser.mjs
+https://cdn.jsdelivr.net/npm/@web5/api@0.8.2/dist/browser.mjs
 ```
 
 ## Usage
@@ -263,6 +263,7 @@ The `create` request object is composed as follows:
 The `create()` method is an alias for `write()` and both can take the same request object properties.
 
 ### **`web5.dwn.records.read(request)`**
+
 Method for reading a record stored in the user's local DWeb Node, remote DWeb Nodes, or another party's DWeb Nodes (if permitted). The request takes a filter; if there is exactly one record matching the filter, the record and its data are returned. The most common filter is by `recordId`, but it is also useful to filter by `protocol`, `contextId`, and `protocolPath`.
 
 ```javascript
@@ -271,7 +272,7 @@ const { record } = await web5.dwn.records.read({
   message: {
     filter: {
       recordId: "bfw35evr6e54c4cqa4c589h4cq3v7w4nc534c9w7h5",
-    }
+    },
   },
 });
 
@@ -283,7 +284,7 @@ const { record } = await web5.dwn.records.read({
   message: {
     filter: {
       recordId: "bfw35evr6e54c4cqa4c589h4cq3v7w4nc534c9w7h5",
-    }
+    },
   },
 });
 
@@ -305,6 +306,7 @@ The `read` request object is composed as follows:
     - **`recipient`** - _`string`_ (_optional_): the DID in the `recipient` field of the record.
     - **`schema`** - _`URI string`_ (_optional_): the URI of the schema bucket in which to query.
     - **`dataFormat`** - _`Media Type string`_ (_optional_): the IANA string corresponding with the format of the data to filter for. See IANA's Media Type list here: https://www.iana.org/assignments/media-types/media-types.xhtml
+
 ### **`web5.dwn.records.delete(request)`**
 
 Method for deleting a record stored in the user's local DWeb Node, remote DWeb Nodes, or another party's DWeb Nodes (if permitted).

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -77,7 +77,7 @@
   "dependencies": {
     "@tbd54566975/dwn-sdk-js": "0.2.4",
     "@web5/agent": "0.2.3",
-    "@web5/crypto": "0.2.1",
+    "@web5/crypto": "0.2.2",
     "@web5/dids": "0.2.2",
     "@web5/user-agent": "0.2.3",
     "level": "8.0.0",

--- a/packages/api/src/did-api.ts
+++ b/packages/api/src/did-api.ts
@@ -1,51 +1,14 @@
 import type { Web5Agent } from '@web5/agent';
+import type { DidResolutionOptions, DidResolutionResult } from '@web5/dids';
 
-// import type {
-//   DidKeyOptions,
-//   DidIonCreateOptions,
-//   DidMethodApi,
-//   DidMethodCreator,
-//   DidMethodResolver,
-//   DidResolverCache,
-//   DidResolutionResult,
-//   DidState
-// } from '@web5/dids';
-
-
-
-// import { DidResolver } from '@web5/dids';
-
-// // Map method names to option types
-// type CreateMethodOptions = {
-//   ion: DidIonCreateOptions;
-//   key: DidKeyOptions;
-// };
-
-// // A conditional type for inferring options based on the method name
-// type CreateOptions<M extends keyof CreateMethodOptions> = CreateMethodOptions[M];
-
-// export type DidApiOptions = {
-//   didMethodApis: DidMethodApi[];
-//   cache?: DidResolverCache;
-// }
+import { DidMessage } from '@web5/agent';
 
 /**
- * The DID API is used to create and resolve DIDs.
+ * The DID API is used to resolve DIDs.
  *
  * @beta
  */
 export class DidApi {
-  // private didResolver: DidResolver;
-  // private methodCreatorMap: Map<string, DidMethodCreator> = new Map();
-
-  // /**
-  //  * returns the DID resolver created by this api. useful in scenarios where you want to pass around
-  //  * the same resolver so that you can leverage the resolver's cache
-  //  */
-  // get resolver() {
-  //   return this.didResolver;
-  // }
-
   private agent: Web5Agent;
   private connectedDid: string;
 
@@ -54,54 +17,20 @@ export class DidApi {
     this.connectedDid = options.connectedDid;
   }
 
-  // constructor(options: DidApiOptions) {
-  //   const { didMethodApis, cache } = options;
+  /**
+   * Resolves a DID to a DID Resolution Result.
+   *
+   * @param didUrl - The DID or DID URL to resolve.
+   * @returns A promise that resolves to the DID Resolution Result.
+   */
+  async resolve(didUrl: string, resolutionOptions?: DidResolutionOptions): Promise<DidResolutionResult> {
+    const agentResponse = await this.agent.processDidRequest({
+      messageOptions : { didUrl, resolutionOptions },
+      messageType    : DidMessage.Resolve
+    });
 
-  //   this.didResolver = new DidResolver({ methodResolvers: options.didMethodApis, cache });
+    const { result } = agentResponse;
 
-  //   for (let methodApi of didMethodApis) {
-  //     this.methodCreatorMap.set(methodApi.methodName, methodApi);
-  //   }
-  // }
-
-  // /**
-  //  * Creates a DID of the method provided
-  //  * @param method - the method of DID to create
-  //  * @param options - method-specific options
-  //  * @returns the created DID
-  //  */
-  // create<M extends keyof CreateMethodOptions>(method: M, options?: CreateOptions<M>): Promise<DidState> {
-  //   const didMethodCreator = this.methodCreatorMap.get(method);
-  //   if (!didMethodCreator) {
-  //     throw new Error(`no creator available for ${method}`);
-  //   }
-
-  //   return didMethodCreator.create(options);
-  // }
-
-  // /**
-  //  * Resolves the provided DID
-  //  * @param did - the did to resolve
-  //  * @see {@link https://www.w3.org/TR/did-core/#did-resolution | DID Resolution}
-  //  * @returns DID Resolution Result
-  //  */
-  // resolve(did: string): Promise<DidResolutionResult> {
-  //   return this.didResolver.resolve(did);
-  // }
-
-  // /**
-  //  * can be used to add different did method resolvers
-  //  * @param _resolver
-  //  */
-  // addMethodResolver(_resolver: DidMethodResolver) {
-  //   throw new Error('not yet implemented');
-  // }
-
-  // /**
-  //  * can be used to add differed did method creators
-  //  * @param _creator
-  //  */
-  // addMethodCreator(_creator: DidMethodCreator) {
-  //   throw new Error('not yet implemented');
-  // }
+    return result as DidResolutionResult;
+  }
 }

--- a/packages/api/tests/did-api.spec.ts
+++ b/packages/api/tests/did-api.spec.ts
@@ -37,7 +37,39 @@ describe('DidApi', () => {
     await testAgent.closeStorage();
   });
 
-  it('needs tests', () => {
-    expect(did).to.exist;
+  describe('resolve()', async () => {
+    it('resolves a DID and returns a resolution result', async () => {
+      const testDid = 'did:key:z6MkmNvXGmVuux5W63nXKEM8zoxFmDLNfe7siCKG2GM7Kd8D';
+      const didResolutionResult = await did.resolve(testDid);
+
+      expect(didResolutionResult).to.exist;
+      expect(didResolutionResult).to.have.property('didDocument');
+      expect(didResolutionResult.didDocument).to.have.property('id', testDid);
+      expect(didResolutionResult).to.have.property('didDocument');
+      expect(didResolutionResult).to.have.property('didDocumentMetadata');
+      expect(didResolutionResult).to.have.property('didResolutionMetadata');
+    });
+
+    it('returns an invalidDid error if the DID cannot be parsed', async () => {
+      const didResolutionResult = await did.resolve('unparseable:did');
+
+      expect(didResolutionResult).to.exist;
+      expect(didResolutionResult).to.have.property('@context');
+      expect(didResolutionResult).to.have.property('didDocument');
+      expect(didResolutionResult).to.have.property('didDocumentMetadata');
+      expect(didResolutionResult).to.have.property('didResolutionMetadata');
+      expect(didResolutionResult.didResolutionMetadata).to.have.property('error', 'invalidDid');
+    });
+
+    it('returns a methodNotSupported error if the DID method is not supported', async () => {
+      const didResolutionResult = await did.resolve('did:unknown:abc123');
+
+      expect(didResolutionResult).to.exist;
+      expect(didResolutionResult).to.have.property('@context');
+      expect(didResolutionResult).to.have.property('didDocument');
+      expect(didResolutionResult).to.have.property('didDocumentMetadata');
+      expect(didResolutionResult).to.have.property('didResolutionMetadata');
+      expect(didResolutionResult.didResolutionMetadata).to.have.property('error', 'methodNotSupported');
+    });
   });
 });

--- a/packages/api/tests/utils/test-user-agent.ts
+++ b/packages/api/tests/utils/test-user-agent.ts
@@ -1,15 +1,14 @@
 import type {
-  DwnRpc,
+  Web5Rpc,
+  DidRequest,
   VcResponse,
   DidResponse,
   DwnResponse,
   AppDataStore,
   SendVcRequest,
-  SendDidRequest,
   SendDwnRequest,
   ProcessVcRequest,
   Web5ManagedAgent,
-  ProcessDidRequest,
   ProcessDwnRequest,
   SyncManager,
 } from '@web5/agent';
@@ -24,6 +23,7 @@ import {
 import {
   LocalKms,
   DidManager,
+  DidMessage,
   DwnManager,
   KeyManager,
   AppDataVault,
@@ -43,7 +43,7 @@ type TestUserAgentOptions = {
   dwnManager: DwnManager;
   identityManager: IdentityManager;
   keyManager: KeyManager;
-  rpcClient: DwnRpc;
+  rpcClient: Web5Rpc;
   syncManager: SyncManager;
 
   dwn: Dwn;
@@ -60,7 +60,7 @@ export class TestUserAgent implements Web5ManagedAgent {
   dwnManager: DwnManager;
   identityManager: IdentityManager;
   keyManager: KeyManager;
-  rpcClient: DwnRpc;
+  rpcClient: Web5Rpc;
   syncManager: SyncManager;
 
   /**
@@ -173,8 +173,18 @@ export class TestUserAgent implements Web5ManagedAgent {
     throw new Error('Not implemented');
   }
 
-  async processDidRequest(_request: ProcessDidRequest): Promise<DidResponse> {
-    throw new Error('Not implemented');
+  async processDidRequest(request: DidRequest): Promise<DidResponse> {
+    switch (request.messageType) {
+      case DidMessage.Resolve: {
+        const { didUrl, resolutionOptions } = request.messageOptions;
+        const result = await this.didResolver.resolve(didUrl, resolutionOptions);
+        return { result };
+      }
+
+      default: {
+        return this.didManager.processRequest(request);
+      }
+    }
   }
 
   async processDwnRequest(request: ProcessDwnRequest): Promise<DwnResponse> {
@@ -185,7 +195,7 @@ export class TestUserAgent implements Web5ManagedAgent {
     throw new Error('Not implemented');
   }
 
-  async sendDidRequest(_request: SendDidRequest): Promise<DidResponse> {
+  async sendDidRequest(_request: DidRequest): Promise<DidResponse> {
     throw new Error('Not implemented');
   }
 

--- a/packages/credentials/package.json
+++ b/packages/credentials/package.json
@@ -85,7 +85,7 @@
     "@typescript-eslint/eslint-plugin": "6.4.0",
     "@typescript-eslint/parser": "6.4.0",
     "@web5/common": "0.2.1",
-    "@web5/crypto": "0.2.1",
+    "@web5/crypto": "0.2.2",
     "@web5/dids": "0.2.2",
     "c8": "8.0.1",
     "chai": "4.3.10",

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web5/crypto",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "TBD crypto library",
   "type": "module",
   "main": "./dist/cjs/index.js",

--- a/packages/dids/build/cjs-bundle.js
+++ b/packages/dids/build/cjs-bundle.js
@@ -8,7 +8,7 @@ const includeList = new Set([
 ]);
 
 // create list of dependencies that we _do not_ want to include in our bundle
-const excludeList = [];
+const excludeList = ['sodium-universal'];
 for (const dependency in packageJson.dependencies) {
   if (includeList.has(dependency)) {
     continue;

--- a/packages/dids/build/cjs-bundle.js
+++ b/packages/dids/build/cjs-bundle.js
@@ -3,7 +3,8 @@ import packageJson from '../package.json' assert { type: 'json' };
 
 // list of dependencies that _dont_ ship cjs
 const includeList = new Set([
-  '@decentralized-identity/ion-sdk'
+  '@decentralized-identity/ion-sdk',
+  'pkarr'
 ]);
 
 // create list of dependencies that we _do not_ want to include in our bundle

--- a/packages/dids/package.json
+++ b/packages/dids/package.json
@@ -77,7 +77,7 @@
     "@decentralized-identity/ion-pow-sdk": "1.0.17",
     "@decentralized-identity/ion-sdk": "1.0.1",
     "@web5/common": "0.2.1",
-    "@web5/crypto": "0.2.1",
+    "@web5/crypto": "0.2.2",
     "did-resolver": "4.1.0",
     "dns-packet": "5.6.1",
     "level": "8.0.0",

--- a/packages/identity-agent/src/identity-agent.ts
+++ b/packages/identity-agent/src/identity-agent.ts
@@ -1,17 +1,16 @@
 import type {
-  DwnRpc,
+  Web5Rpc,
+  DidRequest,
   VcResponse,
   DidResponse,
   DwnResponse,
   SyncManager,
   AppDataStore,
   SendVcRequest,
-  SendDidRequest,
   SendDwnRequest,
   ProcessVcRequest,
   Web5ManagedAgent,
   ProcessDwnRequest,
-  ProcessDidRequest,
 } from '@web5/agent';
 
 import { LevelStore } from '@web5/common';
@@ -20,6 +19,7 @@ import { DidIonMethod, DidKeyMethod, DidResolver } from '@web5/dids';
 import {
   LocalKms,
   DidManager,
+  DidMessage,
   DwnManager,
   KeyManager,
   DidStoreDwn,
@@ -41,7 +41,7 @@ export type IdentityAgentOptions = {
   dwnManager: DwnManager;
   identityManager: IdentityManager;
   keyManager: KeyManager;
-  rpcClient: DwnRpc;
+  rpcClient: Web5Rpc;
   syncManager: SyncManager;
 }
 
@@ -53,7 +53,7 @@ export class IdentityAgent implements Web5ManagedAgent {
   dwnManager: DwnManager;
   identityManager: IdentityManager;
   keyManager: KeyManager;
-  rpcClient: DwnRpc;
+  rpcClient: Web5Rpc;
   syncManager: SyncManager;
 
   constructor(options: IdentityAgentOptions) {
@@ -199,8 +199,18 @@ export class IdentityAgent implements Web5ManagedAgent {
     });
   }
 
-  async processDidRequest(_request: ProcessDidRequest): Promise<DidResponse> {
-    throw new Error('Not implemented');
+  async processDidRequest(request: DidRequest): Promise<DidResponse> {
+    switch (request.messageType) {
+      case DidMessage.Resolve: {
+        const { didUrl, resolutionOptions } = request.messageOptions;
+        const result = await this.didResolver.resolve(didUrl, resolutionOptions);
+        return { result };
+      }
+
+      default: {
+        return this.didManager.processRequest(request);
+      }
+    }
   }
 
   async processDwnRequest(request: ProcessDwnRequest): Promise<DwnResponse> {
@@ -211,7 +221,7 @@ export class IdentityAgent implements Web5ManagedAgent {
     throw new Error('Not implemented');
   }
 
-  async sendDidRequest(_request: SendDidRequest): Promise<DidResponse> {
+  async sendDidRequest(_request: DidRequest): Promise<DidResponse> {
     throw new Error('Not implemented');
   }
 

--- a/packages/proxy-agent/package.json
+++ b/packages/proxy-agent/package.json
@@ -69,7 +69,7 @@
   "dependencies": {
     "@web5/agent": "0.2.3",
     "@web5/common": "0.2.1",
-    "@web5/crypto": "0.2.1",
+    "@web5/crypto": "0.2.2",
     "@web5/dids": "0.2.2"
   },
   "devDependencies": {

--- a/packages/proxy-agent/src/proxy-agent.ts
+++ b/packages/proxy-agent/src/proxy-agent.ts
@@ -1,17 +1,16 @@
 import type {
-  DwnRpc,
+  Web5Rpc,
+  DidRequest,
   VcResponse,
   DidResponse,
   DwnResponse,
   SyncManager,
   AppDataStore,
   SendVcRequest,
-  SendDidRequest,
   SendDwnRequest,
   ProcessVcRequest,
   Web5ManagedAgent,
   ProcessDwnRequest,
-  ProcessDidRequest,
 } from '@web5/agent';
 
 import { LevelStore } from '@web5/common';
@@ -41,7 +40,7 @@ export type Web5ProxyAgentOptions = {
   dwnManager: DwnManager;
   identityManager: IdentityManager;
   keyManager: KeyManager;
-  rpcClient: DwnRpc;
+  rpcClient: Web5Rpc;
   syncManager: SyncManager;
 }
 
@@ -53,7 +52,7 @@ export class Web5ProxyAgent implements Web5ManagedAgent {
   dwnManager: DwnManager;
   identityManager: IdentityManager;
   keyManager: KeyManager;
-  rpcClient: DwnRpc;
+  rpcClient: Web5Rpc;
   syncManager: SyncManager;
 
   constructor(options: Web5ProxyAgentOptions) {
@@ -199,7 +198,7 @@ export class Web5ProxyAgent implements Web5ManagedAgent {
     });
   }
 
-  async processDidRequest(_request: ProcessDidRequest): Promise<DidResponse> {
+  async processDidRequest(_request: DidRequest): Promise<DidResponse> {
     throw new Error('Not implemented');
   }
 
@@ -211,7 +210,7 @@ export class Web5ProxyAgent implements Web5ManagedAgent {
     throw new Error('Not implemented');
   }
 
-  async sendDidRequest(_request: SendDidRequest): Promise<DidResponse> {
+  async sendDidRequest(_request: DidRequest): Promise<DidResponse> {
     throw new Error('Not implemented');
   }
 

--- a/packages/user-agent/package.json
+++ b/packages/user-agent/package.json
@@ -69,7 +69,7 @@
   "dependencies": {
     "@web5/agent": "0.2.3",
     "@web5/common": "0.2.1",
-    "@web5/crypto": "0.2.1",
+    "@web5/crypto": "0.2.2",
     "@web5/dids": "0.2.2"
   },
   "devDependencies": {

--- a/packages/user-agent/src/user-agent.ts
+++ b/packages/user-agent/src/user-agent.ts
@@ -1,17 +1,16 @@
 import type {
-  DwnRpc,
+  Web5Rpc,
+  DidRequest,
   VcResponse,
   DidResponse,
   DwnResponse,
   SyncManager,
   AppDataStore,
   SendVcRequest,
-  SendDidRequest,
   SendDwnRequest,
   ProcessVcRequest,
   Web5ManagedAgent,
   ProcessDwnRequest,
-  ProcessDidRequest,
 } from '@web5/agent';
 
 import { LevelStore } from '@web5/common';
@@ -31,6 +30,7 @@ import {
   SyncManagerLevel,
   PrivateKeyStoreDwn,
   cryptoToPortableKeyPair,
+  DidMessage,
 } from '@web5/agent';
 
 export type Web5UserAgentOptions = {
@@ -41,7 +41,7 @@ export type Web5UserAgentOptions = {
   dwnManager: DwnManager;
   identityManager: IdentityManager;
   keyManager: KeyManager;
-  rpcClient: DwnRpc;
+  rpcClient: Web5Rpc;
   syncManager: SyncManager;
 }
 
@@ -53,7 +53,7 @@ export class Web5UserAgent implements Web5ManagedAgent {
   dwnManager: DwnManager;
   identityManager: IdentityManager;
   keyManager: KeyManager;
-  rpcClient: DwnRpc;
+  rpcClient: Web5Rpc;
   syncManager: SyncManager;
 
   constructor(options: Web5UserAgentOptions) {
@@ -201,8 +201,18 @@ export class Web5UserAgent implements Web5ManagedAgent {
     });
   }
 
-  async processDidRequest(_request: ProcessDidRequest): Promise<DidResponse> {
-    throw new Error('Not implemented');
+  async processDidRequest(request: DidRequest): Promise<DidResponse> {
+    switch (request.messageType) {
+      case DidMessage.Resolve: {
+        const { didUrl, resolutionOptions } = request.messageOptions;
+        const result = await this.didResolver.resolve(didUrl, resolutionOptions);
+        return { result };
+      }
+
+      default: {
+        return this.didManager.processRequest(request);
+      }
+    }
   }
 
   async processDwnRequest(request: ProcessDwnRequest): Promise<DwnResponse> {
@@ -213,7 +223,7 @@ export class Web5UserAgent implements Web5ManagedAgent {
     throw new Error('Not implemented');
   }
 
-  async sendDidRequest(_request: SendDidRequest): Promise<DidResponse> {
+  async sendDidRequest(_request: DidRequest): Promise<DidResponse> {
     throw new Error('Not implemented');
   }
 


### PR DESCRIPTION
## Summary
This PR (re-)introduces the `resolve()` method to the `DidApi` class, enabling the resolution of DIDs through `web5.dids.resolve()`. The method is designed to be a simple interface for resolving a DID to its corresponding DID Resolution Result, which includes the DID Document.

## Implementation Details
- The `DidApi` class is equipped with a `resolve` method that takes a DID URL and optional resolution options.
- The resolution process is carried out by delegating the request to the `Web5Agent`, which is expected to handle the actual resolution logic.
- The `resolve` method returns a promise that resolves with the `DidResolutionResult`.