### PR TITLE
add watch mode for browser testing

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -51,6 +51,14 @@ module.exports = {
     'no-trailing-spaces'                       : ['error'],
     '@typescript-eslint/no-non-null-assertion' : 'off',
     '@typescript-eslint/ban-ts-comment'        : 'off',
-    'mocha/no-exclusive-tests'                 : 'warn'
-  }
+    'mocha/no-exclusive-tests'                 : 'warn',
+  },
+  overrides: [
+    {
+      files : ['*.cjs'],
+      rules : {
+        '@typescript-eslint/no-var-requires': 'off'
+      }
+    }
+  ]
 };

--- a/packages/agent/build/esbuild-browser-config.cjs
+++ b/packages/agent/build/esbuild-browser-config.cjs
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
 const polyfillProviderPlugin = require('node-stdlib-browser/helpers/esbuild/plugin');
 const stdLibBrowser = require('node-stdlib-browser');
 

--- a/packages/agent/build/esbuild-tests.cjs
+++ b/packages/agent/build/esbuild-tests.cjs
@@ -1,8 +1,8 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
 const esbuild = require('esbuild');
 const browserConfig = require('./esbuild-browser-config.cjs');
 
-esbuild.build({
+/** @type {import('esbuild').BuildOptions} */
+let config = {
   ...browserConfig,
   format      : 'esm',
   entryPoints : ['./tests/*.spec.*'],
@@ -13,4 +13,22 @@ esbuild.build({
     ...browserConfig.define,
     'process.env.TEST_DWN_URL': JSON.stringify(process.env.TEST_DWN_URL ?? null),
   },
-});
+};
+
+const handleBuild = () => {
+  esbuild.build(config);
+};
+
+const handleWatch = async() => {
+  let ctx = await esbuild.context(config);
+
+  await ctx.watch();
+};
+
+const hasWatchArg = process.argv.includes('--watch');
+
+if (hasWatchArg) {
+  handleWatch();
+} else {
+  handleBuild();
+}

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -12,11 +12,13 @@
     "build:browser": "rimraf dist/browser.mjs dist/browser.js && node build/bundles.js",
     "build:tests:node": "rimraf tests/compiled && tsc -p tests/tsconfig.json",
     "build:tests:browser": "rimraf tests/compiled && node build/esbuild-tests.cjs",
+    "build:tests:browser:watch": "rimraf tests/compiled && node build/esbuild-tests.cjs --watch &",
     "build": "npm run clean && npm run build:esm && npm run build:cjs && npm run build:browser",
     "lint": "eslint . --ext .ts --max-warnings 0",
     "lint:fix": "eslint . --ext .ts --fix",
     "test:node": "npm run build:tests:node && c8 mocha",
-    "test:browser": "npm run build:tests:browser && web-test-runner"
+    "test:browser": "npm run build:tests:browser && web-test-runner",
+    "test:browser:watch": "(npm run build:tests:browser:watch && web-test-runner --watch) || killall esbuild"
   },
   "homepage": "https://github.com/TBD54566975/web5-js/tree/main/packages/agent#readme",
   "bugs": "https://github.com/TBD54566975/web5-js/issues",

--- a/packages/agent/web-test-runner.config.cjs
+++ b/packages/agent/web-test-runner.config.cjs
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
 const playwrightLauncher =
   require('@web/test-runner-playwright').playwrightLauncher;
 

--- a/packages/api/build/esbuild-browser-config.cjs
+++ b/packages/api/build/esbuild-browser-config.cjs
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
 const polyfillProviderPlugin = require('node-stdlib-browser/helpers/esbuild/plugin');
 const stdLibBrowser = require('node-stdlib-browser');
 

--- a/packages/api/build/esbuild-tests.cjs
+++ b/packages/api/build/esbuild-tests.cjs
@@ -1,8 +1,8 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
 const esbuild = require('esbuild');
 const browserConfig = require('./esbuild-browser-config.cjs');
 
