### PR TITLE
Fix bug that was causing record.send() and record.update() issues

### DIFF
--- a/packages/api/src/record.ts
+++ b/packages/api/src/record.ts
@@ -366,7 +366,7 @@ export class Record implements RecordModel {
     }
 
     // Throw an error if an attempt is made to modify immutable properties. `data` has already been handled.
-    const mutableDescriptorProperties = new Set(['data', 'dataCid', 'dataSize', 'dateModified', 'datePublished', 'published']);
+    const mutableDescriptorProperties = new Set(['data', 'dataCid', 'dataSize', 'datePublished', 'messageTimestamp', 'published']);
     Record.verifyPermittedMutation(Object.keys(options), mutableDescriptorProperties);
 
     // If a new `dateModified` was not provided, remove the equivalent `messageTimestamp` property from from the


### PR DESCRIPTION
## Summary

This is primarily a bug fix PR that resolves an issue that was causing `dateModified` to never be updated after executing `record.update()` and intermittently caused `record.send()` to fail after one or more `record.update()` operations.

## Context

Several months ago `dwn-sdk-js` [PR #419](https://github.com/TBD54566975/dwn-sdk-js/pull/419) changed and standardized the naming convention for timestamps across all interfaces.  At the time, the decision was made to retain the `dateCreated` and `dateModified` property names for the [`Record`](https://github.com/TBD54566975/web5-js/blob/d57927afe7e225e6a3e01500e154af6035288d42/packages/api/src/record.ts#L69) model used in `@web5/api`.  Since `Record` is a logical representation of a record, `dateCreated` maps to the timestamp when the initial `RecordsWrite` was created and `dateModified` maps to the timestamp of the most recent modification.

Unfortunately, when `@web5/api` was updated to reflect this change an update to the list of mutable properties was missed, which resulted in a bug:
- After each `record.update()` operation, the `messageTimestamp` descriptor property was not updated.  As a result, subsequent updates would be written with the same `messageTimestamp`.

## Changes

#### `@web5/api`
- Fix bug so that a `Record` instance's `messageTimestamp` property is updated each time a modification is made.
- Add tests to confirm that this resolves both the issue of repeated `record.update()` operations not updating the timestamp and to ensure that `record.send()` succeeded in writing to the remote DWN after multiple rounds of `update()`/`send()`.