### PR TITLE
Some more clean up for import/store

### DIFF
--- a/packages/agent/src/dwn-manager.ts
+++ b/packages/agent/src/dwn-manager.ts
@@ -283,7 +283,7 @@ export class DwnManager {
     });
 
     if (dwnMessageConstructor === RecordsWrite){
-      if (request.import) {
+      if (request.signAsOwner) {
         await (dwnMessage as RecordsWrite).signAsOwner(dwnSigner);
       }
     }

--- a/packages/agent/src/types/agent.ts
+++ b/packages/agent/src/types/agent.ts
@@ -78,7 +78,7 @@ export type ProcessDwnRequest = DwnRequest & {
   rawMessage?: unknown;
   messageOptions?: unknown;
   store?: boolean;
-  import?: boolean;
+  signAsOwner?: boolean;
 };
 
 export type SendDwnRequest = DwnRequest & (ProcessDwnRequest | { messageCid: string })

--- a/packages/agent/tests/sync-manager.spec.ts
+++ b/packages/agent/tests/sync-manager.spec.ts
@@ -242,7 +242,7 @@ describe('SyncManagerLevel', () => {
 
         // create a remote record
         const record = await testAgent.agent.dwnManager.sendRequest({
-          store          : false,
+          store    : false,
           author         : alice.did,
           target         : alice.did,
           messageType    : 'RecordsWrite',

--- a/packages/agent/tests/sync-manager.spec.ts
+++ b/packages/agent/tests/sync-manager.spec.ts
@@ -242,7 +242,7 @@ describe('SyncManagerLevel', () => {
 
         // create a remote record
         const record = await testAgent.agent.dwnManager.sendRequest({
-          store    : false,
+          store          : false,
           author         : alice.did,
           target         : alice.did,
           messageType    : 'RecordsWrite',

--- a/packages/api/src/record.ts
+++ b/packages/api/src/record.ts
@@ -194,17 +194,17 @@ export class Record implements RecordModel {
    * Returns a copy of the raw `RecordsWriteMessage` that was used to create the current `Record` instance.
    */
   private get rawMessage(): RecordsWriteMessage {
-    const message = {
+    const message = JSON.parse(JSON.stringify({
       contextId     : this._contextId,
       recordId      : this._recordId,
       descriptor    : this._descriptor,
       attestation   : this._attestation,
       authorization : this._authorization,
       encryption    : this._encryption,
-    };
+    }));
 
     removeUndefinedProperties(message);
-    return JSON.parse(JSON.stringify(message));
+    return message;
   }
 
   constructor(agent: Web5Agent, options: RecordOptions) {
@@ -431,9 +431,7 @@ export class Record implements RecordModel {
 
     // if there is already an authz payload, just pass along the record
     if (this._authorization) {
-      const rawMessage = this.rawMessage;
-      removeUndefinedProperties(rawMessage);
-      latestState.rawMessage = rawMessage;
+      latestState.rawMessage = { ...this.rawMessage };
     } else {
       // if there is no authz, pass options so the DWN SDK can construct and sign the record
       latestState.messageOptions = this.toJSON();


### PR DESCRIPTION
- Kept the user facing methods both `record.import()` and `record.store()` but modified the signature to accept just the single option they take for now.
- Modified the `ProcessDwnRequest` type to accept an optional `signAsOwner`, i think it better describes what it's doing there vs what the user is doing with the record abstraction.
- modified the underlying helper `processRecord` method to understand `signAsOwner`.
- moved the `SendCache` into it's own class to reduce some clutter. Need to add some testing for it.

Needs some more tests to test the paths of importing but not storing, and of storing but not importing.