### PR TITLE
Bump `@web5/dids` version and improve DID spec compliance

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13936,7 +13936,7 @@
     },
     "packages/credentials": {
       "name": "@web5/credentials",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@sphereon/pex": "2.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1104,9 +1104,9 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.8.0.tgz",
-      "integrity": "sha512-zdTObFRoNENrdPpnTNnhOljYIcOX7aI7+7wyrSpPFFIOf/nRdedE6IYsjaBE7tjukphh1tMTojgJ7p3lKY8x6Q==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.9.0.tgz",
+      "integrity": "sha512-+1ge/xmaJpm1KVBuIH38Z94zj9fBD+hp+/5WLaHgyY8XLq1ibxk/zj6dTXaqM2cAbYKq8jYlhHd6k05If1W5xA==",
       "cpu": [
         "arm"
       ],
@@ -1117,9 +1117,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.8.0.tgz",
-      "integrity": "sha512-aiItwP48BiGpMFS9Znjo/xCNQVwTQVcRKkFKsO81m8exrGjHkCBDvm9PHay2kpa8RPnZzzKcD1iQ9KaLY4fPQQ==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.9.0.tgz",
+      "integrity": "sha512-im6hUEyQ7ZfoZdNvtwgEJvBWZYauC9KVKq1w58LG2Zfz6zMd8gRrbN+xCVoqA2hv/v6fm9lp5LFGJ3za8EQH3A==",
       "cpu": [
         "arm64"
       ],
@@ -1130,9 +1130,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.8.0.tgz",
-      "integrity": "sha512-zhNIS+L4ZYkYQUjIQUR6Zl0RXhbbA0huvNIWjmPc2SL0cB1h5Djkcy+RZ3/Bwszfb6vgwUvcVJYD6e6Zkpsi8g==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.9.0.tgz",
+      "integrity": "sha512-u7aTMskN6Dmg1lCT0QJ+tINRt+ntUrvVkhbPfFz4bCwRZvjItx2nJtwJnJRlKMMaQCHRjrNqHRDYvE4mBm3DlQ==",
       "cpu": [
         "arm64"
       ],
@@ -1143,9 +1143,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.8.0.tgz",
-      "integrity": "sha512-A/FAHFRNQYrELrb/JHncRWzTTXB2ticiRFztP4ggIUAfa9Up1qfW8aG2w/mN9jNiZ+HB0t0u0jpJgFXG6BfRTA==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.9.0.tgz",
+      "integrity": "sha512-8FvEl3w2ExmpcOmX5RJD0yqXcVSOqAJJUJ29Lca29Ik+3zPS1yFimr2fr5JSZ4Z5gt8/d7WqycpgkX9nocijSw==",
       "cpu": [
         "x64"
       ],
@@ -1156,9 +1156,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.8.0.tgz",
-      "integrity": "sha512-JsidBnh3p2IJJA4/2xOF2puAYqbaczB3elZDT0qHxn362EIoIkq7hrR43Xa8RisgI6/WPfvb2umbGsuvf7E37A==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.9.0.tgz",
+      "integrity": "sha512-lHoKYaRwd4gge+IpqJHCY+8Vc3hhdJfU6ukFnnrJasEBUvVlydP8PuwndbWfGkdgSvZhHfSEw6urrlBj0TSSfg==",
       "cpu": [
         "arm"
       ],
@@ -1169,9 +1169,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.8.0.tgz",
-      "integrity": "sha512-hBNCnqw3EVCkaPB0Oqd24bv8SklETptQWcJz06kb9OtiShn9jK1VuTgi7o4zPSt6rNGWQOTDEAccbk0OqJmS+g==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.9.0.tgz",
+      "integrity": "sha512-JbEPfhndYeWHfOSeh4DOFvNXrj7ls9S/2omijVsao+LBPTPayT1uKcK3dHW3MwDJ7KO11t9m2cVTqXnTKpeaiw==",
       "cpu": [
         "arm64"
       ],
@@ -1182,9 +1182,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.8.0.tgz",
-      "integrity": "sha512-Fw9ChYfJPdltvi9ALJ9wzdCdxGw4wtq4t1qY028b2O7GwB5qLNSGtqMsAel1lfWTZvf4b6/+4HKp0GlSYg0ahA==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.9.0.tgz",
+      "integrity": "sha512-ahqcSXLlcV2XUBM3/f/C6cRoh7NxYA/W7Yzuv4bDU1YscTFw7ay4LmD7l6OS8EMhTNvcrWGkEettL1Bhjf+B+w==",
       "cpu": [
         "arm64"
       ],
@@ -1195,9 +1195,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.8.0.tgz",
-      "integrity": "sha512-BH5xIh7tOzS9yBi8dFrCTG8Z6iNIGWGltd3IpTSKp6+pNWWO6qy8eKoRxOtwFbMrid5NZaidLYN6rHh9aB8bEw==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.9.0.tgz",
+      "integrity": "sha512-uwvOYNtLw8gVtrExKhdFsYHA/kotURUmZYlinH2VcQxNCQJeJXnkmWgw2hI9Xgzhgu7J9QvWiq9TtTVwWMDa+w==",
       "cpu": [
         "riscv64"
       ],
@@ -1208,9 +1208,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.8.0.tgz",
-      "integrity": "sha512-PmvAj8k6EuWiyLbkNpd6BLv5XeYFpqWuRvRNRl80xVfpGXK/z6KYXmAgbI4ogz7uFiJxCnYcqyvZVD0dgFog7Q==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.9.0.tgz",
+      "integrity": "sha512-m6pkSwcZZD2LCFHZX/zW2aLIISyzWLU3hrLLzQKMI12+OLEzgruTovAxY5sCZJkipklaZqPy/2bEEBNjp+Y7xg==",
       "cpu": [
         "x64"
       ],
@@ -1221,9 +1221,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.8.0.tgz",
-      "integrity": "sha512-mdxnlW2QUzXwY+95TuxZ+CurrhgrPAMveDWI97EQlA9bfhR8tw3Pt7SUlc/eSlCNxlWktpmT//EAA8UfCHOyXg==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.9.0.tgz",
+      "integrity": "sha512-VFAC1RDRSbU3iOF98X42KaVicAfKf0m0OvIu8dbnqhTe26Kh6Ym9JrDulz7Hbk7/9zGc41JkV02g+p3BivOdAg==",
       "cpu": [
         "x64"
       ],
@@ -1234,9 +1234,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.8.0.tgz",
-      "integrity": "sha512-ge7saUz38aesM4MA7Cad8CHo0Fyd1+qTaqoIo+Jtk+ipBi4ATSrHWov9/S4u5pbEQmLjgUjB7BJt+MiKG2kzmA==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.9.0.tgz",
+      "integrity": "sha512-9jPgMvTKXARz4inw6jezMLA2ihDBvgIU9Ml01hjdVpOcMKyxFBJrn83KVQINnbeqDv0+HdO1c09hgZ8N0s820Q==",
       "cpu": [
         "arm64"
       ],
@@ -1247,9 +1247,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.8.0.tgz",
-      "integrity": "sha512-p9E3PZlzurhlsN5h9g7zIP1DnqKXJe8ZUkFwAazqSvHuWfihlIISPxG9hCHCoA+dOOspL/c7ty1eeEVFTE0UTw==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.9.0.tgz",
+      "integrity": "sha512-WE4pT2kTXQN2bAv40Uog0AsV7/s9nT9HBWXAou8+++MBCnY51QS02KYtm6dQxxosKi1VIz/wZIrTQO5UP2EW+Q==",
       "cpu": [
         "ia32"
       ],
@@ -1260,9 +1260,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.8.0.tgz",
-      "integrity": "sha512-kb4/auKXkYKqlUYTE8s40FcJIj5soOyRLHKd4ugR0dCq0G2EfcF54eYcfQiGkHzjidZ40daB4ulsFdtqNKZtBg==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.9.0.tgz",
+      "integrity": "sha512-aPP5Q5AqNGuT0tnuEkK/g4mnt3ZhheiXrDIiSVIHN9mcN21OyXDVbEMqmXPE7e2OplNLDkcvV+ZoGJa2ZImFgw==",
       "cpu": [
         "x64"
       ],
@@ -3130,9 +3130,9 @@
       ]
     },
     "node_modules/basic-ftp": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.3.tgz",
