### PR TITLE
migrate to arm runner for macOS gh actions

### DIFF
--- a/.github/workflows/tests-ci.yml
+++ b/.github/workflows/tests-ci.yml
@@ -109,9 +109,9 @@ jobs:
           - group: "A"
             packages: "--workspace packages/agent"
           - group: "B"
-            packages: "--workspace packages/crypto --workspace packages/dids --workspace packages/proxy-agent --workspace packages/identity-agent --workspace packages/user-agent"
+            packages: "--workspace packages/credentials --workspace packages/crypto --workspace packages/dids --workspace packages/proxy-agent --workspace packages/identity-agent --workspace packages/user-agent"
           - group: "C"
-            packages: "--workspace packages/api --workspace packages/common --workspace packages/credentials"
+            packages: "--workspace packages/api --workspace packages/common"
     steps:
       - name: Checkout source
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1

--- a/.github/workflows/tests-ci.yml
+++ b/.github/workflows/tests-ci.yml
@@ -101,7 +101,7 @@ jobs:
   test-with-browsers:
     name: test-with-browsers (group ${{ matrix.group }})
     # Run browser tests using macOS so that WebKit tests don't fail under a Linux environment
-    runs-on: macos-latest
+    runs-on: macos-14
     strategy:
       # parallelism strategy: agent takes as long as roughly all other pkgs combined.
       matrix:

--- a/.github/workflows/tests-ci.yml
+++ b/.github/workflows/tests-ci.yml
@@ -46,7 +46,7 @@ jobs:
         run: npm ci
 
       - name: Build all workspace packages
-        run: npm run build
+        run: npm run build:esm --ws && npm run build:cjs --ws
 
       - name: Run linter for all packages
         run: npm run lint --ws

--- a/.github/workflows/tests-ci.yml
+++ b/.github/workflows/tests-ci.yml
@@ -131,7 +131,7 @@ jobs:
       - name: Get Playwright Version (for cache)
         id: get-playwright-version
         run: |
-          PLAYWRIGHT_VERSION=$(npm view @playwright/test version)
+          PLAYWRIGHT_VERSION=$(npm ls @playwright/test --workspace=./packages/api | grep '@playwright/test' | awk 'NR==1{print $2}')
           echo "Playwright Version: $PLAYWRIGHT_VERSION"
           echo "PLAYWRIGHT_VERSION=$PLAYWRIGHT_VERSION" >> $GITHUB_ENV
 


### PR DESCRIPTION
Update to the new [Github M1 runner](https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/) free for open source, which also ships `macos-14` 

CI runs about 10% faster and variance is significantly reduced

Average CI run is now about 4m15s after these changes