-esbuild.build({
+/** @type {import('esbuild').BuildOptions} */
+let config = {
   ...browserConfig,
   format      : 'esm',
   entryPoints : ['./tests/*.spec.*'],
@@ -13,4 +13,22 @@ esbuild.build({
     ...browserConfig.define,
     'process.env.TEST_DWN_URL': JSON.stringify(process.env.TEST_DWN_URL ?? null),
   },
-});
+};
+
+const handleBuild = () => {
+  esbuild.build(config);
+};
+
+const handleWatch = async() => {
+  let ctx = await esbuild.context(config);
+
+  await ctx.watch();
+};
+
+const hasWatchArg = process.argv.includes('--watch');
+
+if (hasWatchArg) {
+  handleWatch();
+} else {
+  handleBuild();
+}

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -13,11 +13,13 @@
     "build:browser": "rimraf dist/browser.mjs dist/browser.js && node build/bundles.js",
     "build:tests:node": "rimraf tests/compiled && tsc -p tests/tsconfig.json",
     "build:tests:browser": "rimraf tests/compiled && node build/esbuild-tests.cjs",
+    "build:tests:browser:watch": "rimraf tests/compiled && node build/esbuild-tests.cjs --watch &",
     "build": "npm run clean && npm run build:esm && npm run build:cjs && npm run build:browser",
     "lint": "eslint . --ext .ts --max-warnings 0",
     "lint:fix": "eslint . --ext .ts --fix",
     "test:node": "npm run build:tests:node && c8 mocha",
-    "test:browser": "npm run build:tests:browser && web-test-runner"
+    "test:browser": "npm run build:tests:browser && web-test-runner",
+    "test:browser:watch": "(npm run build:tests:browser:watch && web-test-runner --watch) || killall esbuild"
   },
   "homepage": "https://github.com/TBD54566975/web5-js/tree/main/packages/api#readme",
   "bugs": "https://github.com/TBD54566975/web5-js/issues",

--- a/packages/api/web-test-runner.config.cjs
+++ b/packages/api/web-test-runner.config.cjs
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
 const playwrightLauncher =
   require('@web/test-runner-playwright').playwrightLauncher;
 

--- a/packages/common/build/esbuild-tests.cjs
+++ b/packages/common/build/esbuild-tests.cjs
@@ -1,8 +1,8 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
 const esbuild = require('esbuild');
 const browserConfig = require('./esbuild-browser-config.cjs');
 
-esbuild.build({
+/** @type {import('esbuild').BuildOptions} */
+let config = {
   ...browserConfig,
   format      : 'esm',
   entryPoints : ['./tests/*.spec.*'],
@@ -13,4 +13,22 @@ esbuild.build({
     ...browserConfig.define,
     'process.env.TEST_DWN_URL': JSON.stringify(process.env.TEST_DWN_URL ?? null),
   },
-});
+};
+
+const handleBuild = () => {
+  esbuild.build(config);
+};
+
+const handleWatch = async() => {
+  let ctx = await esbuild.context(config);
+
+  await ctx.watch();
+};
+
+const hasWatchArg = process.argv.includes('--watch');
+
+if (hasWatchArg) {
+  handleWatch();
+} else {
+  handleBuild();
+}

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -12,11 +12,13 @@
     "build:browser": "rimraf dist/browser.mjs dist/browser.js && node build/bundles.js",
     "build:tests:node": "rimraf tests/compiled && tsc -p tests/tsconfig.json",
     "build:tests:browser": "rimraf tests/compiled && node build/esbuild-tests.cjs",
+    "build:tests:browser:watch": "rimraf tests/compiled && node build/esbuild-tests.cjs --watch &",
     "build": "npm run clean && npm run build:esm && npm run build:cjs && npm run build:browser",
     "lint": "eslint . --ext .ts --max-warnings 0",
     "lint:fix": "eslint . --ext .ts --fix",
     "test:node": "npm run build:tests:node && c8 mocha",
-    "test:browser": "npm run build:tests:browser && web-test-runner"
+    "test:browser": "npm run build:tests:browser && web-test-runner",
+    "test:browser:watch": "(npm run build:tests:browser:watch && web-test-runner --watch) || killall esbuild"
   },
   "homepage": "https://github.com/TBD54566975/web5-js/tree/main/packages/common#readme",
   "bugs": "https://github.com/TBD54566975/web5-js/issues",

--- a/packages/common/web-test-runner.config.cjs
+++ b/packages/common/web-test-runner.config.cjs
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
 const playwrightLauncher =
   require('@web/test-runner-playwright').playwrightLauncher;
 