-      "integrity": "sha512-QHX8HLlncOLpy54mh+k/sWIFd0ThmRqwe9ZjELybGZK+tZ8rUb9VO0saKJUROTbE+KhzDUT7xziGpGrW8Kmd+g==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.4.tgz",
+      "integrity": "sha512-8PzkB0arJFV4jJWSGOYR+OEic6aeKMu/osRhBULN6RY0ykby6LKhbmuQ5ublvaas5BOwboah5D87nrHyuh8PPA==",
       "dev": true,
       "engines": {
         "node": ">=10.0.0"
@@ -3754,9 +3754,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001568",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001568.tgz",
-      "integrity": "sha512-vSUkH84HontZJ88MiNrOau1EBrCqEQYgkC5gIySiDlpsm8sGVrhU7Kx4V6h0tnqaHzIHZv08HlJIwPbL4XL9+A==",
+      "version": "1.0.30001570",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001570.tgz",
+      "integrity": "sha512-+3e0ASu4sw1SWaoCtvPeyXp+5PsjigkSt8OXZbF9StH5pQWbxEjLAZE3n8Aup5udop1uRiKA7a4utUk/uoSpUw==",
       "dev": true,
       "funding": [
         {
@@ -4917,9 +4917,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.610",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.610.tgz",
-      "integrity": "sha512-mqi2oL1mfeHYtOdCxbPQYV/PL7YrQlxbvFEZ0Ee8GbDdShimqt2/S6z2RWqysuvlwdOrQdqvE0KZrBTipAeJzg==",
+      "version": "1.4.613",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.613.tgz",
+      "integrity": "sha512-r4x5+FowKG6q+/Wj0W9nidx7QO31BJwmR2uEo+Qh3YLGQ8SbBAFuDFpTxzly/I2gsbrFwBuIjrMp423L3O5U3w==",
       "dev": true,
       "peer": true
     },
@@ -10574,9 +10574,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.8.0.tgz",
-      "integrity": "sha512-NpsklK2fach5CdI+PScmlE5R4Ao/FSWtF7LkoIrHDxPACY/xshNasPsbpG0VVHxUTbf74tJbVT4PrP8JsJ6ZDA==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.9.0.tgz",
+      "integrity": "sha512-bUHW/9N21z64gw8s6tP4c88P382Bq/L5uZDowHlHx6s/QWpjJXivIAbEw6LZthgSvlEizZBfLC4OAvWe7aoF7A==",
       "dev": true,
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -10586,19 +10586,19 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.8.0",
-        "@rollup/rollup-android-arm64": "4.8.0",
-        "@rollup/rollup-darwin-arm64": "4.8.0",
-        "@rollup/rollup-darwin-x64": "4.8.0",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.8.0",
-        "@rollup/rollup-linux-arm64-gnu": "4.8.0",
-        "@rollup/rollup-linux-arm64-musl": "4.8.0",
-        "@rollup/rollup-linux-riscv64-gnu": "4.8.0",
-        "@rollup/rollup-linux-x64-gnu": "4.8.0",
-        "@rollup/rollup-linux-x64-musl": "4.8.0",
-        "@rollup/rollup-win32-arm64-msvc": "4.8.0",
-        "@rollup/rollup-win32-ia32-msvc": "4.8.0",
-        "@rollup/rollup-win32-x64-msvc": "4.8.0",
+        "@rollup/rollup-android-arm-eabi": "4.9.0",
+        "@rollup/rollup-android-arm64": "4.9.0",
+        "@rollup/rollup-darwin-arm64": "4.9.0",
+        "@rollup/rollup-darwin-x64": "4.9.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.9.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.9.0",
+        "@rollup/rollup-linux-arm64-musl": "4.9.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.9.0",
+        "@rollup/rollup-linux-x64-gnu": "4.9.0",
+        "@rollup/rollup-linux-x64-musl": "4.9.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.9.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.9.0",
+        "@rollup/rollup-win32-x64-msvc": "4.9.0",
         "fsevents": "~2.3.2"
       }
     },
