### PR TITLE
Fix bug with `record.data.*` after record queries

### DIFF
--- a/packages/agent/tests/dwn-manager.spec.ts
+++ b/packages/agent/tests/dwn-manager.spec.ts
@@ -8,7 +8,6 @@ import {
   EventsGetReply,
   EventsGetMessage,
   MessagesGetReply,
-  RecordsReadReply,
   RecordsQueryReply,
   UnionMessageReply,
   MessagesGetMessage,
@@ -377,7 +376,7 @@ describe('DwnManager', () => {
         expect(readMessage).to.have.property('authorization');
         expect(readMessage).to.have.property('descriptor');
 
-        const readReply = readResponse.reply as RecordsReadReply;
+        const readReply = readResponse.reply;
         expect(readReply).to.have.property('status');
         expect(readReply.status.code).to.equal(200);
         expect(readReply).to.have.property('record');
@@ -552,7 +551,7 @@ describe('DwnManager', () => {
         expect(readMessage.descriptor.method).to.equal('Read');
         expect(readMessage.descriptor.interface).to.equal('Records');
 
-        const readReply = response.reply as RecordsReadReply;
+        const readReply = response.reply;
         expect(readReply.record).to.exist;
 
         const record = readReply.record as unknown as RecordsWriteMessage & { data: ReadableStream };

--- a/packages/api/src/dwn-api.ts
+++ b/packages/api/src/dwn-api.ts
@@ -440,13 +440,11 @@ export class DwnApi {
       /**
        * Writes a record to the DWN
        *
-       * As a convenience, the Record instance returned will cache a copy of the data if the
-       * data size, in bytes, is less than the DWN 'max data size allowed to be encoded'
-       * parameter of 10KB. This is done to maintain consistency with other DWN methods,
-       * like RecordsQuery, that include relatively small data payloads when returning
-       * RecordsWrite message properties. Regardless of data size, methods such as
-       * `record.data.stream()` will return the data when called even if it requires fetching
-       * from the DWN datastore.
+       * As a convenience, the Record instance returned will cache a copy of the data.  This is done
+       * to maintain consistency with other DWN methods, like RecordsQuery, that include relatively
+       * small data payloads when returning RecordsWrite message properties. Regardless of data
+       * size, methods such as `record.data.stream()` will return the data when called even if it
+       * requires fetching from the DWN datastore.
        */
       write: async (request: RecordsWriteRequest): Promise<RecordsWriteResponse> => {
         const messageOptions: Partial<RecordsWriteOptions> = {

--- a/packages/api/src/record.ts
+++ b/packages/api/src/record.ts
@@ -1,7 +1,6 @@
 import type { Web5Agent } from '@web5/agent';
 import type { Readable } from 'readable-stream';
 import type {
-  RecordsReadReply,
   RecordsWriteMessage,
   RecordsWriteOptions,
   RecordsWriteDescriptor,
@@ -195,8 +194,8 @@ export class Record implements RecordModel {
         messageType    : DwnInterfaceName.Records + DwnMethodName.Read,
         target         : this.target,
       })
-        .then(response => response.reply as RecordsReadReply)
-        .then(reply => reply.record.data as Readable)
+        .then(response => response.reply)
+        .then(reply => reply.record.data)
         .catch(error => { throw new Error(`Error encountered while attempting to read data: ${error.message}`); });
     }
 

--- a/packages/api/src/record.ts
+++ b/packages/api/src/record.ts
@@ -190,7 +190,7 @@ export class Record implements RecordModel {
       // If neither of the above are true, then the record must be fetched from the DWN.
       this._readableStream = this._agent.processDwnRequest({
         author         : this.author,
-        messageOptions : { recordId: this.id },
+        messageOptions : { filter: { recordId: this.id } },
         messageType    : DwnInterfaceName.Records + DwnMethodName.Read,
         target         : this.target,
       })

--- a/packages/api/tests/record.spec.ts
+++ b/packages/api/tests/record.spec.ts
@@ -272,6 +272,32 @@ describe('Record', () => {
       expect(readDataBytes).to.deep.equal(inputDataBytes);
     });
 
+    it('returns large data payloads after dwn.records.query()', async () => {
+      /** Generate data that exceeds the DWN encoded data limit to ensure that the data will have to
+       * be fetched with a RecordsRead when record.data.blob() is executed. */
+      const dataJson = TestDataGenerator.randomJson(DwnConstant.maxDataSizeAllowedToBeEncoded + 1000);
+      const inputDataBytes = new TextEncoder().encode(JSON.stringify(dataJson));
+
+      // Write the large record to agent-connected DWN.
+      const { record, status } = await dwn.records.write({ data: dataJson });
+      expect(status.code).to.equal(202);
+
+      // Query for the record that was just created.
+      const { records: queryRecords, status: queryRecordStatus } = await dwn.records.query({
+        message: { filter: { recordId: record!.id }}
+      });
+      expect(queryRecordStatus.code).to.equal(200);
+
+      // Confirm that the size, in bytes, of the data read as a Blob matches the original input data.
+      const [ queryRecord ] = queryRecords;
+      const queriedDataBlob = await queryRecord.data.blob();
+      expect(queriedDataBlob.size).to.equal(inputDataBytes.length);
+
+      // Convert the Blob into an array and ensure it matches the input data, byte for byte.
+      const queriedDataBytes = new Uint8Array(await queriedDataBlob.arrayBuffer());
+      expect(queriedDataBytes).to.deep.equal(inputDataBytes);
+    });
+
     it('returns large data payloads after dwn.records.read()', async () => {
       // Generate data that exceeds the DWN encoded data limit to ensure that the data will have to be fetched
       // with a RecordsRead when record.data.blob() is executed.
@@ -364,6 +390,32 @@ describe('Record', () => {
       expect(readDataBytes).to.deep.equal(inputDataBytes);
     });
 
+    it('returns large data payloads after dwn.records.query()', async () => {
+      /** Generate data that exceeds the DWN encoded data limit to ensure that the data will have to
+       * be fetched with a RecordsRead when record.data.json() is executed. */
+      const dataJson = TestDataGenerator.randomJson(DwnConstant.maxDataSizeAllowedToBeEncoded + 1000);
+      const inputDataBytes = new TextEncoder().encode(JSON.stringify(dataJson));
+
+      // Write the large record to agent-connected DWN.
+      const { record, status } = await dwn.records.write({ data: dataJson });
+      expect(status.code).to.equal(202);
+
+      // Query for the record that was just created.
+      const { records: queryRecords, status: queryRecordStatus } = await dwn.records.query({
+        message: { filter: { recordId: record!.id }}
+      });
+      expect(queryRecordStatus.code).to.equal(200);
+
+      // Confirm that the size, in bytes, of the data read as JSON matches the original input data.
+      const [ queryRecord ] = queryRecords;
+      const queriedDataBlob = await queryRecord!.data.json();
+
+      // Convert the JSON to bytes and ensure it matches the input data, byte for byte.
+      const queriedDataBytes = new TextEncoder().encode(JSON.stringify(queriedDataBlob));
+      expect(queriedDataBytes.length).to.equal(inputDataBytes.length);
+      expect(queriedDataBytes).to.deep.equal(inputDataBytes);
+    });
+
     it('returns large data payloads after dwn.records.read()', async () => {
       // Generate data that exceeds the DWN encoded data limit to ensure that the data will have to be fetched
       // with a RecordsRead when record.data.json() is executed.
@@ -448,6 +500,30 @@ describe('Record', () => {
 
       // Ensure the text returned matches the input data, char for char.
       expect(readDataText).to.deep.equal(dataText);
+    });
+
+    it('returns large data payloads after dwn.records.query()', async () => {
+      /** Generate data that exceeds the DWN encoded data limit to ensure that the data will have to
+       * be fetched with a RecordsRead when record.data.blob() is executed. */
+      const dataText = TestDataGenerator.randomString(DwnConstant.maxDataSizeAllowedToBeEncoded + 1000);
+
+      // Write the large record to agent-connected DWN.
+      const { record, status } = await dwn.records.write({ data: dataText });
+      expect(status.code).to.equal(202);
+
+      // Query for the record that was just created.
+      const { records: queryRecords, status: queryRecordStatus } = await dwn.records.query({
+        message: { filter: { recordId: record!.id }}
+      });
+      expect(queryRecordStatus.code).to.equal(200);
+
+      // Confirm that the length of the data read as text matches the original input data.
+      const [ queryRecord ] = queryRecords;
+      const queriedDataText = await queryRecord!.data.text();
+      expect(queriedDataText.length).to.equal(dataText.length);
+
+      // Ensure the text returned matches the input data, char for char.
+      expect(queriedDataText).to.deep.equal(dataText);
     });
 
     it('returns large data payloads after dwn.records.read()', async () => {

--- a/packages/api/tests/record.spec.ts
+++ b/packages/api/tests/record.spec.ts
@@ -12,6 +12,7 @@ import chaiAsPromised from 'chai-as-promised';
 import { utils as didUtils } from '@web5/dids';
 import { TestManagedAgent } from '@web5/agent';
 import {
+  DwnConstant,
   RecordsWrite,
   DwnMethodName,
   DwnInterfaceName,
@@ -254,10 +255,10 @@ describe('Record', () => {
     it('returns large data payloads after dwn.records.write()', async () => {
       // Generate data that exceeds the DWN encoded data limit to ensure that the data will have to be fetched
       // with a RecordsRead when record.data.blob() is executed.
-      const dataJson = TestDataGenerator.randomJson(11_000);
+      const dataJson = TestDataGenerator.randomJson(DwnConstant.maxDataSizeAllowedToBeEncoded + 1000);
       const inputDataBytes = new TextEncoder().encode(JSON.stringify(dataJson));
 
-      // Write the 11KB record to agent-connected DWN.
+      // Write the large record to agent-connected DWN.
       const { record, status } = await dwn.records.write({ data: dataJson });
 
       expect(status.code).to.equal(202);
@@ -274,10 +275,10 @@ describe('Record', () => {
     it('returns large data payloads after dwn.records.read()', async () => {
       // Generate data that exceeds the DWN encoded data limit to ensure that the data will have to be fetched
       // with a RecordsRead when record.data.blob() is executed.
-      const dataJson = TestDataGenerator.randomJson(11_000);
+      const dataJson = TestDataGenerator.randomJson(DwnConstant.maxDataSizeAllowedToBeEncoded + 1000);
       const inputDataBytes = new TextEncoder().encode(JSON.stringify(dataJson));
 
-      // Write the 11KB record to agent-connected DWN.
+      // Write the large record to agent-connected DWN.
       const { record, status } = await dwn.records.write({ data: dataJson });
 
       expect(status.code).to.equal(202);
@@ -346,10 +347,10 @@ describe('Record', () => {
     it('returns large data payloads after dwn.records.write()', async () => {
       // Generate data that exceeds the DWN encoded data limit to ensure that the data will have to be fetched
       // with a RecordsRead when record.data.json() is executed.
-      const dataJson = TestDataGenerator.randomJson(11_000);
+      const dataJson = TestDataGenerator.randomJson(DwnConstant.maxDataSizeAllowedToBeEncoded + 1000);
       const inputDataBytes = new TextEncoder().encode(JSON.stringify(dataJson));
 
-      // Write the 11KB record to agent-connected DWN.
+      // Write the large record to agent-connected DWN.
       const { record, status } = await dwn.records.write({ data: dataJson });
 
       expect(status.code).to.equal(202);
@@ -366,10 +367,10 @@ describe('Record', () => {
     it('returns large data payloads after dwn.records.read()', async () => {
       // Generate data that exceeds the DWN encoded data limit to ensure that the data will have to be fetched
       // with a RecordsRead when record.data.json() is executed.
-      const dataJson = TestDataGenerator.randomJson(11_000);
+      const dataJson = TestDataGenerator.randomJson(DwnConstant.maxDataSizeAllowedToBeEncoded + 1000);
       const inputDataBytes = new TextEncoder().encode(JSON.stringify(dataJson));
 
-      // Write the 11KB record to agent-connected DWN.
+      // Write the large record to agent-connected DWN.
       const { record, status } = await dwn.records.write({ data: dataJson });
 
       expect(status.code).to.equal(202);
@@ -434,9 +435,9 @@ describe('Record', () => {
     it('returns large data payloads after dwn.records.write()', async () => {
       // Generate data that exceeds the DWN encoded data limit to ensure that the data will have to be fetched
       // with a RecordsRead when record.data.text() is executed.
-      const dataText = TestDataGenerator.randomString(11_000);
+      const dataText = TestDataGenerator.randomString(DwnConstant.maxDataSizeAllowedToBeEncoded + 1000);
 
-      // Write the 11KB record to agent-connected DWN.
+      // Write the large record to agent-connected DWN.
       const { record, status } = await dwn.records.write({ data: dataText });
 
       expect(status.code).to.equal(202);
@@ -452,9 +453,9 @@ describe('Record', () => {
     it('returns large data payloads after dwn.records.read()', async () => {
       // Generate data that exceeds the DWN encoded data limit to ensure that the data will have to be fetched
       // with a RecordsRead when record.data.text() is executed.
-      const dataText = TestDataGenerator.randomString(11_000);
+      const dataText = TestDataGenerator.randomString(DwnConstant.maxDataSizeAllowedToBeEncoded + 1000);
 
-      // Write the 11KB record to agent-connected DWN.
+      // Write the large record to agent-connected DWN.
       const { record, status } = await dwn.records.write({ data: dataText });
 
       expect(status.code).to.equal(202);


### PR DESCRIPTION
This is primarily a bug fix PR that resolves the following error that was reported by multiple developers:

```shell
Error encountered while attempting to read data: Cannot read properties of undefined (reading 'protocol')
```

#### `@web5/agent`
- Improve Type safety now that `RecordsReadReply` is part of `DwnResponse` and type casting is no longer necessary.

#### `@web5/api`
- Fix bug introduced when [`RecordsRead` switched to taking a filter property](https://github.com/TBD54566975/dwn-sdk-js/pull/470) and add tests
- Improve test coverage by ensuring that the DWN query record size limit is inherited from DWN SDK so that tests cover both above and below limit cases when this [constant changes in DWN SDK](https://github.com/TBD54566975/dwn-sdk-js/pull/470).