--- a/packages/credentials/build/esbuild-tests.cjs
+++ b/packages/credentials/build/esbuild-tests.cjs
@@ -1,8 +1,8 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
 const esbuild = require('esbuild');
 const browserConfig = require('./esbuild-browser-config.cjs');
 
-esbuild.build({
+/** @type {import('esbuild').BuildOptions} */
+let config = {
   ...browserConfig,
   format      : 'esm',
   entryPoints : ['./tests/*.spec.*'],
@@ -13,4 +13,22 @@ esbuild.build({
     ...browserConfig.define,
     'process.env.TEST_DWN_URL': JSON.stringify(process.env.TEST_DWN_URL ?? null),
   },
-});
+};
+
+const handleBuild = () => {
+  esbuild.build(config);
+};
+
+const handleWatch = async() => {
+  let ctx = await esbuild.context(config);
+
+  await ctx.watch();
+};
+
+const hasWatchArg = process.argv.includes('--watch');
+
+if (hasWatchArg) {
+  handleWatch();
+} else {
+  handleBuild();
+}

--- a/packages/credentials/package.json
+++ b/packages/credentials/package.json
@@ -13,11 +13,13 @@
     "build:browser": "rimraf dist/browser.mjs dist/browser.js && node build/bundles.js",
     "build:tests:node": "rimraf tests/compiled && tsc -p tests/tsconfig.json",
     "build:tests:browser": "rimraf tests/compiled && node build/esbuild-tests.cjs",
+    "build:tests:browser:watch": "rimraf tests/compiled && node build/esbuild-tests.cjs --watch &",
     "build": "npm run clean && npm run build:esm && npm run build:cjs && npm run build:browser",
     "lint": "eslint . --ext .ts --max-warnings 0",
     "lint:fix": "eslint . --ext .ts --fix",
     "test:node": "npm run build:tests:node && c8 mocha",
-    "test:browser": "npm run build:tests:browser && web-test-runner"
+    "test:browser": "npm run build:tests:browser && web-test-runner",
+    "test:browser:watch": "(npm run build:tests:browser:watch && web-test-runner --watch) || killall esbuild"
   },
   "homepage": "https://github.com/TBD54566975/web5-js/tree/main/packages/credentials#readme",
   "bugs": "https://github.com/TBD54566975/web5-js/issues",

--- a/packages/credentials/web-test-runner.config.cjs
+++ b/packages/credentials/web-test-runner.config.cjs
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
 const playwrightLauncher =
   require('@web/test-runner-playwright').playwrightLauncher;
 

--- a/packages/crypto/build/esbuild-tests.cjs
+++ b/packages/crypto/build/esbuild-tests.cjs
@@ -1,8 +1,8 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
 const esbuild = require('esbuild');
 const browserConfig = require('./esbuild-browser-config.cjs');
 
-esbuild.build({
+/** @type {import('esbuild').BuildOptions} */
+let config = {
   ...browserConfig,
   format      : 'esm',
   entryPoints : ['./tests/*.spec.*'],
@@ -13,4 +13,22 @@ esbuild.build({
     ...browserConfig.define,
     'process.env.TEST_DWN_URL': JSON.stringify(process.env.TEST_DWN_URL ?? null),
   },
-});
+};
+
+const handleBuild = () => {
+  esbuild.build(config);
+};
+
+const handleWatch = async() => {
+  let ctx = await esbuild.context(config);
+
+  await ctx.watch();
+};
+
+const hasWatchArg = process.argv.includes('--watch');
+
+if (hasWatchArg) {
+  handleWatch();
+} else {
+  handleBuild();
+}

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -13,11 +13,13 @@
     "build:browser": "rimraf dist/browser.mjs dist/browser.js && node build/bundles.js",
     "build:tests:node": "rimraf tests/compiled && tsc -p tests/tsconfig.json",
     "build:tests:browser": "rimraf tests/compiled && node build/esbuild-tests.cjs",
+    "build:tests:browser:watch": "rimraf tests/compiled && node build/esbuild-tests.cjs --watch &",
     "build": "npm run clean && npm run build:esm && npm run build:cjs && npm run build:browser",
     "lint": "eslint . --ext .ts --max-warnings 0",
     "lint:fix": "eslint . --ext .ts --fix",
     "test:node": "npm run build:tests:node && c8 mocha",
-    "test:browser": "npm run build:tests:browser && web-test-runner"
+    "test:browser": "npm run build:tests:browser && web-test-runner",
+    "test:browser:watch": "(npm run build:tests:browser:watch && web-test-runner --watch) || killall esbuild"
   },
   "homepage": "https://github.com/TBD54566975/web5-js/tree/main/packages/crypto#readme",
   "bugs": "https://github.com/TBD54566975/web5-js/issues",