@@ -12981,7 +12981,7 @@
         "@tbd54566975/dwn-sdk-js": "0.2.8",
         "@web5/common": "0.2.2",
         "@web5/crypto": "0.2.2",
-        "@web5/dids": "0.2.3",
+        "@web5/dids": "0.2.4",
         "level": "8.0.0",
         "readable-stream": "4.4.2",
         "readable-web-to-node-stream": "3.0.2"
@@ -13317,7 +13317,7 @@
         "@web5/agent": "0.2.5",
         "@web5/common": "0.2.2",
         "@web5/crypto": "0.2.2",
-        "@web5/dids": "0.2.3",
+        "@web5/dids": "0.2.4",
         "@web5/user-agent": "0.2.5",
         "level": "8.0.0",
         "ms": "2.1.3",
@@ -13942,7 +13942,7 @@
         "@sphereon/pex": "2.1.0",
         "@web5/common": "0.2.2",
         "@web5/crypto": "0.2.4",
-        "@web5/dids": "0.2.3"
+        "@web5/dids": "0.2.4"
       },
       "devDependencies": {
         "@playwright/test": "1.40.1",
@@ -14487,7 +14487,7 @@
     },
     "packages/dids": {
       "name": "@web5/dids",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@decentralized-identity/ion-pow-sdk": "1.0.17",
@@ -14833,7 +14833,7 @@
         "@web5/agent": "0.2.5",
         "@web5/common": "0.2.2",
         "@web5/crypto": "0.2.2",
-        "@web5/dids": "0.2.3"
+        "@web5/dids": "0.2.4"
       },
       "devDependencies": {
         "@playwright/test": "1.40.1",
@@ -15165,7 +15165,7 @@
         "@web5/agent": "0.2.5",
         "@web5/common": "0.2.2",
         "@web5/crypto": "0.2.2",
-        "@web5/dids": "0.2.3"
+        "@web5/dids": "0.2.4"
       },
       "devDependencies": {
         "@playwright/test": "1.40.1",
@@ -15496,7 +15496,7 @@
         "@web5/agent": "0.2.5",
         "@web5/common": "0.2.2",
         "@web5/crypto": "0.2.2",
-        "@web5/dids": "0.2.3"
+        "@web5/dids": "0.2.4"
       },
       "devDependencies": {
         "@playwright/test": "1.40.1",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -71,7 +71,7 @@
     "@tbd54566975/dwn-sdk-js": "0.2.8",
     "@web5/common": "0.2.2",
     "@web5/crypto": "0.2.2",
-    "@web5/dids": "0.2.3",
+    "@web5/dids": "0.2.4",
     "level": "8.0.0",
     "readable-stream": "4.4.2",
     "readable-web-to-node-stream": "3.0.2"

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -80,7 +80,7 @@
     "@web5/agent": "0.2.5",
     "@web5/common": "0.2.2",
     "@web5/crypto": "0.2.2",
-    "@web5/dids": "0.2.3",
+    "@web5/dids": "0.2.4",
     "@web5/user-agent": "0.2.5",
     "level": "8.0.0",
     "ms": "2.1.3",

--- a/packages/credentials/package.json
+++ b/packages/credentials/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web5/credentials",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Verifiable Credentials",
   "type": "module",
   "main": "./dist/cjs/index.js",

--- a/packages/credentials/package.json
+++ b/packages/credentials/package.json
@@ -77,7 +77,7 @@
     "@sphereon/pex": "2.1.0",
     "@web5/common": "0.2.2",
     "@web5/crypto": "0.2.4",
-    "@web5/dids": "0.2.3"
+    "@web5/dids": "0.2.4"
   },
   "devDependencies": {
     "@playwright/test": "1.40.1",

--- a/packages/credentials/tests/verifiable-credential.spec.ts
+++ b/packages/credentials/tests/verifiable-credential.spec.ts
@@ -392,8 +392,7 @@ describe('Verifiable Credential Tests', () => {
         },
         didDocumentMetadata   : {},
         didResolutionMetadata : {
-          contentType : 'application/did+ld+json',
-          did         : {
+          did: {
             didString        : 'did:dht:ejzu3k7eay57szh6sms6kzpuyeug35ay9688xcy6u5d1fh3zqtiy',
             methodSpecificId : 'ejzu3k7eay57szh6sms6kzpuyeug35ay9688xcy6u5d1fh3zqtiy',
             method           : 'dht'

--- a/packages/dids/package.json
+++ b/packages/dids/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web5/dids",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "TBD DIDs library",
   "type": "module",
   "main": "./dist/cjs/index.js",

--- a/packages/dids/src/did-dht.ts
+++ b/packages/dids/src/did-dht.ts
@@ -258,7 +258,6 @@ export class DidDhtMethod implements DidMethod {
         didDocument           : null,
         didDocumentMetadata   : {},
         didResolutionMetadata : {
-          contentType  : 'application/did+json',
           error        : 'invalidDid',
           errorMessage : `Cannot parse DID: ${didUrl}`
         }
@@ -271,7 +270,6 @@ export class DidDhtMethod implements DidMethod {
         didDocument           : null,
         didDocumentMetadata   : {},
         didResolutionMetadata : {
-          contentType  : 'application/did+json',
           error        : 'methodNotSupported',
           errorMessage : `Method not supported: ${parsedDid.method}`
         }
@@ -294,7 +292,6 @@ export class DidDhtMethod implements DidMethod {
         didDocument           : null,
         didDocumentMetadata   : {},
         didResolutionMetadata : {
-          contentType  : 'application/did+json',
           error        : 'internalError',
           errorMessage : `An unexpected error occurred while resolving DID: ${parsedDid.did}`
         }
@@ -306,8 +303,7 @@ export class DidDhtMethod implements DidMethod {
       didDocument,
       didDocumentMetadata   : {},
       didResolutionMetadata : {
-        contentType : 'application/did+json',
-        did         : {
+        did: {
           didString        : parsedDid.did,
           methodSpecificId : parsedDid.id,
           method           : parsedDid.method

--- a/packages/dids/src/did-ion.ts
+++ b/packages/dids/src/did-ion.ts
@@ -440,7 +440,6 @@ export class DidIonMethod implements DidMethod {
         didDocument           : undefined,
         didDocumentMetadata   : {},
         didResolutionMetadata : {
-          contentType  : 'application/did+ld+json',
           error        : 'invalidDid',
           errorMessage : `Cannot parse DID: ${didUrl}`
         }
@@ -453,7 +452,6 @@ export class DidIonMethod implements DidMethod {
         didDocument           : undefined,
         didDocumentMetadata   : {},
         didResolutionMetadata : {
-          contentType  : 'application/did+ld+json',
           error        : 'methodNotSupported',
           errorMessage : `Method not supported: ${parsedDid.method}`
         }
@@ -505,7 +503,6 @@ export class DidIonMethod implements DidMethod {
       didDocument           : undefined,
       didDocumentMetadata   : {},
       didResolutionMetadata : {
-        contentType: 'application/did+ld+json',
         error,
         errorMessage
       }

--- a/packages/dids/src/did-key.ts
+++ b/packages/dids/src/did-key.ts
@@ -725,7 +725,6 @@ export class DidKeyMethod implements DidMethod {
         didDocument           : undefined,
         didDocumentMetadata   : {},
         didResolutionMetadata : {
-          contentType  : 'application/did+ld+json',
           error        : 'invalidDid',
           errorMessage : `Cannot parse DID: ${didUrl}`
         }
@@ -738,7 +737,6 @@ export class DidKeyMethod implements DidMethod {
         didDocument           : undefined,
         didDocumentMetadata   : {},
         didResolutionMetadata : {
-          contentType  : 'application/did+ld+json',
           error        : 'methodNotSupported',
           errorMessage : `Method not supported: ${parsedDid.method}`
         }
@@ -752,8 +750,7 @@ export class DidKeyMethod implements DidMethod {
       didDocument,
       didDocumentMetadata   : {},
       didResolutionMetadata : {
-        contentType : 'application/did+ld+json',
-        did         : {
+        did: {
           didString        : parsedDid.did,
           methodSpecificId : parsedDid.id,
           method           : parsedDid.method

--- a/packages/dids/src/types.ts
+++ b/packages/dids/src/types.ts
@@ -5,6 +5,79 @@ import { DidKeyKeySet } from './did-key.js';
 import { DidIonKeySet } from './did-ion.js';
 import { DidDhtKeySet } from './did-dht.js';
 
+export type DidDereferencingMetadata = {
+  /** The Media Type of the returned contentStream SHOULD be expressed using this property if
+   * dereferencing is successful. */
+  contentType?: string;
+
+  /**
+   * The error code from the dereferencing process. This property is REQUIRED when there is an
+   * error in the dereferencing process. The value of this property MUST be a single keyword
+   * expressed as an ASCII string. The possible property values of this field SHOULD be registered
+   * in the {@link https://www.w3.org/TR/did-spec-registries/ | DID Specification Registries}.
+   * The DID Core specification defines the following common error values.
+   *
+   * @see {@link https://www.w3.org/TR/did-core/#did-url-dereferencing-metadata | Section 7.2.2, DID URL Dereferencing Metadata}
+   */
+  error?:
+    /** The DID URL supplied to the DID URL dereferencing function does not conform to valid
+     * syntax. */
+    | 'invalidDidUrl'
+
+    /** The DID URL dereferencer was unable to find the contentStream resulting from this
+     * dereferencing request. */
+    | 'notFound'
+    | string;
+
+  /** Additional output metadata generated during DID Resolution. */
+  [key: string]: any
+}
+
+/**
+ * A metadata structure consisting of input options to the dereference function.
+ *
+ * @see {@link https://www.w3.org/TR/did-core/#did-url-dereferencing-options}
+ */
+export interface DidDereferencingOptions {
+  /** The Media Type that the caller prefers for contentStream. */
+  accept?: string;
+
+  /** Additional properties used during DID dereferencing. */
+  [key: string]: any;
+}
+
+export type DidDereferencingResult = {
+  /**
+   * A metadata structure consisting of values relating to the results of the DID URL dereferencing
+   * process. This structure is REQUIRED, and in the case of an error in the dereferencing process,
+   * this MUST NOT be empty. Properties defined by this specification are in 7.2.2 DID URL
+   * Dereferencing Metadata. If the dereferencing is not successful, this structure MUST contain an
+   * `error` property describing the error.
+   */
+  dereferencingMetadata: DidDereferencingMetadata;
+
+  /**
+   * If the `dereferencing` function was called and successful, this MUST contain a resource
+   * corresponding to the DID URL. The contentStream MAY be a resource such as:
+   *   - a DID document that is serializable in one of the conformant representations
+   *   - a Verification Method
+   *   - a service.
+   *   - any other resource format that can be identified via a Media Type and obtained through the
+   *     resolution process.
+   *
+   * If the dereferencing is unsuccessful, this value MUST be empty.
+   */
+  contentStream: DidResource | null;
+
+  /**
+   * If the dereferencing is successful, this MUST be a metadata structure, but the structure MAY be
+   * empty. This structure contains metadata about the contentStream. If the contentStream is a DID
+   * document, this MUST be a didDocumentMetadata structure as described in DID Resolution. If the
+   * dereferencing is unsuccessful, this output MUST be an empty metadata structure.
+   */
+  contentMetadata: DidDocumentMetadata;
+}
+
 export type DidDocument = {
   '@context'?: 'https://www.w3.org/ns/did/v1' | string | string[];
   id: string;
@@ -124,11 +197,20 @@ export interface DwnServiceEndpoint extends DidServiceEndpoint {
 }
 
 export type DidResolutionMetadata = {
+  /**
+   * The Media Type of the returned `didDocumentStream`. This property is REQUIRED if resolution is
+   * successful and if the `resolveRepresentation` function was called. This property MUST NOT be
+   * present if the `resolve` function was called. The value of this property MUST be an ASCII
+   * string that is the Media Type of the conformant representations. The caller of the
+   * `resolveRepresentation` function MUST use this value when determining how to parse and process
+   * the `didDocumentStream` returned by this function into the data model.
+   */
   contentType?: string
 
   error?:
     /**
-     * When an unexpected error occurs during DID Resolution or DID URL dereferencing, the value of the DID Resolution or DID URL Dereferencing Metadata error property MUST be internalError.
+     * When an unexpected error occurs during DID Resolution or DID URL dereferencing, the value of
+     * the DID Resolution or DID URL Dereferencing Metadata error property MUST be internalError.
      */
     | 'internalError'
 
@@ -160,7 +242,7 @@ export type DidResolutionMetadata = {
     | 'representationNotSupported'
     | string
 
-  // Additional output metadata generated during DID Resolution.
+  /** Additional output metadata generated during DID Resolution. */
   [key: string]: any
 };
 
@@ -182,35 +264,6 @@ export type DidResolutionResult = {
   didDocument?: DidDocument
   didDocumentMetadata: DidDocumentMetadata
 };
-
-export type DidDereferenceResult = {
-  /**
-   * A metadata structure consisting of values relating to the results of the DID URL dereferencing process.
-   * This structure is REQUIRED, and in the case of an error in the dereferencing process, this MUST NOT be empty.
-   * Properties defined by this specification are in 7.2.2 DID URL Dereferencing Metadata. If the dereferencing is
-   * not successful, this structure MUST contain an error property describing the error.
-   */
-  dereferencingMetadata: DidResolutionMetadata
-  /**
-   * If the dereferencing function was called and successful, this MUST contain a resource corresponding to the DID URL.
-   * The contentStream MAY be a resource such as:
-   *   * A DID document that is serializable in one of the conformant representations
-   *   * A Verification Method,
-   *   * A service
-   *   * Any other resource format that can be identified via a Media Type and obtained through the resolution process.
-   *
-   * If the dereferencing is unsuccessful, this value MUST be empty.
-   */
-  contentStream: DidResource | null
-  /**
-   * If the dereferencing is successful, this MUST be a metadata structure, but the structure MAY be empty.
-   * This structure contains metadata about the contentStream. If the contentStream is a DID document,
-   * this MUST be a didDocumentMetadata structure as described in DID Resolution. If the dereferencing is unsuccessful,
-   * this output MUST be an empty metadata structure.
-
-   */
-  contentMetadata: DidDocumentMetadata
-}
 
 /**
  * implement this interface to provide your own cache for did resolution results. can be plugged in through Web5 API

--- a/packages/dids/tests/did-dht.spec.ts
+++ b/packages/dids/tests/did-dht.spec.ts
@@ -271,8 +271,7 @@ describe('DidDhtMethod', () => {
         didDocument           : document,
         didDocumentMetadata   : {},
         didResolutionMetadata : {
-          contentType : 'application/did+json',
-          did         : {
+          did: {
             didString        : document.id,
             methodSpecificId : parseDid({ didUrl: document.id }).id,
             method           : 'dht'
@@ -325,8 +324,7 @@ describe('DidDhtMethod', () => {
         didDocument           : document,
         didDocumentMetadata   : {},
         didResolutionMetadata : {
-          contentType : 'application/did+json',
-          did         : {
+          did: {
             didString        : 'did:dht:123456789abcdefgh',
             methodSpecificId : '123456789abcdefgh',
             method           : 'dht'
@@ -423,8 +421,7 @@ describe('DidDhtMethod', () => {
         didDocument,
         didDocumentMetadata   : {},
         didResolutionMetadata : {
-          contentType : 'application/did+json',
-          did         : {
+          did: {
             didString        : 'did:dht:h4d3ixkwt6q5a455tucw7j14jmqyghdtbr6cpiz6on5oxj5bpr3o',
             methodSpecificId : 'h4d3ixkwt6q5a455tucw7j14jmqyghdtbr6cpiz6on5oxj5bpr3o',
             method           : 'dht'

--- a/packages/identity-agent/package.json
+++ b/packages/identity-agent/package.json
@@ -71,7 +71,7 @@
     "@web5/agent": "0.2.5",
     "@web5/common": "0.2.2",
     "@web5/crypto": "0.2.2",
-    "@web5/dids": "0.2.3"
+    "@web5/dids": "0.2.4"
   },
   "devDependencies": {
     "@playwright/test": "1.40.1",

--- a/packages/proxy-agent/package.json
+++ b/packages/proxy-agent/package.json
@@ -71,7 +71,7 @@
     "@web5/agent": "0.2.5",
     "@web5/common": "0.2.2",
     "@web5/crypto": "0.2.2",
-    "@web5/dids": "0.2.3"
+    "@web5/dids": "0.2.4"
   },
   "devDependencies": {
     "@playwright/test": "1.40.1",

--- a/packages/user-agent/package.json
+++ b/packages/user-agent/package.json
@@ -71,7 +71,7 @@
     "@web5/agent": "0.2.5",
     "@web5/common": "0.2.2",
     "@web5/crypto": "0.2.2",
-    "@web5/dids": "0.2.3"
+    "@web5/dids": "0.2.4"
   },
   "devDependencies": {
     "@playwright/test": "1.40.1",


### PR DESCRIPTION
This PR will:

### `@web5/dids`

- bump the version to `0.2.4`
- Remove the `contentType` property from `DidResolutionResult` returned by the `DidResolver.resolve` function
    - Per the [DID Core spec](https://www.w3.org/TR/did-core/#did-resolution-metadata):
        > This property MUST NOT be present if the resolve function was called
- Improves spec compliance of the `DidDereferencingResult` type.
- Returns the spec defined values for `dereferencingMetadata` and adds a `DidDereferencingMetadata` type.
- Improves test coverage for the `DidResolver.dereference()` function to include validating return of `service` DID resources.
- Adds more docs to DID resolution / dereference types and implementations.

### `@web5/credentials`
- bump the version to `0.4.1` so that a new release can be published to NPM Registry which depends on `@web5/dids@0.2.4`

### `@web5/*`
- Use `@web5/dids@0.2.4` in all dependent packages.