### PR TITLE
Bump DWN SDK 0.2.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1011,9 +1011,9 @@
       }
     },
     "node_modules/@tbd54566975/dwn-sdk-js": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@tbd54566975/dwn-sdk-js/-/dwn-sdk-js-0.2.6.tgz",
-      "integrity": "sha512-q9HjMhW9KyUD94XVjuO4N+tkeZaOsgtRINIioMKucuZZTCb8Z2lilUleZqc7LiVePCMzlqdRBVeJpMKbnAGj8Q==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@tbd54566975/dwn-sdk-js/-/dwn-sdk-js-0.2.7.tgz",
+      "integrity": "sha512-p7W7di+bf7X3mFu7HURYCr+WV4HJOu9SntqSjMf6J2i7PveOpwEfxQ16aEdTtPvg1v6i5GfMbYYmwuKDlRuBwA==",
       "dependencies": {
         "@ipld/dag-cbor": "9.0.3",
         "@js-temporal/polyfill": "0.4.4",
@@ -1035,7 +1035,7 @@
         "ms": "2.1.3",
         "multiformats": "11.0.2",
         "randombytes": "2.1.0",
-        "readable-stream": "4.4.0",
+        "readable-stream": "4.4.2",
         "ulidx": "2.1.0",
         "uuid": "8.3.2",
         "varint": "6.0.0"
@@ -1077,20 +1077,6 @@
         "encoding": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@tbd54566975/dwn-sdk-js/node_modules/readable-stream": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.4.0.tgz",
-      "integrity": "sha512-kDMOq0qLtxV9f/SQv522h8cxZBqNZXuXNyjyezmfAAuribMyVXziljpQ/uQhfE1XLg2/TLTW2DsnoE4VAi/krg==",
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "buffer": "^6.0.3",
-        "events": "^3.3.0",
-        "process": "^0.11.10"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/@tbd54566975/dwn-sdk-js/node_modules/uuid": {
@@ -9808,7 +9794,7 @@
       "version": "0.2.4",
       "license": "Apache-2.0",
       "dependencies": {
-        "@tbd54566975/dwn-sdk-js": "0.2.6",
+        "@tbd54566975/dwn-sdk-js": "0.2.7",
         "@web5/common": "0.2.1",
         "@web5/crypto": "0.2.2",
         "@web5/dids": "0.2.2",
@@ -9998,7 +9984,7 @@
       "version": "0.8.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@tbd54566975/dwn-sdk-js": "0.2.6",
+        "@tbd54566975/dwn-sdk-js": "0.2.7",
         "@web5/agent": "0.2.4",
         "@web5/crypto": "0.2.2",
         "@web5/dids": "0.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1011,9 +1011,9 @@
       }
     },
     "node_modules/@tbd54566975/dwn-sdk-js": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/@tbd54566975/dwn-sdk-js/-/dwn-sdk-js-0.2.7.tgz",
