### PR TITLE
fix tsconfig errors

### DIFF
--- a/.web5-spec/tsconfig.json
+++ b/.web5-spec/tsconfig.json
@@ -1,10 +1,6 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
-    "lib": [
-      "DOM",
-      "ES6"
-    ],
     "declarationDir": "dist/types",
     "outDir": "dist",
   },

--- a/.web5-spec/tsconfig.json
+++ b/.web5-spec/tsconfig.json
@@ -1,6 +1,6 @@
 {
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "extends": "../../tsconfig.json",
     "lib": [
       "DOM",
       "ES6"

--- a/.web5-spec/tsconfig.json
+++ b/.web5-spec/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "declarationDir": "dist/types",
     "outDir": "dist",
+    "strict": false
   },
   "include": [
     "main.ts",

--- a/.web5-spec/tsconfig.json
+++ b/.web5-spec/tsconfig.json
@@ -1,22 +1,12 @@
 {
   "compilerOptions": {
-    // "strict": true,
+    "extends": "../../tsconfig.json",
     "lib": [
       "DOM",
       "ES6"
     ],
-    "allowJs": true,
-    "target": "es6",
-    "module": "NodeNext",
-    "declaration": true,
-    "declarationMap": true,
     "declarationDir": "dist/types",
     "outDir": "dist",
-    // `NodeNext` will throw compilation errors if relative import paths are missing file extension
-    // reference: https://devblogs.microsoft.com/typescript/announcing-typescript-4-7/#ecmascript-module-support-in-node-js
-    "moduleResolution": "NodeNext",
-    "esModuleInterop": true,
-    "resolveJsonModule": true
   },
   "include": [
     "main.ts",

--- a/.web5-spec/tsconfig.json
+++ b/.web5-spec/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../tsconfig.json",
   "compilerOptions": {
     "lib": [
       "DOM",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1118,9 +1118,9 @@
       }
     },
     "node_modules/@types/dns-packet": {
-      "version": "5.6.3",
-      "resolved": "https://registry.npmjs.org/@types/dns-packet/-/dns-packet-5.6.3.tgz",
-      "integrity": "sha512-T7YsGU31kUqAeN5SzfJxapsTAVCXucSb4QsnB7wcbFBpdm7Y77r/5SBrUpdT3Ng22pgxJtLljtQtBvkP5BiSqg==",
+      "version": "5.6.4",
+      "resolved": "https://registry.npmjs.org/@types/dns-packet/-/dns-packet-5.6.4.tgz",
+      "integrity": "sha512-R0ORTvCCeujG+upKfV4JlvozKLdQWlpsducXGd1L6ezBChwpjSj9K84F+KoMDsZQ9RhOLTR1hnNrwJHWagY24g==",
       "dev": true,
       "dependencies": {
         "@types/node": "*"
@@ -1187,9 +1187,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.10.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.0.tgz",
-      "integrity": "sha512-D0WfRmU9TQ8I9PFx9Yc+EBHw+vSpIub4IDvQivcp26PtPrdMGAq5SDcpXEo/epqa/DXotVpekHiLNTg3iaKXBQ==",
+      "version": "20.10.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.1.tgz",
+      "integrity": "sha512-T2qwhjWwGH81vUEx4EXmBKsTJRXFXNZTL4v0gi01+zyBmCwzE6TyHszqX01m+QHTEq+EZNo13NeJIdEqf+Myrg==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -3419,9 +3419,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.596",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.596.tgz",
-      "integrity": "sha512-zW3zbZ40Icb2BCWjm47nxwcFGYlIgdXkAx85XDO7cyky9J4QQfq8t0W19/TLZqq3JPQXtlv8BPIGmfa9Jb4scg==",
+      "version": "1.4.597",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.597.tgz",
+      "integrity": "sha512-0XOQNqHhg2YgRVRUrS4M4vWjFCFIP2ETXcXe/0KIQBjXE9Cpy+tgzzYfuq6HGai3hWq0YywtG+5XK8fyG08EjA==",
       "dev": true,
       "peer": true
     },

--- a/packages/agent/src/dwn-manager.ts
+++ b/packages/agent/src/dwn-manager.ts
@@ -10,7 +10,7 @@ import {
 import { Jose } from '@web5/crypto';
 import { Convert } from '@web5/common';
 import { DidResolver } from '@web5/dids';
-import { Readable } from 'readable-stream';
+import type { Readable } from 'readable-stream';
 import { utils as didUtils } from '@web5/dids';
 
 import {

--- a/packages/agent/src/dwn-manager.ts
+++ b/packages/agent/src/dwn-manager.ts
@@ -1,3 +1,5 @@
+import type { Readable } from 'readable-stream';
+
 import {
   Signer,
   GenericMessage,
@@ -10,7 +12,6 @@ import {
 import { Jose } from '@web5/crypto';
 import { Convert } from '@web5/common';
 import { DidResolver } from '@web5/dids';
-import type { Readable } from 'readable-stream';
 import { utils as didUtils } from '@web5/dids';
 
 import {

--- a/packages/agent/tsconfig.cjs.json
+++ b/packages/agent/tsconfig.cjs.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "lib": [
       "DOM",
-      "ES5",
+      "ES5"
     ],
     "target": "ES5",
     "module": "CommonJS",

--- a/packages/agent/tsconfig.json
+++ b/packages/agent/tsconfig.json
@@ -1,10 +1,10 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist/esm",
     "declaration": true,
     "declarationMap": true,
     "declarationDir": "dist/types",
+    "outDir": "dist/esm"
   },
   "include": [
     "src",

--- a/packages/agent/tsconfig.json
+++ b/packages/agent/tsconfig.json
@@ -1,27 +1,15 @@
 {
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "strict": true,
-    "lib": [
-      "DOM",
-      "ESNext"
-    ],
-    "allowJs": true,
-    "target": "ESNext",
-    "module": "ESNext", // Required for enabling JavaScript import assertion support
+    "outDir": "dist/esm",
     "declaration": true,
     "declarationMap": true,
     "declarationDir": "dist/types",
-    "outDir": "dist/esm",
-    "sourceMap": true,
-    // `NodeNext` will throw compilation errors if relative import paths are missing file extension
-    // reference: https://devblogs.microsoft.com/typescript/announcing-typescript-4-7/#ecmascript-module-support-in-node-js
-    "esModuleInterop": true,
-    "rootDir": "./src"
   },
   "include": [
     "src",
   ],
   "exclude": [
     "node_modules"
-  ]
+  ],
 }

--- a/packages/agent/tsconfig.json
+++ b/packages/agent/tsconfig.json
@@ -5,9 +5,9 @@
     "outDir": "dist/esm"
   },
   "include": [
-    "src",
+    "src"
   ],
   "exclude": [
     "node_modules"
-  ],
+  ]
 }

--- a/packages/agent/tsconfig.json
+++ b/packages/agent/tsconfig.json
@@ -1,8 +1,6 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "declaration": true,
-    "declarationMap": true,
     "declarationDir": "dist/types",
     "outDir": "dist/esm"
   },

--- a/packages/agent/tsconfig.json
+++ b/packages/agent/tsconfig.json
@@ -3,10 +3,10 @@
     "strict": true,
     "lib": [
       "DOM",
-      "ES6"
+      "ESNext"
     ],
     "allowJs": true,
-    "target": "es6",
+    "target": "ESNext",
     "module": "ESNext", // Required for enabling JavaScript import assertion support
     "declaration": true,
     "declarationMap": true,
@@ -15,8 +15,8 @@
     "sourceMap": true,
     // `NodeNext` will throw compilation errors if relative import paths are missing file extension
     // reference: https://devblogs.microsoft.com/typescript/announcing-typescript-4-7/#ecmascript-module-support-in-node-js
-    "moduleResolution": "NodeNext",
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "rootDir": "./src"
   },
   "include": [
     "src",

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -28,6 +28,4 @@ export * from './record.js';
 export * from './vc-api.js';
 export * from './web5.js';
 export * from './tech-preview.js';
-
-import * as utils from './utils.js';
-export { utils };
+export * from './utils.js';

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -28,4 +28,6 @@ export * from './record.js';
 export * from './vc-api.js';
 export * from './web5.js';
 export * from './tech-preview.js';
-export * from './utils.js';
+
+import * as utils from './utils.js';
+export { utils };

--- a/packages/api/tsconfig.cjs.json
+++ b/packages/api/tsconfig.cjs.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "lib": [
       "DOM",
-      "ES5",
+      "ES5"
     ],
     "target": "ES5",
     "module": "CommonJS",

--- a/packages/api/tsconfig.json
+++ b/packages/api/tsconfig.json
@@ -3,20 +3,21 @@
     // "strict": true,
     "lib": [
       "DOM",
-      "ES6"
+      "ESNext"
     ],
     "allowJs": true,
-    "target": "es6",
-    "module": "ESNext",
+    "target": "ESNext",
+    "module": "ESNext", // Required for enabling JavaScript import assertion support
     "declaration": true,
     "declarationMap": true,
     "declarationDir": "dist/types",
     "outDir": "dist/esm",
+    "sourceMap": true,
     // `NodeNext` will throw compilation errors if relative import paths are missing file extension
     // reference: https://devblogs.microsoft.com/typescript/announcing-typescript-4-7/#ecmascript-module-support-in-node-js
-    "moduleResolution": "NodeNext",
     "esModuleInterop": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "rootDir": "./src"
   },
   "include": [
     "src",

--- a/packages/api/tsconfig.json
+++ b/packages/api/tsconfig.json
@@ -2,8 +2,6 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "strict": false,
-    "declaration": true,
-    "declarationMap": true,
     "declarationDir": "dist/types",
     "outDir": "dist/esm"
   },

--- a/packages/api/tsconfig.json
+++ b/packages/api/tsconfig.json
@@ -1,23 +1,11 @@
 {
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
-    // "strict": true,
-    "lib": [
-      "DOM",
-      "ESNext"
-    ],
-    "allowJs": true,
-    "target": "ESNext",
-    "module": "ESNext", // Required for enabling JavaScript import assertion support
+    "strict": false,
+    "outDir": "dist/esm",
     "declaration": true,
     "declarationMap": true,
     "declarationDir": "dist/types",
-    "outDir": "dist/esm",
-    "sourceMap": true,
-    // `NodeNext` will throw compilation errors if relative import paths are missing file extension
-    // reference: https://devblogs.microsoft.com/typescript/announcing-typescript-4-7/#ecmascript-module-support-in-node-js
-    "esModuleInterop": true,
-    "resolveJsonModule": true,
-    "rootDir": "./src"
   },
   "include": [
     "src",

--- a/packages/api/tsconfig.json
+++ b/packages/api/tsconfig.json
@@ -6,7 +6,7 @@
     "outDir": "dist/esm"
   },
   "include": [
-    "src",
+    "src"
   ],
   "exclude": [
     "node_modules"

--- a/packages/api/tsconfig.json
+++ b/packages/api/tsconfig.json
@@ -2,10 +2,10 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "strict": false,
-    "outDir": "dist/esm",
     "declaration": true,
     "declarationMap": true,
     "declarationDir": "dist/types",
+    "outDir": "dist/esm"
   },
   "include": [
     "src",

--- a/packages/common/tsconfig.json
+++ b/packages/common/tsconfig.json
@@ -1,10 +1,10 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist/esm",
     "declaration": true,
     "declarationMap": true,
     "declarationDir": "dist/types",
+    "outDir": "dist/esm"
   },
   "include": [
     "src",

--- a/packages/common/tsconfig.json
+++ b/packages/common/tsconfig.json
@@ -1,8 +1,6 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "declaration": true,
-    "declarationMap": true,
     "declarationDir": "dist/types",
     "outDir": "dist/esm"
   },

--- a/packages/common/tsconfig.json
+++ b/packages/common/tsconfig.json
@@ -5,7 +5,7 @@
     "outDir": "dist/esm"
   },
   "include": [
-    "src",
+    "src"
   ],
   "exclude": [
     "node_modules"

--- a/packages/common/tsconfig.json
+++ b/packages/common/tsconfig.json
@@ -1,22 +1,10 @@
 {
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "strict": true,
-    "lib": [
-      "DOM",
-      "ESNext"
-    ],
-    "allowJs": true,
-    "target": "ESNext",
-    "module": "ESNext", // Required for enabling JavaScript import assertion support
+    "outDir": "dist/esm",
     "declaration": true,
     "declarationMap": true,
     "declarationDir": "dist/types",
-    "outDir": "dist/esm",
-    "sourceMap": true,
-    // `NodeNext` will throw compilation errors if relative import paths are missing file extension
-    // reference: https://devblogs.microsoft.com/typescript/announcing-typescript-4-7/#ecmascript-module-support-in-node-js
-    "esModuleInterop": true,
-    "rootDir": "./src"
   },
   "include": [
     "src",

--- a/packages/common/tsconfig.json
+++ b/packages/common/tsconfig.json
@@ -3,10 +3,10 @@
     "strict": true,
     "lib": [
       "DOM",
-      "ES6"
+      "ESNext"
     ],
     "allowJs": true,
-    "target": "es6",
+    "target": "ESNext",
     "module": "ESNext", // Required for enabling JavaScript import assertion support
     "declaration": true,
     "declarationMap": true,
@@ -15,8 +15,8 @@
     "sourceMap": true,
     // `NodeNext` will throw compilation errors if relative import paths are missing file extension
     // reference: https://devblogs.microsoft.com/typescript/announcing-typescript-4-7/#ecmascript-module-support-in-node-js
-    "moduleResolution": "NodeNext",
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "rootDir": "./src"
   },
   "include": [
     "src",

--- a/packages/credentials/tsconfig.cjs.json
+++ b/packages/credentials/tsconfig.cjs.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "lib": [
       "DOM",
-      "ES5",
+      "ES5"
     ],
     "target": "ES5",
     "module": "CommonJS",

--- a/packages/credentials/tsconfig.json
+++ b/packages/credentials/tsconfig.json
@@ -1,10 +1,10 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist/esm",
     "declaration": true,
     "declarationMap": true,
     "declarationDir": "dist/types",
+    "outDir": "dist/esm"
   },
   "include": [
     "src",

--- a/packages/credentials/tsconfig.json
+++ b/packages/credentials/tsconfig.json
@@ -1,8 +1,6 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "declaration": true,
-    "declarationMap": true,
     "declarationDir": "dist/types",
     "outDir": "dist/esm"
   },

--- a/packages/credentials/tsconfig.json
+++ b/packages/credentials/tsconfig.json
@@ -5,7 +5,7 @@
     "outDir": "dist/esm"
   },
   "include": [
-    "src",
+    "src"
   ],
   "exclude": [
     "node_modules"

--- a/packages/credentials/tsconfig.json
+++ b/packages/credentials/tsconfig.json
@@ -1,22 +1,10 @@
 {
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "strict": true,
-    "lib": [
-      "DOM",
-      "ESNext"
-    ],
-    "allowJs": true,
-    "target": "ESNext",
-    "module": "ESNext", // Required for enabling JavaScript import assertion support
+    "outDir": "dist/esm",
     "declaration": true,
     "declarationMap": true,
     "declarationDir": "dist/types",
-    "outDir": "dist/esm",
-    "sourceMap": true,
-    // `NodeNext` will throw compilation errors if relative import paths are missing file extension
-    // reference: https://devblogs.microsoft.com/typescript/announcing-typescript-4-7/#ecmascript-module-support-in-node-js
-    "esModuleInterop": true,
-    "rootDir": "./src"
   },
   "include": [
     "src",

--- a/packages/credentials/tsconfig.json
+++ b/packages/credentials/tsconfig.json
@@ -3,10 +3,10 @@
     "strict": true,
     "lib": [
       "DOM",
-      "ES6"
+      "ESNext"
     ],
     "allowJs": true,
-    "target": "es6",
+    "target": "ESNext",
     "module": "ESNext", // Required for enabling JavaScript import assertion support
     "declaration": true,
     "declarationMap": true,
@@ -15,8 +15,8 @@
     "sourceMap": true,
     // `NodeNext` will throw compilation errors if relative import paths are missing file extension
     // reference: https://devblogs.microsoft.com/typescript/announcing-typescript-4-7/#ecmascript-module-support-in-node-js
-    "moduleResolution": "NodeNext",
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "rootDir": "./src"
   },
   "include": [
     "src",

--- a/packages/crypto/tsconfig.cjs.json
+++ b/packages/crypto/tsconfig.cjs.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "lib": [
       "DOM",
-      "ES5",
+      "ES5"
     ],
     "target": "ES5",
     "module": "CommonJS",

--- a/packages/crypto/tsconfig.json
+++ b/packages/crypto/tsconfig.json
@@ -1,10 +1,10 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist/esm",
     "declaration": true,
     "declarationMap": true,
     "declarationDir": "dist/types",
+    "outDir": "dist/esm"
   },
   "include": [
     "src",

--- a/packages/crypto/tsconfig.json
+++ b/packages/crypto/tsconfig.json
@@ -3,19 +3,20 @@
     "strict": true,
     "lib": [
       "DOM",
-      "ES6"
+      "ESNext"
     ],
     "allowJs": true,
-    "target": "es6",
+    "target": "ESNext",
     "module": "ESNext", // Required for enabling JavaScript import assertion support
     "declaration": true,
     "declarationMap": true,
     "declarationDir": "dist/types",
     "outDir": "dist/esm",
+    "sourceMap": true,
     // `NodeNext` will throw compilation errors if relative import paths are missing file extension
     // reference: https://devblogs.microsoft.com/typescript/announcing-typescript-4-7/#ecmascript-module-support-in-node-js
-    "moduleResolution": "NodeNext",
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "rootDir": "./src"
   },
   "include": [
     "src"

--- a/packages/crypto/tsconfig.json
+++ b/packages/crypto/tsconfig.json
@@ -1,8 +1,6 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "declaration": true,
-    "declarationMap": true,
     "declarationDir": "dist/types",
     "outDir": "dist/esm"
   },

--- a/packages/crypto/tsconfig.json
+++ b/packages/crypto/tsconfig.json
@@ -1,25 +1,13 @@
 {
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "strict": true,
-    "lib": [
-      "DOM",
-      "ESNext"
-    ],
-    "allowJs": true,
-    "target": "ESNext",
-    "module": "ESNext", // Required for enabling JavaScript import assertion support
+    "outDir": "dist/esm",
     "declaration": true,
     "declarationMap": true,
     "declarationDir": "dist/types",
-    "outDir": "dist/esm",
-    "sourceMap": true,
-    // `NodeNext` will throw compilation errors if relative import paths are missing file extension
-    // reference: https://devblogs.microsoft.com/typescript/announcing-typescript-4-7/#ecmascript-module-support-in-node-js
-    "esModuleInterop": true,
-    "rootDir": "./src"
   },
   "include": [
-    "src"
+    "src",
   ],
   "exclude": [
     "node_modules"

--- a/packages/crypto/tsconfig.json
+++ b/packages/crypto/tsconfig.json
@@ -5,7 +5,7 @@
     "outDir": "dist/esm"
   },
   "include": [
-    "src",
+    "src"
   ],
   "exclude": [
     "node_modules"

--- a/packages/dids/tsconfig.cjs.json
+++ b/packages/dids/tsconfig.cjs.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "lib": [
       "DOM",
-      "ES5",
+      "ES5"
     ],
     "target": "ES5",
     "module": "CommonJS",

--- a/packages/dids/tsconfig.json
+++ b/packages/dids/tsconfig.json
@@ -2,8 +2,6 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "strict": false,
-    "declaration": true,
-    "declarationMap": true,
     "declarationDir": "dist/types",
     "outDir": "dist/esm"
   },

--- a/packages/dids/tsconfig.json
+++ b/packages/dids/tsconfig.json
@@ -1,20 +1,11 @@
 {
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "lib": [
-      "DOM",
-      "ESNext"
-    ],
-    "target": "ESNext",
-    "module": "ESNext", // Required for enabling JavaScript import assertion support
+    "strict": false,
+    "outDir": "dist/esm",
     "declaration": true,
     "declarationMap": true,
     "declarationDir": "dist/types",
-    "outDir": "dist/esm",
-    "sourceMap": true,
-    // `NodeNext` will throw compilation errors if relative import paths are missing file extension
-    // reference: https://devblogs.microsoft.com/typescript/announcing-typescript-4-7/#ecmascript-module-support-in-node-js
-    "esModuleInterop": true,
-    "rootDir": "./src"
   },
   "include": [
     "src",

--- a/packages/dids/tsconfig.json
+++ b/packages/dids/tsconfig.json
@@ -2,18 +2,19 @@
   "compilerOptions": {
     "lib": [
       "DOM",
-      "ES6"
+      "ESNext"
     ],
-    "target": "es6",
+    "target": "ESNext",
     "module": "ESNext", // Required for enabling JavaScript import assertion support
     "declaration": true,
     "declarationMap": true,
     "declarationDir": "dist/types",
     "outDir": "dist/esm",
+    "sourceMap": true,
     // `NodeNext` will throw compilation errors if relative import paths are missing file extension
     // reference: https://devblogs.microsoft.com/typescript/announcing-typescript-4-7/#ecmascript-module-support-in-node-js
-    "moduleResolution": "NodeNext",
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "rootDir": "./src"
   },
   "include": [
     "src",

--- a/packages/dids/tsconfig.json
+++ b/packages/dids/tsconfig.json
@@ -2,10 +2,10 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "strict": false,
-    "outDir": "dist/esm",
     "declaration": true,
     "declarationMap": true,
     "declarationDir": "dist/types",
+    "outDir": "dist/esm"
   },
   "include": [
     "src",

--- a/packages/identity-agent/tsconfig.cjs.json
+++ b/packages/identity-agent/tsconfig.cjs.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "lib": [
       "DOM",
-      "ES5",
+      "ES5"
     ],
     "target": "ES5",
     "module": "CommonJS",

--- a/packages/identity-agent/tsconfig.json
+++ b/packages/identity-agent/tsconfig.json
@@ -1,10 +1,10 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist/esm",
     "declaration": true,
     "declarationMap": true,
     "declarationDir": "dist/types",
+    "outDir": "dist/esm"
   },
   "include": [
     "src",

--- a/packages/identity-agent/tsconfig.json
+++ b/packages/identity-agent/tsconfig.json
@@ -3,10 +3,10 @@
     "strict": true,
     "lib": [
       "DOM",
-      "ES6"
+      "ESNext"
     ],
     "allowJs": true,
-    "target": "es6",
+    "target": "ESNext",
     "module": "ESNext", // Required for enabling JavaScript import assertion support
     "declaration": true,
     "declarationMap": true,
@@ -15,7 +15,6 @@
     "sourceMap": true,
     // `NodeNext` will throw compilation errors if relative import paths are missing file extension
     // reference: https://devblogs.microsoft.com/typescript/announcing-typescript-4-7/#ecmascript-module-support-in-node-js
-    "moduleResolution": "NodeNext",
     "esModuleInterop": true
   },
   "include": [

--- a/packages/identity-agent/tsconfig.json
+++ b/packages/identity-agent/tsconfig.json
@@ -1,8 +1,6 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "declaration": true,
-    "declarationMap": true,
     "declarationDir": "dist/types",
     "outDir": "dist/esm"
   },

--- a/packages/identity-agent/tsconfig.json
+++ b/packages/identity-agent/tsconfig.json
@@ -1,21 +1,10 @@
 {
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "strict": true,
-    "lib": [
-      "DOM",
-      "ESNext"
-    ],
-    "allowJs": true,
-    "target": "ESNext",
-    "module": "ESNext", // Required for enabling JavaScript import assertion support
+    "outDir": "dist/esm",
     "declaration": true,
     "declarationMap": true,
     "declarationDir": "dist/types",
-    "outDir": "dist/esm",
-    "sourceMap": true,
-    // `NodeNext` will throw compilation errors if relative import paths are missing file extension
-    // reference: https://devblogs.microsoft.com/typescript/announcing-typescript-4-7/#ecmascript-module-support-in-node-js
-    "esModuleInterop": true
   },
   "include": [
     "src",

--- a/packages/proxy-agent/tsconfig.cjs.json
+++ b/packages/proxy-agent/tsconfig.cjs.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "lib": [
       "DOM",
-      "ES5",
+      "ES5"
     ],
     "target": "ES5",
     "module": "CommonJS",

--- a/packages/proxy-agent/tsconfig.json
+++ b/packages/proxy-agent/tsconfig.json
@@ -1,10 +1,10 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist/esm",
     "declaration": true,
     "declarationMap": true,
     "declarationDir": "dist/types",
+    "outDir": "dist/esm"
   },
   "include": [
     "src",

--- a/packages/proxy-agent/tsconfig.json
+++ b/packages/proxy-agent/tsconfig.json
@@ -1,8 +1,6 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "declaration": true,
-    "declarationMap": true,
     "declarationDir": "dist/types",
     "outDir": "dist/esm"
   },

--- a/packages/proxy-agent/tsconfig.json
+++ b/packages/proxy-agent/tsconfig.json
@@ -1,21 +1,10 @@
 {
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "strict": true,
-    "lib": [
-      "DOM",
-      "ESNext"
-    ],
-    "target": "ESNext",
-    "module": "ESNext", // Required for enabling JavaScript import assertion support
+    "outDir": "dist/esm",
     "declaration": true,
     "declarationMap": true,
     "declarationDir": "dist/types",
-    "outDir": "dist/esm",
-    "sourceMap": true,
-    // `NodeNext` will throw compilation errors if relative import paths are missing file extension
-    // reference: https://devblogs.microsoft.com/typescript/announcing-typescript-4-7/#ecmascript-module-support-in-node-js
-    "esModuleInterop": true,
-    "rootDir": "./src"
   },
   "include": [
     "src",

--- a/packages/proxy-agent/tsconfig.json
+++ b/packages/proxy-agent/tsconfig.json
@@ -3,9 +3,9 @@
     "strict": true,
     "lib": [
       "DOM",
-      "ES6"
+      "ESNext"
     ],
-    "target": "es6",
+    "target": "ESNext",
     "module": "ESNext", // Required for enabling JavaScript import assertion support
     "declaration": true,
     "declarationMap": true,
@@ -14,8 +14,8 @@
     "sourceMap": true,
     // `NodeNext` will throw compilation errors if relative import paths are missing file extension
     // reference: https://devblogs.microsoft.com/typescript/announcing-typescript-4-7/#ecmascript-module-support-in-node-js
-    "moduleResolution": "NodeNext",
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "rootDir": "./src"
   },
   "include": [
     "src",

--- a/packages/user-agent/tsconfig.cjs.json
+++ b/packages/user-agent/tsconfig.cjs.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "lib": [
       "DOM",
-      "ES5",
+      "ES5"
     ],
     "target": "ES5",
     "module": "CommonJS",

--- a/packages/user-agent/tsconfig.json
+++ b/packages/user-agent/tsconfig.json
@@ -1,10 +1,10 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist/esm",
     "declaration": true,
     "declarationMap": true,
     "declarationDir": "dist/types",
+    "outDir": "dist/esm"
   },
   "include": [
     "src",

--- a/packages/user-agent/tsconfig.json
+++ b/packages/user-agent/tsconfig.json
@@ -1,8 +1,6 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "declaration": true,
-    "declarationMap": true,
     "declarationDir": "dist/types",
     "outDir": "dist/esm"
   },

--- a/packages/user-agent/tsconfig.json
+++ b/packages/user-agent/tsconfig.json
@@ -5,7 +5,7 @@
     "outDir": "dist/esm"
   },
   "include": [
-    "src",
+    "src"
   ],
   "exclude": [
     "node_modules"

--- a/packages/user-agent/tsconfig.json
+++ b/packages/user-agent/tsconfig.json
@@ -1,22 +1,10 @@
 {
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "strict": true,
-    "lib": [
-      "DOM",
-      "ESNext"
-    ],
-    "allowJs": true,
-    "target": "ESNext",
-    "module": "ESNext", // Required for enabling JavaScript import assertion support
+    "outDir": "dist/esm",
     "declaration": true,
     "declarationMap": true,
     "declarationDir": "dist/types",
-    "outDir": "dist/esm",
-    "sourceMap": true,
-    // `NodeNext` will throw compilation errors if relative import paths are missing file extension
-    // reference: https://devblogs.microsoft.com/typescript/announcing-typescript-4-7/#ecmascript-module-support-in-node-js
-    "esModuleInterop": true,
-    "rootDir": "./src"
   },
   "include": [
     "src",

--- a/packages/user-agent/tsconfig.json
+++ b/packages/user-agent/tsconfig.json
@@ -3,10 +3,10 @@
     "strict": true,
     "lib": [
       "DOM",
-      "ES6"
+      "ESNext"
     ],
     "allowJs": true,
-    "target": "es6",
+    "target": "ESNext",
     "module": "ESNext", // Required for enabling JavaScript import assertion support
     "declaration": true,
     "declarationMap": true,
@@ -15,8 +15,8 @@
     "sourceMap": true,
     // `NodeNext` will throw compilation errors if relative import paths are missing file extension
     // reference: https://devblogs.microsoft.com/typescript/announcing-typescript-4-7/#ecmascript-module-support-in-node-js
-    "moduleResolution": "NodeNext",
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "rootDir": "./src"
   },
   "include": [
     "src",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
     "strict": true,
     "declaration": true,
     "declarationMap": true,
-    "target": "ESNext",
+    "target": "ES6",
     "module": "NodeNext", // Required for enabling JavaScript import assertion support
     "sourceMap": true,
     // `NodeNext` will throw compilation errors if relative import paths are missing file extension

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,8 @@
     ],
     "allowJs": true,
     "strict": true,
+    "declaration": true,
+    "declarationMap": true,
     "target": "ESNext",
     "module": "NodeNext", // Required for enabling JavaScript import assertion support
     "sourceMap": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "lib": [
+      "DOM",
+      "ESNext"
+    ],
+    "allowJs": true,
+    "strict": true,
+    "target": "ESNext",
+    "module": "NodeNext", // Required for enabling JavaScript import assertion support
+    "sourceMap": true,
+    // `NodeNext` will throw compilation errors if relative import paths are missing file extension
+    // reference: https://devblogs.microsoft.com/typescript/announcing-typescript-4-7/#ecmascript-module-support-in-node-js
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "moduleResolution": "NodeNext",
+  },
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": [
       "DOM",
-      "ESNext"
+      "ES6"
     ],
     "allowJs": true,
     "strict": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,6 @@
     // reference: https://devblogs.microsoft.com/typescript/announcing-typescript-4-7/#ecmascript-module-support-in-node-js
     "esModuleInterop": true,
     "resolveJsonModule": true,
-    "moduleResolution": "NodeNext",
-  },
+    "moduleResolution": "NodeNext"
+  }
 }


### PR DESCRIPTION
## Reason for PR

- Several annoying and intermittent errors
- tsconfigs were verbose and repeated
- Noticed some of the packages lacked sourcemaps 

## Solution
- Enable sourcemaps
- Extend from a base tsconfig
- Pass minimal required settings (e.g. `outDir` and `declarationDir`)
- Overwrite settings as needed