### PR TITLE
fix Single-quoted string interpolation in src/web5.ts

### DIFF
--- a/packages/api/src/web5.ts
+++ b/packages/api/src/web5.ts
@@ -152,7 +152,7 @@ export class Web5 {
           // Set the stored identity as the connected DID.
           connectedDid = identity.did;
         } else {
-          throw new Error('connect() failed due to unexpected state: ${storedIdentities} stored identities');
+          throw new Error(`connect() failed due to unexpected state: ${storedIdentities} stored identities`);
         }
       }
 


### PR DESCRIPTION
Code line: 155

path: [path](https://github.com/TBD54566975/web5-js/blob/main/packages/api/src/web5.ts)

code snippet: 
<img width="823" alt="Screenshot 2023-11-20 at 12 41 14 PM" src="https://github.com/TBD54566975/web5-js/assets/34712687/97ed1f10-98c8-4be9-857f-b2b755ac13be">


**Issue**:  static async connect() throws error with `${storedIdentities}` treated as literal characters, not as an expression for interpolation.

**Relsoved issue**:
<img width="774" alt="Screenshot 2023-11-20 at 12 51 30 PM" src="https://github.com/TBD54566975/web5-js/assets/34712687/fc96a12f-83fd-4785-8e5b-b54d23de6e4a">