-      "integrity": "sha512-p7W7di+bf7X3mFu7HURYCr+WV4HJOu9SntqSjMf6J2i7PveOpwEfxQ16aEdTtPvg1v6i5GfMbYYmwuKDlRuBwA==",
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@tbd54566975/dwn-sdk-js/-/dwn-sdk-js-0.2.8.tgz",
+      "integrity": "sha512-oiKk+ekAQO94bUkt6yk+xkDY8uCGmNC+rKaYQLhAoTrhYrczeRSuDT04F5/vPBT5K6NfAoRcQsIyBmvgRCUvgA==",
       "dependencies": {
         "@ipld/dag-cbor": "9.0.3",
         "@js-temporal/polyfill": "0.4.4",
@@ -9794,7 +9794,7 @@
       "version": "0.2.4",
       "license": "Apache-2.0",
       "dependencies": {
-        "@tbd54566975/dwn-sdk-js": "0.2.7",
+        "@tbd54566975/dwn-sdk-js": "0.2.8",
         "@web5/common": "0.2.1",
         "@web5/crypto": "0.2.2",
         "@web5/dids": "0.2.2",
@@ -9984,7 +9984,7 @@
       "version": "0.8.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@tbd54566975/dwn-sdk-js": "0.2.7",
+        "@tbd54566975/dwn-sdk-js": "0.2.8",
         "@web5/agent": "0.2.4",
         "@web5/crypto": "0.2.2",
         "@web5/dids": "0.2.2",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -67,7 +67,7 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
-    "@tbd54566975/dwn-sdk-js": "0.2.7",
+    "@tbd54566975/dwn-sdk-js": "0.2.8",
     "@web5/common": "0.2.1",
     "@web5/crypto": "0.2.2",
     "@web5/dids": "0.2.2",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -67,7 +67,7 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
-    "@tbd54566975/dwn-sdk-js": "0.2.6",
+    "@tbd54566975/dwn-sdk-js": "0.2.7",
     "@web5/common": "0.2.1",
     "@web5/crypto": "0.2.2",
     "@web5/dids": "0.2.2",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -75,7 +75,7 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
-    "@tbd54566975/dwn-sdk-js": "0.2.6",
+    "@tbd54566975/dwn-sdk-js": "0.2.7",
     "@web5/agent": "0.2.4",
     "@web5/crypto": "0.2.2",
     "@web5/dids": "0.2.2",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -75,7 +75,7 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
-    "@tbd54566975/dwn-sdk-js": "0.2.7",
+    "@tbd54566975/dwn-sdk-js": "0.2.8",
     "@web5/agent": "0.2.4",
     "@web5/crypto": "0.2.2",
     "@web5/dids": "0.2.2",

--- a/packages/api/tests/dwn-api.spec.ts
+++ b/packages/api/tests/dwn-api.spec.ts
@@ -149,25 +149,70 @@ describe('DwnApi', () => {
         expect(response.protocols.length).to.equal(0);
       });
 
-      it('returns a 401 when authorization fails', async () => {
-        /** Create a new DID to represent an external entity who has a remote
-         * DWN server defined in their DID document. */
-        const { did: bob } = await testAgent.createIdentity({ testDwnUrls });
+      it('returns published protocol definitions for requests from external did', async () => {
 
-        // Attempt to query for a protocol using Bob's DWN tenant.
-        const response = await dwnAlice.protocols.query({
-          from    : bob.did,
+        // configure a non-published protocol on alice's DWN
+        const notPublicProtocol = await dwnAlice.protocols.configure({
+          message: {
+            definition: { ...emailProtocolDefinition, protocol: 'http://proto-not-published', published: false }
+          }
+        });
+        expect(notPublicProtocol.status.code).to.equal(202);
+        const sendNotPublic = await notPublicProtocol.protocol.send(aliceDid.did);
+        expect(sendNotPublic.status.code).to.equal(202);
+        expect(sendNotPublic.status.detail).to.equal('Accepted');
+
+        // configure a published protocol on alice's DWN
+        const publicProtocol = await dwnAlice.protocols.configure({
+          message: {
+            definition: { ...emailProtocolDefinition, protocol: 'http://proto-published', published: true }
+          }
+        });
+        expect(publicProtocol.status.code).to.equal(202);
+        const sendPublic = await publicProtocol.protocol.send(aliceDid.did);
+        expect(sendPublic.status.code).to.equal(202);
+        expect(sendPublic.status.detail).to.equal('Accepted');
+
+        // Attempt to query for a published protocol using Bob's DWN tenant from Alice.
+        const publishedResponse = await dwnBob.protocols.query({
+          from    : aliceDid.did,
           message : {
             filter: {
+              protocol: 'http://proto-published'
+            }
+          }
+        });
+
+        expect(publishedResponse.status.code).to.equal(200);
+        expect(publishedResponse.protocols.length).to.equal(1);
+        expect(publishedResponse.protocols[0].definition.protocol).to.equal('http://proto-published');
+
+        // Attempt to query for a non-published protocol using Bob's DWN tenant from Alice.
+        const nonPublishedResponse = await dwnBob.protocols.query({
+          from    : aliceDid.did,
+          message : {
+            filter: {
+              protocol: 'http://proto-not-published'
+            }
+          }
+        });
+        expect(nonPublishedResponse.status.code).to.equal(200);
+        expect(nonPublishedResponse.protocols.length).to.equal(0);
+      });
+
+      it('returns a 401 when making an unauthorized ProtocolsQuery', async () => {
+        // Attempt to query for a record using Bob's DWN tenant with an invalid grant.
+        const response = await dwnAlice.protocols.query({
+          from    : bobDid.did,
+          message : {
+            permissionsGrantId : 'invalid-grant-id',
+            filter             : {
               protocol: 'https://doesnotexist.com/protocol'
             }
           }
         });
 
-        /** Confirm that authorization failed because the test identity does not have
-         * permission to delete a record from Bob's DWN. */
         expect(response.status.code).to.equal(401);
-        expect(response.status.detail).to.include('ProtocolsQuery failed authorization');
         expect(response.protocols).to.exist;
         expect(response.protocols.length).to.equal(0);
       });

--- a/packages/api/tests/dwn-api.spec.ts
+++ b/packages/api/tests/dwn-api.spec.ts
@@ -219,7 +219,6 @@ describe('DwnApi', () => {
         });
 
         expect(response.status.code).to.equal(401);
-        console.log(response.status.detail);
         expect(response.status.detail).to.include('GrantAuthorizationGrantMissing');
         expect(response.protocols).to.exist;
         expect(response.protocols.length).to.equal(0);

--- a/packages/dev-env/docker-compose.yaml
+++ b/packages/dev-env/docker-compose.yaml
@@ -3,6 +3,6 @@ version: "3.98"
 services:
   dwn-server:
     container_name: dwn-server
-    image: ghcr.io/tbd54566975/dwn-server:dwn-sdk-0.2.6
+    image: ghcr.io/tbd54566975/dwn-server:dwn-sdk-0.2.7
     ports:
       - "3000:3000"

--- a/packages/dev-env/docker-compose.yaml
+++ b/packages/dev-env/docker-compose.yaml
@@ -3,6 +3,6 @@ version: "3.98"
 services:
   dwn-server:
     container_name: dwn-server
-    image: ghcr.io/tbd54566975/dwn-server:dwn-sdk-0.2.7
+    image: ghcr.io/tbd54566975/dwn-server:dwn-sdk-0.2.8
     ports:
       - "3000:3000"


### PR DESCRIPTION
This PR will:
- Bump `dwn-sdk-js` from `v0.2.6` to `v0.2.8`
- Refactor tests to reflect that `ProtocolQuery` now supports  returning of published protocols by anonymous/unauthorized dids.