### PR TITLE
Bump readable-stream types dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1201,18 +1201,18 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.9.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.9.1.tgz",
-      "integrity": "sha512-HhmzZh5LSJNS5O8jQKpJ/3ZcrrlG6L70hpGqMIAoM9YVD0YBRNWYsfwcXq8VnSjlNpCpgLzMXdiPo+dxcvSmiA==",
+      "version": "20.9.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.9.2.tgz",
+      "integrity": "sha512-WHZXKFCEyIUJzAwh3NyyTHYSR35SevJ6mZ1nWwJafKtiQbqRTIKSRcw3Ma3acqgsent3RRDqeVwpHntMk+9irg==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
     },
     "node_modules/@types/readable-stream": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-4.0.0.tgz",
-      "integrity": "sha512-s6YqDV111kwuFsT9SwFC+FmZ5n1SEp4H9DXGg6Zqag0lPGeEvBGP9UaLJYpX4cxY7fAFnx2avy1QVvft0LLb7g==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-4.0.6.tgz",
+      "integrity": "sha512-awa7+N1SSD9xz8ZvEUSO3/N3itc2PMH6Sca11HiX55TVsWiMaIgmbM76lN+2eZOrCQPiFqj0GmgsfsNtNGWoUw==",
       "dev": true,
       "dependencies": {
         "@types/node": "*",
@@ -6316,13 +6316,10 @@
       }
     },
     "node_modules/lru-cache": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.2.tgz",
-      "integrity": "sha512-Yj9mA8fPiVgOUpByoTZO5pNrcl5Yk37FcSHsUINpAsaBIEZIuqcCclDZJCVxqQShDsmYX8QG63svJiTbOATZwg==",
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.3.tgz",
+      "integrity": "sha512-B7gr+F6MkqB3uzINHXNctGieGsRTMwIBgxkp0yq/5BwcuDzD4A8wQpHQW6vDAm1uKSLQghmRdD9sKqf2vJ1cEg==",
       "dev": true,
-      "dependencies": {
-        "semver": "^7.3.5"
-      },
       "engines": {
         "node": "14 || >=16.14"
       }
@@ -9825,7 +9822,7 @@
         "@types/chai-as-promised": "7.1.5",
         "@types/eslint": "8.44.2",
         "@types/mocha": "10.0.1",
-        "@types/readable-stream": "4.0.0",
+        "@types/readable-stream": "4.0.6",
         "@typescript-eslint/eslint-plugin": "6.4.0",
         "@typescript-eslint/parser": "6.4.0",
         "c8": "8.0.1",
@@ -10018,7 +10015,7 @@
         "@types/eslint": "8.44.2",
         "@types/mocha": "10.0.1",
         "@types/ms": "0.7.31",
-        "@types/readable-stream": "4.0.0",
+        "@types/readable-stream": "4.0.6",
         "@types/sinon": "10.0.15",
         "@typescript-eslint/eslint-plugin": "6.4.0",
         "@typescript-eslint/parser": "6.4.0",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -81,7 +81,7 @@
     "@types/chai-as-promised": "7.1.5",
     "@types/eslint": "8.44.2",
     "@types/mocha": "10.0.1",
-    "@types/readable-stream": "4.0.0",
+    "@types/readable-stream": "4.0.6",
     "@typescript-eslint/eslint-plugin": "6.4.0",
     "@typescript-eslint/parser": "6.4.0",
     "c8": "8.0.1",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -92,7 +92,7 @@
     "@types/eslint": "8.44.2",
     "@types/mocha": "10.0.1",
     "@types/ms": "0.7.31",
-    "@types/readable-stream": "4.0.0",
+    "@types/readable-stream": "4.0.6",
     "@types/sinon": "10.0.15",
     "@typescript-eslint/eslint-plugin": "6.4.0",
     "@typescript-eslint/parser": "6.4.0",


### PR DESCRIPTION
## Summary

This PR bumps the version of the `@types/readable-stream` dependency.

## Context

For context see [PR #618](https://github.com/TBD54566975/dwn-sdk-js/pull/618) in `dwn-sdk-js`.

## Changes

- Bumps the `@types/readable-stream` version from `4.0.0` to `4.0.6`.
