### PR TITLE
speed up ci

### DIFF
--- a/.github/workflows/tests-ci.yml
+++ b/.github/workflows/tests-ci.yml
@@ -8,7 +8,7 @@ on:
     branches:
       - main
 
-  # Allows you to run this workflow manually from the Actions tab
+  # Allows you to run this workflow manually from the Actions tab 
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/tests-ci.yml
+++ b/.github/workflows/tests-ci.yml
@@ -16,15 +16,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source
-        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+        uses: actions/checkout@v4
 
       - name: Set up Node.js
-        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
+        uses: actions/setup-node@v4
         with:
           node-version: 18
-
-      - name: Install latest npm
-        run: npm install -g npm@latest
+          cache: 'npm'
 
       - name: Install dependencies
         run: npm ci
@@ -50,16 +48,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source
-        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+        uses: actions/checkout@v4
 
       - name: Set up Node.js
-        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
+        uses: actions/setup-node@v4
         with:
           node-version: 18
           registry-url: https://registry.npmjs.org/
-
-      - name: Install latest npm
-        run: npm install -g npm@latest
+          cache: 'npm'
 
       - name: Install dependencies
         run: npm ci
@@ -86,62 +82,57 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
-  test-with-browsers:
-    # Run browser tests using macOS so that WebKit tests don't fail under a Linux environment
-    runs-on: macos-latest
-    steps:
-      - name: Checkout source
-        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+  # test-with-browsers:
+  #   # Run browser tests using macOS so that WebKit tests don't fail under a Linux environment
+  #   runs-on: macos-latest
+  #   steps:
+  #     - name: Checkout source
+  #       uses: actions/checkout@v4
 
-      - name: Set up Node.js
-        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
-        with:
-          node-version: 18
-          registry-url: https://registry.npmjs.org/
+  #     - name: Set up Node.js
+  #       uses: actions/setup-node@v4
+  #       with:
+  #         node-version: 18
+  #         registry-url: https://registry.npmjs.org/
 
-      - name: Install latest npm
-        run: npm install -g npm@latest
+  #     - name: Install dependencies
+  #       run: npm ci
 
-      - name: Install dependencies
-        run: npm ci
+  #     - name: Install Playwright Browsers
+  #       run: npx playwright install --with-deps
 
-      - name: Install Playwright Browsers
-        run: npx playwright install --with-deps
+  #     - name: Build all workspace packages
+  #       run: npm run build
 
-      - name: Build all workspace packages
-        run: npm run build
+  #     - name: Install docker
+  #       run: brew install docker && brew install docker-compose # && colima start
 
-      - name: Install docker
-        run: brew install docker && brew install docker-compose # && colima start
+  #     - name: Start docker
+  #       run: colima start
 
-      - name: Start docker
-        run: colima start
+  #     - name: Start dwn-server container
+  #       run: cd packages/dev-env && docker-compose up -d
 
-      - name: Start dwn-server container
-        run: cd packages/dev-env && docker-compose up -d
+  #     - name: Wait for dwn-server to be ready
+  #       run: until curl -sf http://localhost:3000/health; do echo -n .; sleep .1; done
 
-      - name: Wait for dwn-server to be ready
-        run: until curl -sf http://localhost:3000/health; do echo -n .; sleep .1; done
-
-      - name: Run tests for all packages
-        run: npm run test:browser --ws -- --color
-        env:
-          TEST_DWN_URL: http://localhost:3000
+  #     - name: Run tests for all packages
+  #       run: npm run test:browser --ws -- --color
+  #       env:
+  #         TEST_DWN_URL: http://localhost:3000
 
   tbdocs-reporter:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source
-        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+        uses: actions/checkout@v4
 
       - name: Set up Node.js
-        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
+        uses: actions/setup-node@v4
         with:
           node-version: 18
           registry-url: https://registry.npmjs.org/
-
-      - name: Install latest npm
-        run: npm install -g npm@latest
+          cache: 'npm'
 
       - name: Install dependencies
         run: npm ci
@@ -165,5 +156,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@v4
       - uses: TBD54566975/sdk-development@v0.2.3


### PR DESCRIPTION
## Reason for PR
- CI was running slow. checked the CI steps and saw that node_modules wasn't being cached.
- reinstalling npm globally wasn't necessary as v18 LTS ships a modern version of npm
- actions can be bumped to latest versions

## Solution

- cache node_modules. the cache invalidation of `actions/setup-node` says it supports npm workspaces and works as-is with symlinked projects.
- remove npm install -g npm CI step
- bump action versions to v4
- include #307 
