### PR TITLE
decouple tbdocs commenter

### DIFF
--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -1,0 +1,53 @@
+name: Docs Continuous Integration
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  tbdocs-reporter:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
+        with:
+          node-version: 18
+          registry-url: https://registry.npmjs.org/
+
+      - name: Install latest npm
+        run: npm install -g npm@latest
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build all workspace packages
+        run: npm run build
+
+      - name: TBDocs Reporter
+        id: tbdocs-reporter-protocol
+        uses: TBD54566975/tbdocs@main
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          report_changed_scope_only: false
+          fail_on_error: false
+          entry_points: |
+            - file: packages/api/src/index.ts
+              docsReporter: api-extractor
+              docsGenerator: typedoc-markdown
+
+      - name: Save Artifacts
+        uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: tbdocs-reporter-output
+          path: ./.tbdocs

--- a/.github/workflows/tbdocs-commenter.yml
+++ b/.github/workflows/tbdocs-commenter.yml
@@ -2,7 +2,7 @@ name: TBDocs Commenter
 
 on:
   workflow_run:
-    workflows: ["Continuous Integration"]
+    workflows: ["Docs Continuous Integration"]
     types:
       - completed
 
@@ -25,7 +25,7 @@ jobs:
         run: |
           report_file='.tbdocs/docs-report.md'
           head_sha="${{ github.event.workflow_run.pull_requests[0].head.sha }}"
-          short_sha=${head_sha:0:7} 
+          short_sha=${head_sha:0:7}
           timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
           repo="${{ github.repository }}"
           sha_link="https://github.com/$repo/commit/$head_sha"
@@ -43,7 +43,6 @@ jobs:
           comment-author: "github-actions[bot]"
           body-includes: TBDocs Report
 
-      # Comment content of the report.md file on the PR
       - name: Comment on PR
         uses: peter-evans/create-or-update-comment@v3
         with:

--- a/.github/workflows/tests-ci.yml
+++ b/.github/workflows/tests-ci.yml
@@ -128,46 +128,6 @@ jobs:
         env:
           TEST_DWN_URL: http://localhost:3000
 
-  tbdocs-reporter:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout source
-        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
-
-      - name: Set up Node.js
-        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
-        with:
-          node-version: 18
-          registry-url: https://registry.npmjs.org/
-
-      - name: Install latest npm
-        run: npm install -g npm@latest
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Build all workspace packages
-        run: npm run build
-
-      - name: TBDocs Reporter
-        id: tbdocs-reporter-protocol
-        uses: TBD54566975/tbdocs@main
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          report_changed_scope_only: false
-          fail_on_error: false
-          entry_points: |
-            - file: packages/api/src/index.ts
-              docsReporter: api-extractor
-              docsGenerator: typedoc-markdown
-
-      - name: Save Artifacts
-        uses: actions/upload-artifact@v3
-        if: always()
-        with:
-          name: tbdocs-reporter-output
-          path: ./.tbdocs
-
   web5-spec:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Now we also have the tbdocs report in the GH Action summary! 
<img width="486" alt="image" src="https://github.com/TBD54566975/web5-js/assets/6147142/7c20b9c0-537c-4c86-b85f-e59d4eef2190">

https://github.com/TBD54566975/web5-js/actions/runs/7039346479?pr=323#summary-19158131202

- Decouples the docs reporter from the CI tests
- Decouples the PR comments generation from the tbdocs activity because secrets are not exposed to forked PRs
  - we could either create a server app to watch the PR and open a comment from the server (same [approach taken by CodeCov](https://github.com/codecov/codecov-action/releases/tag/v1.0.6) reports which are passing in our PRs!)
  - or, per the github workflows security recommendations, use the `workflow_run` trigger to safely execute code from the main branch, access secrets and be able to create the report comment
    - [Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)
    - [workflow_run usage example](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#using-data-from-the-triggering-workflow)


PS: the tbdocs report comment in the PR will only start to show up when we merge this PR to main. Unfortunately this is the normal behavior for new `workflow_run` definitions.

Working evidence: 
- TBDocs PR with a comment: https://github.com/TBD54566975/tbdocs/pull/89#issuecomment-1832688597
- TBDocs Commenter workflow_run triggered action logs: https://github.com/TBD54566975/tbdocs/actions/runs/7039271133/job/19157923330#step:5:12