--- a/packages/crypto/web-test-runner.config.cjs
+++ b/packages/crypto/web-test-runner.config.cjs
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
 const playwrightLauncher =
   require('@web/test-runner-playwright').playwrightLauncher;
 

--- a/packages/dids/build/buffer-polyfill.cjs
+++ b/packages/dids/build/buffer-polyfill.cjs
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
 const polyfilledBuffer = require('buffer/').Buffer;
 const { Buffer } = require('buffer');
 

--- a/packages/dids/build/esbuild-tests.cjs
+++ b/packages/dids/build/esbuild-tests.cjs
@@ -1,8 +1,8 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
 const esbuild = require('esbuild');
 const browserConfig = require('./esbuild-browser-config.cjs');
 
-esbuild.build({
+/** @type {import('esbuild').BuildOptions} */
+let config = {
   ...browserConfig,
   format      : 'esm',
   entryPoints : ['./tests/*.spec.*'],
@@ -13,4 +13,22 @@ esbuild.build({
     ...browserConfig.define,
     'process.env.TEST_DWN_URL': JSON.stringify(process.env.TEST_DWN_URL ?? null),
   },
-});
+};
+
+const handleBuild = () => {
+  esbuild.build(config);
+};
+
+const handleWatch = async() => {
+  let ctx = await esbuild.context(config);
+
+  await ctx.watch();
+};
+
+const hasWatchArg = process.argv.includes('--watch');
+
+if (hasWatchArg) {
+  handleWatch();
+} else {
+  handleBuild();
+}

--- a/packages/dids/package.json
+++ b/packages/dids/package.json
@@ -13,11 +13,13 @@
     "build:browser": "rimraf dist/browser.mjs dist/browser.js && node build/bundles.js",
     "build:tests:node": "rimraf tests/compiled && tsc -p tests/tsconfig.json",
     "build:tests:browser": "rimraf tests/compiled && node build/esbuild-tests.cjs",
+    "build:tests:browser:watch": "rimraf tests/compiled && node build/esbuild-tests.cjs --watch &",
     "build": "npm run clean && npm run build:esm && npm run build:cjs && npm run build:browser",
     "lint": "eslint . --ext .ts --max-warnings 0",
     "lint:fix": "eslint . --ext .ts --fix",
     "test:node": "npm run build:tests:node && c8 mocha",
-    "test:browser": "npm run build:tests:browser && web-test-runner"
+    "test:browser": "npm run build:tests:browser && web-test-runner",
+    "test:browser:watch": "(npm run build:tests:browser:watch && web-test-runner --watch) || killall esbuild"
   },
   "homepage": "https://github.com/TBD54566975/web5-js/tree/main/packages/dids#readme",
   "bugs": "https://github.com/TBD54566975/web5-js/issues",

--- a/packages/dids/web-test-runner.config.cjs
+++ b/packages/dids/web-test-runner.config.cjs
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
 const playwrightLauncher =
   require('@web/test-runner-playwright').playwrightLauncher;
 

--- a/packages/identity-agent/build/esbuild-browser-config.cjs
+++ b/packages/identity-agent/build/esbuild-browser-config.cjs
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
 const polyfillProviderPlugin = require('node-stdlib-browser/helpers/esbuild/plugin');
 const stdLibBrowser = require('node-stdlib-browser');
 

--- a/packages/identity-agent/build/esbuild-tests.cjs
+++ b/packages/identity-agent/build/esbuild-tests.cjs
@@ -1,8 +1,8 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
 const esbuild = require('esbuild');
 const browserConfig = require('./esbuild-browser-config.cjs');
 
