### PR TITLE
resolve did:dht in VCs

### DIFF
--- a/packages/credentials/src/verifiable-credential.ts
+++ b/packages/credentials/src/verifiable-credential.ts
@@ -213,13 +213,9 @@ export class VerifiableCredential {
       throw new Error('Signature verification failed: Expected JWS header to contain alg and kid');
     }
 
-
     const verificationResponse = await verifyJWT(vcJwt, {
       resolver: tbdResolver
     });
-
-    console.log('hiii');
-
 
     if (!verificationResponse.verified) {
       throw new Error('VC JWT could not be verified. Reason: ' + JSON.stringify(verificationResponse));

--- a/packages/credentials/src/verifiable-credential.ts
+++ b/packages/credentials/src/verifiable-credential.ts
@@ -8,7 +8,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { getCurrentXmlSchema112Timestamp } from './utils.js';
 import { Convert } from '@web5/common';
 import { verifyJWT } from 'did-jwt';
-import { DidIonMethod, DidKeyMethod, DidResolver } from '@web5/dids';
+import { DidDhtMethod, DidIonMethod, DidKeyMethod, DidResolver } from '@web5/dids';
 import { SsiValidator } from './validators.js';
 
 export const DEFAULT_CONTEXT = 'https://www.w3.org/2018/credentials/v1';
@@ -62,7 +62,7 @@ type DecodedVcJwt = {
   signature: string
 }
 
-const didResolver = new DidResolver({ didResolvers: [DidIonMethod, DidKeyMethod] });
+const didResolver = new DidResolver({ didResolvers: [DidIonMethod, DidKeyMethod, DidDhtMethod] });
 
 class TbdResolver implements Resolvable {
   async resolve(didUrl: string): Promise<DIDResolutionResult> {
@@ -213,9 +213,13 @@ export class VerifiableCredential {
       throw new Error('Signature verification failed: Expected JWS header to contain alg and kid');
     }
 
+
     const verificationResponse = await verifyJWT(vcJwt, {
       resolver: tbdResolver
     });
+
+    console.log('hiii');
+
 
     if (!verificationResponse.verified) {
       throw new Error('VC JWT could not be verified. Reason: ' + JSON.stringify(verificationResponse));

--- a/packages/credentials/tests/verifiable-credential.spec.ts
+++ b/packages/credentials/tests/verifiable-credential.spec.ts
@@ -16,7 +16,6 @@ describe('Verifiable Credential Tests', () => {
     ) {}
   }
 
-
   beforeEach(async () => {
     const alice = await DidKeyMethod.create();
     const [signingKeyPair] = alice.keySet.verificationMethodKeys!;


### PR DESCRIPTION
Tested via:
```
    it('verify does not throw an exception with vaild vc signed by did:dht', async () => {
      const alice = await DidDhtMethod.create({publish: true});
      const sleep = (time: any) => new Promise(resolve => setTimeout(resolve, time));
      await sleep(10_000);
      const [signingKeyPair] = alice.keySet.verificationMethodKeys!;
      const privateKey = (await Jose.jwkToKey({ key: signingKeyPair.privateKeyJwk!})).keyMaterial;
      signer = EdDsaSigner(privateKey);
      signOptions = {
        issuerDid  : alice.did,
        subjectDid : alice.did,
        kid        : alice.did + '#' + alice.did.split(':')[2],
        signer     : signer
      };

      const vc = VerifiableCredential.create({
        type    : 'StreetCred',
        issuer  : signOptions.issuerDid,
        subject : signOptions.subjectDid,
        data    : new StreetCredibility('high', true),
      });

      const vcJwt = await vc.sign(signOptions);

      console.log('signed');

      await VerifiableCredential.verify(vcJwt);

    }).timeout(20_000);
    ```
    
    But not merging due to the long timeout