### PR TITLE
Decouples security scanning analysis and add FOSSA

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,53 @@
+name: Security Scanning
+
+on:
+  pull_request_target:
+    branches:
+      - main
+
+  push:
+    branches:
+      - main
+
+  # Run every day at 5am UTC
+  schedule:
+    - cron: "0 5 * * *"
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  security-action:
+    name: Security Analysis
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+
+      - name: Install Snyk
+        uses: snyk/actions/setup@master
+
+      - name: Snyk VULN and License Check Test
+        run: snyk test --all-projects --sarif-file-output=snyk.sarif
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+
+      - name: Run FOSSA Scan
+        uses: fossas/fossa-action@main
+        with:
+          api-key: ${{ secrets.FOSSA_API_KEY }}
+
+      - name: Run FOSSA Test
+        uses: fossas/fossa-action@main
+        with:
+          api-key: ${{ secrets.FOSSA_API_KEY }}
+          run-tests: true
+
+      - name: Upload SARIF result to GitHub Code Scanning
+        uses: github/codeql-action/upload-sarif@v2
+        if: always()
+        with:
+          sarif_file: snyk.sarif

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -17,8 +17,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  security-action:
-    name: Security Analysis
+  snyk:
     runs-on: ubuntu-latest
 
     steps:
@@ -35,6 +34,21 @@ jobs:
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 
+      - name: Upload SARIF result to GitHub Code Scanning
+        uses: github/codeql-action/upload-sarif@v2
+        if: always()
+        with:
+          sarif_file: snyk.sarif
+
+  fossa:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+
       - name: Run FOSSA Scan
         uses: fossas/fossa-action@main
         with:
@@ -45,9 +59,3 @@ jobs:
         with:
           api-key: ${{ secrets.FOSSA_API_KEY }}
           run-tests: true
-
-      - name: Upload SARIF result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
-        if: always()
-        with:
-          sarif_file: snyk.sarif

--- a/.github/workflows/tests-ci.yml
+++ b/.github/workflows/tests-ci.yml
@@ -23,28 +23,8 @@ jobs:
         with:
           node-version: 18
 
-      - name: Install latest npm
-        run: npm install -g npm@latest
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Install Snyk
-        uses: snyk/actions/setup@3e2680e8df93a24b52d119b1305fb7cedc60ceae # latest master (no released tag)
-
-      - name: Snyk VULN and License Check Test
-        run: snyk test --all-projects --sarif-file-output=snyk.sarif
-        env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-
       - name: Report known vulnerabilities
         run: npm audit
-
-      - name: Upload SARIF result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@74483a38d39275f33fcff5f35b679b5ca4a26a99 # v2.22.5
-        if: always()
-        with:
-          sarif_file: snyk.sarif
 
   test-with-node:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fix #319 

- We are decoupling the security scanning to be able to run security checks on approved forks
- Plus, taking the opportunity to add FOSSA because we are assessing their security tooling and SBOMs generation