-esbuild.build({
+/** @type {import('esbuild').BuildOptions} */
+let config = {
   ...browserConfig,
   format      : 'esm',
   entryPoints : ['./tests/*.spec.*'],
@@ -13,4 +13,22 @@ esbuild.build({
     ...browserConfig.define,
     'process.env.TEST_DWN_URL': JSON.stringify(process.env.TEST_DWN_URL ?? null),
   },
-});
+};
+
+const handleBuild = () => {
+  esbuild.build(config);
+};
+
+const handleWatch = async() => {
+  let ctx = await esbuild.context(config);
+
+  await ctx.watch();
+};
+
+const hasWatchArg = process.argv.includes('--watch');
+
+if (hasWatchArg) {
+  handleWatch();
+} else {
+  handleBuild();
+}

--- a/packages/identity-agent/package.json
+++ b/packages/identity-agent/package.json
@@ -12,11 +12,13 @@
     "build:browser": "rimraf dist/browser.mjs dist/browser.js && node build/bundles.js",
     "build:tests:node": "rimraf tests/compiled && tsc -p tests/tsconfig.json",
     "build:tests:browser": "rimraf tests/compiled && node build/esbuild-tests.cjs",
+    "build:tests:browser:watch": "rimraf tests/compiled && node build/esbuild-tests.cjs --watch &",
     "build": "npm run clean && npm run build:esm && npm run build:cjs && npm run build:browser",
     "lint": "eslint . --ext .ts --max-warnings 0",
     "lint:fix": "eslint . --ext .ts --fix",
     "test:node": "npm run build:tests:node && c8 mocha",
-    "test:browser": "npm run build:tests:browser && web-test-runner"
+    "test:browser": "npm run build:tests:browser && web-test-runner",
+    "test:browser:watch": "(npm run build:tests:browser:watch && web-test-runner --watch) || killall esbuild"
   },
   "homepage": "https://github.com/TBD54566975/web5-js/tree/main/packages/identity-agent#readme",
   "bugs": "https://github.com/TBD54566975/web5-js/issues",

--- a/packages/identity-agent/web-test-runner.config.cjs
+++ b/packages/identity-agent/web-test-runner.config.cjs
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
 const playwrightLauncher =
   require('@web/test-runner-playwright').playwrightLauncher;
 

--- a/packages/proxy-agent/build/esbuild-browser-config.cjs
+++ b/packages/proxy-agent/build/esbuild-browser-config.cjs
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
 const polyfillProviderPlugin = require('node-stdlib-browser/helpers/esbuild/plugin');
 const stdLibBrowser = require('node-stdlib-browser');
 

--- a/packages/proxy-agent/build/esbuild-tests.cjs
+++ b/packages/proxy-agent/build/esbuild-tests.cjs
@@ -1,8 +1,8 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
 const esbuild = require('esbuild');
 const browserConfig = require('./esbuild-browser-config.cjs');
 
-esbuild.build({
+/** @type {import('esbuild').BuildOptions} */
+let config = {
   ...browserConfig,
   format      : 'esm',
   entryPoints : ['./tests/*.spec.*'],
@@ -13,4 +13,22 @@ esbuild.build({
     ...browserConfig.define,
     'process.env.TEST_DWN_URL': JSON.stringify(process.env.TEST_DWN_URL ?? null),
   },
-});
+};
+
+const handleBuild = () => {
+  esbuild.build(config);
+};
+
+const handleWatch = async() => {
+  let ctx = await esbuild.context(config);
+
+  await ctx.watch();
+};
+
+const hasWatchArg = process.argv.includes('--watch');
+
+if (hasWatchArg) {
+  handleWatch();
+} else {
+  handleBuild();
+}

--- a/packages/proxy-agent/package.json
+++ b/packages/proxy-agent/package.json
@@ -12,11 +12,13 @@
     "build:browser": "rimraf dist/browser.mjs dist/browser.js && node build/bundles.js",
     "build:tests:node": "rimraf tests/compiled && tsc -p tests/tsconfig.json",
     "build:tests:browser": "rimraf tests/compiled && node build/esbuild-tests.cjs",
+    "build:tests:browser:watch": "rimraf tests/compiled && node build/esbuild-tests.cjs --watch &",
     "build": "npm run clean && npm run build:esm && npm run build:cjs && npm run build:browser",
     "lint": "eslint . --ext .ts --max-warnings 0",
     "lint:fix": "eslint . --ext .ts --fix",
     "test:node": "npm run build:tests:node && c8 mocha",
-    "test:browser": "npm run build:tests:browser && web-test-runner"
+    "test:browser": "npm run build:tests:browser && web-test-runner",
+    "test:browser:watch": "(npm run build:tests:browser:watch && web-test-runner --watch) || killall esbuild"
   },
   "homepage": "https://github.com/TBD54566975/web5-js/tree/main/packages/proxy-agent#readme",
   "bugs": "https://github.com/TBD54566975/web5-js/issues",

