### PR TITLE
Export PEX type directly

### DIFF
--- a/packages/credentials/src/presentation-exchange.ts
+++ b/packages/credentials/src/presentation-exchange.ts
@@ -1,13 +1,14 @@
 import type { EvaluationResults, PresentationResult, SelectResults, Validated as PexValidated } from '@sphereon/pex';
 import { PEX } from '@sphereon/pex';
 
-import type { PresentationDefinitionV2 } from '@sphereon/pex-models';
-export type { PresentationDefinitionV2 } from '@sphereon/pex-models';
+import type { PresentationDefinitionV2 as PexPresDefV2 } from '@sphereon/pex-models';
 
 import type {
   IPresentation,
   PresentationSubmission,
 } from '@sphereon/ssi-types';
+
+export interface PresentationDefinitionV2 extends PexPresDefV2 { }
 
 export type Validated = PexValidated;
 


### PR DESCRIPTION
This PR exports the sphereon `PresentationDefinitionV2` type directly, instead of a type alias, to resolve a TS issue inferring the type in consuming packages, where `xyz` should be of type `PresentationDefinitionV2`:
> ```The inferred type of 'xyz' cannot be named without a reference to '.pnpm/@sphereon+pex-models@2.0.3/node_modules/@sphereon/pex-models'. This is likely not portable. A type annotation is necessary.```

See [here](https://github.com/TBD54566975/tbdex-js/pull/112#issuecomment-1841107693) for further discussion