--- a/packages/proxy-agent/web-test-runner.config.cjs
+++ b/packages/proxy-agent/web-test-runner.config.cjs
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
 const playwrightLauncher =
   require('@web/test-runner-playwright').playwrightLauncher;
 

--- a/packages/user-agent/build/esbuild-browser-config.cjs
+++ b/packages/user-agent/build/esbuild-browser-config.cjs
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
 const polyfillProviderPlugin = require('node-stdlib-browser/helpers/esbuild/plugin');
 const stdLibBrowser = require('node-stdlib-browser');
 

--- a/packages/user-agent/build/esbuild-tests.cjs
+++ b/packages/user-agent/build/esbuild-tests.cjs
@@ -1,8 +1,8 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
 const esbuild = require('esbuild');
 const browserConfig = require('./esbuild-browser-config.cjs');
 
-esbuild.build({
+/** @type {import('esbuild').BuildOptions} */
+let config = {
   ...browserConfig,
   format      : 'esm',
   entryPoints : ['./tests/*.spec.*'],
@@ -13,4 +13,22 @@ esbuild.build({
     ...browserConfig.define,
     'process.env.TEST_DWN_URL': JSON.stringify(process.env.TEST_DWN_URL ?? null),
   },
-});
+};
+
+const handleBuild = () => {
+  esbuild.build(config);
+};
+
+const handleWatch = async() => {
+  let ctx = await esbuild.context(config);
+
+  await ctx.watch();
+};
+
+const hasWatchArg = process.argv.includes('--watch');
+
+if (hasWatchArg) {
+  handleWatch();
+} else {
+  handleBuild();
+}

--- a/packages/user-agent/package.json
+++ b/packages/user-agent/package.json
@@ -12,11 +12,13 @@
     "build:browser": "rimraf dist/browser.mjs dist/browser.js && node build/bundles.js",
     "build:tests:node": "rimraf tests/compiled && tsc -p tests/tsconfig.json",
     "build:tests:browser": "rimraf tests/compiled && node build/esbuild-tests.cjs",
+    "build:tests:browser:watch": "rimraf tests/compiled && node build/esbuild-tests.cjs --watch &",
     "build": "npm run clean && npm run build:esm && npm run build:cjs && npm run build:browser",
     "lint": "eslint . --ext .ts --max-warnings 0",
     "lint:fix": "eslint . --ext .ts --fix",
     "test:node": "npm run build:tests:node && c8 mocha",
-    "test:browser": "npm run build:tests:browser && web-test-runner"
+    "test:browser": "npm run build:tests:browser && web-test-runner",
+    "test:browser:watch": "(npm run build:tests:browser:watch && web-test-runner --watch) || killall esbuild"
   },
   "homepage": "https://github.com/TBD54566975/web5-js/tree/main/packages/user-agent#readme",
   "bugs": "https://github.com/TBD54566975/web5-js/issues",

--- a/packages/user-agent/web-test-runner.config.cjs
+++ b/packages/user-agent/web-test-runner.config.cjs
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
 const playwrightLauncher =
   require('@web/test-runner-playwright').playwrightLauncher;
 


### PR DESCRIPTION
## Reason for PR

Watch mode is a convenient way to have live reload for testing but is currently missing from the existing test solutions in the project

## Implementation

Use the esbuild API and CLI arguments to integrate web test runner watch with esbuild watch. 

Esbuild watch uses incremental compilation for speed. Using esbuild watch only the relevant files should be re-compiled and web test runner watches these files with its native watcher. 

## Demo

https://github.com/TBD54566975/web5-js/assets/3495974/7146c266-8547-4cec-a378-6bd75eccf2b9

