### PR TITLE
Update `api` and `agent` packages to consume new `dwn-sdk-js`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2661,6 +2661,24 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/@tbd54566975/dwn-sql-store/node_modules/@web5/dids": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@web5/dids/-/dids-0.3.0.tgz",
+      "integrity": "sha512-Y6I/mNkSyjtRxvgTH72DJqcMiCA1ywMVJys09ro//kD0NiFU3NYBulurrFTp/Z4yV4t6KKOq7hj1WopWMagTbQ==",
+      "dev": true,
+      "dependencies": {
+        "@decentralized-identity/ion-sdk": "1.0.1",
+        "@dnsquery/dns-packet": "6.1.1",
+        "@web5/common": "0.2.3",
+        "@web5/crypto": "0.4.0",
+        "bencode": "4.0.0",
+        "level": "8.0.0",
+        "ms": "2.1.3"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@tbd54566975/dwn-sql-store/node_modules/cborg": {
       "version": "4.0.9",
       "resolved": "https://registry.npmjs.org/cborg/-/cborg-4.0.9.tgz",
@@ -3797,6 +3815,24 @@
       "dev": true,
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@web5/dwn-server/node_modules/@web5/dids": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@web5/dids/-/dids-0.3.0.tgz",
+      "integrity": "sha512-Y6I/mNkSyjtRxvgTH72DJqcMiCA1ywMVJys09ro//kD0NiFU3NYBulurrFTp/Z4yV4t6KKOq7hj1WopWMagTbQ==",
+      "dev": true,
+      "dependencies": {
+        "@decentralized-identity/ion-sdk": "1.0.1",
+        "@dnsquery/dns-packet": "6.1.1",
+        "@web5/common": "0.2.3",
+        "@web5/crypto": "0.4.0",
+        "bencode": "4.0.0",
+        "level": "8.0.0",
+        "ms": "2.1.3"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@web5/dwn-server/node_modules/body-parser": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
       "devDependencies": {
         "@npmcli/package-json": "5.0.0",
         "@typescript-eslint/eslint-plugin": "6.4.0",
-        "@web5/dwn-server": "0.1.9",
+        "@web5/dwn-server": "0.1.10",
         "eslint-plugin-mocha": "10.1.0"
       }
     },
@@ -2573,13 +2573,13 @@
       }
     },
     "node_modules/@tbd54566975/dwn-sql-store": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@tbd54566975/dwn-sql-store/-/dwn-sql-store-0.2.6.tgz",
-      "integrity": "sha512-N5SSyKGgHoW7ttWW6xrPq4xK7aYfxDvrmXdYEi+eA3qlT+Wzi5HZfrlcSnFIHee9+s56V6WpJw1AQ6XmjZH2QQ==",
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/@tbd54566975/dwn-sql-store/-/dwn-sql-store-0.2.9.tgz",
+      "integrity": "sha512-D4iKH9qqT43OXkc6tjBabj97z/PoF+zY3cF0W0SyPedEhN+t+jxHG6F+XRqCiqzqPu58wp4kuD4HPErAWWWMDg==",
       "dev": true,
       "dependencies": {
         "@ipld/dag-cbor": "^9.0.5",
-        "@tbd54566975/dwn-sdk-js": "0.2.10",
+        "@tbd54566975/dwn-sdk-js": "0.2.16",
         "kysely": "0.26.3",
         "multiformats": "12.0.1",
         "readable-stream": "4.4.2"
@@ -2608,6 +2608,100 @@
       "integrity": "sha512-bt3R5iXe2O8xpp3wkmQhC73b/lC4S2ihU8Dndwcsysqbydqb8N+bpP116qMcClZ17g58iSIwtXUTcg2zT4sniA==",
       "dev": true
     },
+    "node_modules/@tbd54566975/dwn-sql-store/node_modules/@tbd54566975/dwn-sdk-js": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/@tbd54566975/dwn-sdk-js/-/dwn-sdk-js-0.2.16.tgz",
+      "integrity": "sha512-I/LKbqB7Qn2+G4V3b2rbFQcDaXONTcDRNVLszxV7CDlb8cjPIwYv+vjtEtcyWwjwr+KjlOnS6AxvnhZn5sEnTw==",
+      "dev": true,
+      "dependencies": {
+        "@ipld/dag-cbor": "9.0.3",
+        "@js-temporal/polyfill": "0.4.4",
+        "@noble/ed25519": "2.0.0",
+        "@noble/secp256k1": "2.0.0",
+        "@web5/dids": "0.3.0",
+        "abstract-level": "1.0.3",
+        "ajv": "8.12.0",
+        "blockstore-core": "4.2.0",
+        "cross-fetch": "4.0.0",
+        "eciesjs": "0.4.5",
+        "interface-blockstore": "5.2.3",
+        "interface-store": "5.1.2",
+        "ipfs-unixfs-exporter": "13.1.5",
+        "ipfs-unixfs-importer": "15.1.5",
+        "level": "8.0.0",
+        "lodash": "4.17.21",
+        "lru-cache": "9.1.2",
+        "ms": "2.1.3",
+        "multiformats": "11.0.2",
+        "randombytes": "2.1.0",
+        "readable-stream": "4.5.2",
+        "ulidx": "2.1.0",
+        "uuid": "8.3.2",
+        "varint": "6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@tbd54566975/dwn-sql-store/node_modules/@tbd54566975/dwn-sdk-js/node_modules/@ipld/dag-cbor": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-9.0.3.tgz",
+      "integrity": "sha512-A2UFccS0+sARK9xwXiVZIaWbLbPxLGP3UZOjBeOMWfDY04SXi8h1+t4rHBzOlKYF/yWNm3RbFLyclWO7hZcy4g==",
+      "dev": true,
+      "dependencies": {
+        "cborg": "^2.0.1",
+        "multiformats": "^12.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@tbd54566975/dwn-sql-store/node_modules/@tbd54566975/dwn-sdk-js/node_modules/@ipld/dag-cbor/node_modules/multiformats": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.3.tgz",
+      "integrity": "sha512-eajQ/ZH7qXZQR2AgtfpmSMizQzmyYVmCql7pdhldPuYQi4atACekbJaQplk6dWyIi10jCaFnd6pqvcEFXjbaJw==",
+      "dev": true,
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@tbd54566975/dwn-sql-store/node_modules/@tbd54566975/dwn-sdk-js/node_modules/cborg": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/cborg/-/cborg-2.0.5.tgz",
+      "integrity": "sha512-xVW1rSIw1ZXbkwl2XhJ7o/jAv0vnVoQv/QlfQxV8a7V5PlA4UU/AcIiXqmpyybwNWy/GPQU1m/aBVNIWr7/T0w==",
+      "dev": true,
+      "bin": {
+        "cborg": "cli.js"
+      }
+    },
+    "node_modules/@tbd54566975/dwn-sql-store/node_modules/@tbd54566975/dwn-sdk-js/node_modules/multiformats": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
+      "dev": true,
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@tbd54566975/dwn-sql-store/node_modules/@tbd54566975/dwn-sdk-js/node_modules/readable-stream": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.5.2.tgz",
+      "integrity": "sha512-yjavECdqeZ3GLXNgRXgeQEdz9fvDDkNKyHnbHRFtOr7/LcfgBcmct7t/ET+HaCTqfh06OzoAxrkN/IfjJBVe+g==",
+      "dev": true,
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
     "node_modules/@tbd54566975/dwn-sql-store/node_modules/cborg": {
       "version": "4.0.9",
       "resolved": "https://registry.npmjs.org/cborg/-/cborg-4.0.9.tgz",
@@ -2615,6 +2709,15 @@
       "dev": true,
       "bin": {
         "cborg": "lib/bin.js"
+      }
+    },
+    "node_modules/@tbd54566975/dwn-sql-store/node_modules/lru-cache": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-9.1.2.tgz",
+      "integrity": "sha512-ERJq3FOzJTxBbFjZ7iDs+NiK4VI9Wz+RdrrAB8dio1oV+YvdPzUEE4QNiT2VD51DkIbCYRUUzCRkssXCHqSnKQ==",
+      "dev": true,
+      "engines": {
+        "node": "14 || >=16.14"
       }
     },
     "node_modules/@tbd54566975/dwn-sql-store/node_modules/multiformats": {
@@ -3647,17 +3750,19 @@
       "link": true
     },
     "node_modules/@web5/dwn-server": {
-      "version": "0.1.9",
-      "resolved": "https://registry.npmjs.org/@web5/dwn-server/-/dwn-server-0.1.9.tgz",
-      "integrity": "sha512-t1xpWGQ+hbIglu0OjZS3DG6Q8pmrxK2TmPo53YaxNpceKNT9tkqJqgssiIJzVWiQS90BmR/JULchKR/aQX1sOg==",
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/@web5/dwn-server/-/dwn-server-0.1.10.tgz",
+      "integrity": "sha512-0aBiS8FRYpRoCBi143d5Q6U5ac4V66BkLIOVLJG4XG2N1uVumbSVwZdFwRfhDZG9sqd5ImPc0rlmrfhkjDQ96Q==",
       "dev": true,
       "dependencies": {
-        "@tbd54566975/dwn-sdk-js": "0.2.10",
-        "@tbd54566975/dwn-sql-store": "0.2.6",
+        "@tbd54566975/dwn-sdk-js": "0.2.16",
+        "@tbd54566975/dwn-sql-store": "0.2.9",
         "better-sqlite3": "^8.5.0",
+        "body-parser": "^1.20.2",
         "bytes": "3.1.2",
         "cors": "2.8.5",
         "express": "4.18.2",
+        "kysely": "^0.26.3",
         "loglevel": "^1.8.1",
         "loglevel-plugin-prefix": "^0.8.4",
         "multiformats": "11.0.2",
@@ -3673,6 +3778,129 @@
       },
       "bin": {
         "dwn-server": "dist/esm/src/main.js"
+      }
+    },
+    "node_modules/@web5/dwn-server/node_modules/@tbd54566975/dwn-sdk-js": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/@tbd54566975/dwn-sdk-js/-/dwn-sdk-js-0.2.16.tgz",
+      "integrity": "sha512-I/LKbqB7Qn2+G4V3b2rbFQcDaXONTcDRNVLszxV7CDlb8cjPIwYv+vjtEtcyWwjwr+KjlOnS6AxvnhZn5sEnTw==",
+      "dev": true,
+      "dependencies": {
+        "@ipld/dag-cbor": "9.0.3",
+        "@js-temporal/polyfill": "0.4.4",
+        "@noble/ed25519": "2.0.0",
+        "@noble/secp256k1": "2.0.0",
+        "@web5/dids": "0.3.0",
+        "abstract-level": "1.0.3",
+        "ajv": "8.12.0",
+        "blockstore-core": "4.2.0",
+        "cross-fetch": "4.0.0",
+        "eciesjs": "0.4.5",
+        "interface-blockstore": "5.2.3",
+        "interface-store": "5.1.2",
+        "ipfs-unixfs-exporter": "13.1.5",
+        "ipfs-unixfs-importer": "15.1.5",
+        "level": "8.0.0",
+        "lodash": "4.17.21",
+        "lru-cache": "9.1.2",
+        "ms": "2.1.3",
+        "multiformats": "11.0.2",
+        "randombytes": "2.1.0",
+        "readable-stream": "4.5.2",
+        "ulidx": "2.1.0",
+        "uuid": "8.3.2",
+        "varint": "6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@web5/dwn-server/node_modules/@tbd54566975/dwn-sdk-js/node_modules/readable-stream": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.5.2.tgz",
+      "integrity": "sha512-yjavECdqeZ3GLXNgRXgeQEdz9fvDDkNKyHnbHRFtOr7/LcfgBcmct7t/ET+HaCTqfh06OzoAxrkN/IfjJBVe+g==",
+      "dev": true,
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@web5/dwn-server/node_modules/@tbd54566975/dwn-sdk-js/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@web5/dwn-server/node_modules/body-parser": {
+      "version": "1.20.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.2.tgz",
+      "integrity": "sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==",
+      "dev": true,
+      "dependencies": {
+        "bytes": "3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "on-finished": "2.4.1",
+        "qs": "6.11.0",
+        "raw-body": "2.5.2",
+        "type-is": "~1.6.18",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/@web5/dwn-server/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/@web5/dwn-server/node_modules/debug/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true
+    },
+    "node_modules/@web5/dwn-server/node_modules/lru-cache": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-9.1.2.tgz",
+      "integrity": "sha512-ERJq3FOzJTxBbFjZ7iDs+NiK4VI9Wz+RdrrAB8dio1oV+YvdPzUEE4QNiT2VD51DkIbCYRUUzCRkssXCHqSnKQ==",
+      "dev": true,
+      "engines": {
+        "node": "14 || >=16.14"
+      }
+    },
+    "node_modules/@web5/dwn-server/node_modules/qs": {
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
+      "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
+      "dev": true,
+      "dependencies": {
+        "side-channel": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/@web5/dwn-server/node_modules/uuid": {
@@ -14195,10 +14423,10 @@
     },
     "packages/agent": {
       "name": "@web5/agent",
-      "version": "0.2.6",
+      "version": "0.2.7",
       "license": "Apache-2.0",
       "dependencies": {
-        "@tbd54566975/dwn-sdk-js": "0.2.10",
+        "@tbd54566975/dwn-sdk-js": "0.2.16",
         "@web5/common": "0.2.3",
         "@web5/crypto": "0.2.2",
         "@web5/dids": "0.2.4",
@@ -14266,6 +14494,79 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "packages/agent/node_modules/@tbd54566975/dwn-sdk-js": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/@tbd54566975/dwn-sdk-js/-/dwn-sdk-js-0.2.16.tgz",
+      "integrity": "sha512-I/LKbqB7Qn2+G4V3b2rbFQcDaXONTcDRNVLszxV7CDlb8cjPIwYv+vjtEtcyWwjwr+KjlOnS6AxvnhZn5sEnTw==",
+      "dependencies": {
+        "@ipld/dag-cbor": "9.0.3",
+        "@js-temporal/polyfill": "0.4.4",
+        "@noble/ed25519": "2.0.0",
+        "@noble/secp256k1": "2.0.0",
+        "@web5/dids": "0.3.0",
+        "abstract-level": "1.0.3",
+        "ajv": "8.12.0",
+        "blockstore-core": "4.2.0",
+        "cross-fetch": "4.0.0",
+        "eciesjs": "0.4.5",
+        "interface-blockstore": "5.2.3",
+        "interface-store": "5.1.2",
+        "ipfs-unixfs-exporter": "13.1.5",
+        "ipfs-unixfs-importer": "15.1.5",
+        "level": "8.0.0",
+        "lodash": "4.17.21",
+        "lru-cache": "9.1.2",
+        "ms": "2.1.3",
+        "multiformats": "11.0.2",
+        "randombytes": "2.1.0",
+        "readable-stream": "4.5.2",
+        "ulidx": "2.1.0",
+        "uuid": "8.3.2",
+        "varint": "6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "packages/agent/node_modules/@tbd54566975/dwn-sdk-js/node_modules/@web5/dids": {
+      "resolved": "packages/dids",
+      "link": true
+    },
+    "packages/agent/node_modules/@tbd54566975/dwn-sdk-js/node_modules/ajv": {
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "packages/agent/node_modules/@tbd54566975/dwn-sdk-js/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
+    "packages/agent/node_modules/@tbd54566975/dwn-sdk-js/node_modules/readable-stream": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.5.2.tgz",
+      "integrity": "sha512-yjavECdqeZ3GLXNgRXgeQEdz9fvDDkNKyHnbHRFtOr7/LcfgBcmct7t/ET+HaCTqfh06OzoAxrkN/IfjJBVe+g==",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "packages/agent/node_modules/@typescript-eslint/parser": {
@@ -14563,6 +14864,14 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true
     },
+    "packages/agent/node_modules/lru-cache": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-9.1.2.tgz",
+      "integrity": "sha512-ERJq3FOzJTxBbFjZ7iDs+NiK4VI9Wz+RdrrAB8dio1oV+YvdPzUEE4QNiT2VD51DkIbCYRUUzCRkssXCHqSnKQ==",
+      "engines": {
+        "node": "14 || >=16.14"
+      }
+    },
     "packages/agent/node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -14589,15 +14898,15 @@
     },
     "packages/api": {
       "name": "@web5/api",
-      "version": "0.8.4",
+      "version": "0.8.5",
       "license": "Apache-2.0",
       "dependencies": {
-        "@tbd54566975/dwn-sdk-js": "0.2.10",
-        "@web5/agent": "0.2.6",
+        "@tbd54566975/dwn-sdk-js": "0.2.16",
+        "@web5/agent": "0.2.7",
         "@web5/common": "0.2.3",
         "@web5/crypto": "0.2.2",
         "@web5/dids": "0.2.4",
-        "@web5/user-agent": "0.2.6",
+        "@web5/user-agent": "0.2.7",
         "level": "8.0.0",
         "ms": "2.1.3",
         "readable-stream": "4.4.2",
@@ -14663,6 +14972,96 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "packages/api/node_modules/@tbd54566975/dwn-sdk-js": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/@tbd54566975/dwn-sdk-js/-/dwn-sdk-js-0.2.16.tgz",
+      "integrity": "sha512-I/LKbqB7Qn2+G4V3b2rbFQcDaXONTcDRNVLszxV7CDlb8cjPIwYv+vjtEtcyWwjwr+KjlOnS6AxvnhZn5sEnTw==",
+      "dependencies": {
+        "@ipld/dag-cbor": "9.0.3",
+        "@js-temporal/polyfill": "0.4.4",
+        "@noble/ed25519": "2.0.0",
+        "@noble/secp256k1": "2.0.0",
+        "@web5/dids": "0.3.0",
+        "abstract-level": "1.0.3",
+        "ajv": "8.12.0",
+        "blockstore-core": "4.2.0",
+        "cross-fetch": "4.0.0",
+        "eciesjs": "0.4.5",
+        "interface-blockstore": "5.2.3",
+        "interface-store": "5.1.2",
+        "ipfs-unixfs-exporter": "13.1.5",
+        "ipfs-unixfs-importer": "15.1.5",
+        "level": "8.0.0",
+        "lodash": "4.17.21",
+        "lru-cache": "9.1.2",
+        "ms": "2.1.3",
+        "multiformats": "11.0.2",
+        "randombytes": "2.1.0",
+        "readable-stream": "4.5.2",
+        "ulidx": "2.1.0",
+        "uuid": "8.3.2",
+        "varint": "6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "packages/api/node_modules/@tbd54566975/dwn-sdk-js/node_modules/@web5/crypto": {
+      "resolved": "packages/crypto",
+      "link": true
+    },
+    "packages/api/node_modules/@tbd54566975/dwn-sdk-js/node_modules/@web5/dids": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@web5/dids/-/dids-0.3.0.tgz",
+      "integrity": "sha512-Y6I/mNkSyjtRxvgTH72DJqcMiCA1ywMVJys09ro//kD0NiFU3NYBulurrFTp/Z4yV4t6KKOq7hj1WopWMagTbQ==",
+      "dependencies": {
+        "@decentralized-identity/ion-sdk": "1.0.1",
+        "@dnsquery/dns-packet": "6.1.1",
+        "@web5/common": "0.2.3",
+        "@web5/crypto": "0.4.0",
+        "bencode": "4.0.0",
+        "level": "8.0.0",
+        "ms": "2.1.3"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "packages/api/node_modules/@tbd54566975/dwn-sdk-js/node_modules/ajv": {
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "packages/api/node_modules/@tbd54566975/dwn-sdk-js/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
+    "packages/api/node_modules/@tbd54566975/dwn-sdk-js/node_modules/readable-stream": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.5.2.tgz",
+      "integrity": "sha512-yjavECdqeZ3GLXNgRXgeQEdz9fvDDkNKyHnbHRFtOr7/LcfgBcmct7t/ET+HaCTqfh06OzoAxrkN/IfjJBVe+g==",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "packages/api/node_modules/@typescript-eslint/parser": {
@@ -14959,6 +15358,14 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true
+    },
+    "packages/api/node_modules/lru-cache": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-9.1.2.tgz",
+      "integrity": "sha512-ERJq3FOzJTxBbFjZ7iDs+NiK4VI9Wz+RdrrAB8dio1oV+YvdPzUEE4QNiT2VD51DkIbCYRUUzCRkssXCHqSnKQ==",
+      "engines": {
+        "node": "14 || >=16.14"
+      }
     },
     "packages/api/node_modules/minimatch": {
       "version": "3.1.2",
@@ -16754,6 +17161,169 @@
         }
       }
     },
+    "packages/identity-agent/node_modules/@web5/agent": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/@web5/agent/-/agent-0.2.6.tgz",
+      "integrity": "sha512-qBbFH7b08Sw8JCpPQ+ClbblL++hkSR25e1XNF46ToVTJJldLspLTcXjr2Oui1bpJZ3jppnZ9nvcQPfymtdM5fg==",
+      "dependencies": {
+        "@tbd54566975/dwn-sdk-js": "0.2.10",
+        "@web5/common": "0.2.3",
+        "@web5/crypto": "0.2.2",
+        "@web5/dids": "0.2.4",
+        "level": "8.0.0",
+        "readable-stream": "4.4.2",
+        "readable-web-to-node-stream": "3.0.2",
+        "ulidx": "2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "packages/identity-agent/node_modules/@web5/api": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/@web5/api/-/api-0.8.4.tgz",
+      "integrity": "sha512-3kqh7KQeeffsOBi+K5Vhpa59+ZgdI1em16drrRd7h59Jj4m8a09Enhw7WjWNLre7rTG84hQqB9+rpS1VHnOaKQ==",
+      "dev": true,
+      "dependencies": {
+        "@tbd54566975/dwn-sdk-js": "0.2.10",
+        "@web5/agent": "0.2.5",
+        "@web5/common": "0.2.2",
+        "@web5/crypto": "0.2.2",
+        "@web5/dids": "0.2.4",
+        "@web5/user-agent": "0.2.5",
+        "level": "8.0.0",
+        "ms": "2.1.3",
+        "readable-stream": "4.4.2",
+        "readable-web-to-node-stream": "3.0.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "packages/identity-agent/node_modules/@web5/api/node_modules/@web5/agent": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@web5/agent/-/agent-0.2.5.tgz",
+      "integrity": "sha512-Z9JY/43Yrg0xKK26y/iZFdHNtVf/k9XLxw8mXP5zfYidrqfAgVR0i4LKA7qZKfUSxC7/uaD/STYYIKpNByd/cw==",
+      "dev": true,
+      "dependencies": {
+        "@tbd54566975/dwn-sdk-js": "0.2.8",
+        "@web5/common": "0.2.2",
+        "@web5/crypto": "0.2.2",
+        "@web5/dids": "0.2.3",
+        "level": "8.0.0",
+        "readable-stream": "4.4.2",
+        "readable-web-to-node-stream": "3.0.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "packages/identity-agent/node_modules/@web5/api/node_modules/@web5/agent/node_modules/@tbd54566975/dwn-sdk-js": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@tbd54566975/dwn-sdk-js/-/dwn-sdk-js-0.2.8.tgz",
+      "integrity": "sha512-oiKk+ekAQO94bUkt6yk+xkDY8uCGmNC+rKaYQLhAoTrhYrczeRSuDT04F5/vPBT5K6NfAoRcQsIyBmvgRCUvgA==",
+      "dev": true,
+      "dependencies": {
+        "@ipld/dag-cbor": "9.0.3",
+        "@js-temporal/polyfill": "0.4.4",
+        "@noble/ed25519": "2.0.0",
+        "@noble/secp256k1": "2.0.0",
+        "abstract-level": "1.0.3",
+        "ajv": "8.12.0",
+        "blockstore-core": "4.2.0",
+        "cross-fetch": "4.0.0",
+        "eciesjs": "0.4.5",
+        "flat": "5.0.2",
+        "interface-blockstore": "5.2.3",
+        "interface-store": "5.1.2",
+        "ipfs-unixfs-exporter": "13.1.5",
+        "ipfs-unixfs-importer": "15.1.5",
+        "level": "8.0.0",
+        "lodash": "4.17.21",
+        "lru-cache": "9.1.2",
+        "ms": "2.1.3",
+        "multiformats": "11.0.2",
+        "randombytes": "2.1.0",
+        "readable-stream": "4.4.2",
+        "ulidx": "2.1.0",
+        "uuid": "8.3.2",
+        "varint": "6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "packages/identity-agent/node_modules/@web5/api/node_modules/@web5/agent/node_modules/@web5/dids": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@web5/dids/-/dids-0.2.3.tgz",
+      "integrity": "sha512-Y3PHOavNkSyjBxZQEpKE6XueaqemBO5w0UMOnFh4xH6+5B43ENEE4LHIqVyn2bCpfEBGLXENgDZYqyJphBu0pA==",
+      "dev": true,
+      "dependencies": {
+        "@decentralized-identity/ion-pow-sdk": "1.0.17",
+        "@decentralized-identity/ion-sdk": "1.0.1",
+        "@web5/common": "0.2.2",
+        "@web5/crypto": "0.2.2",
+        "did-resolver": "4.1.0",
+        "dns-packet": "5.6.1",
+        "level": "8.0.0",
+        "ms": "2.1.3",
+        "pkarr": "1.1.1",
+        "z32": "1.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "packages/identity-agent/node_modules/@web5/api/node_modules/@web5/common": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@web5/common/-/common-0.2.2.tgz",
+      "integrity": "sha512-dRn6SmALExeTLMTK/W5ozGarfaddK+Lraf5OjuIGLAaLfcX1RWx3oDMoY5Hr9LjfxHJC8mGXB8DnKflbeYJRgA==",
+      "dev": true,
+      "dependencies": {
+        "level": "8.0.0",
+        "multiformats": "11.0.2",
+        "readable-stream": "4.4.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "packages/identity-agent/node_modules/@web5/api/node_modules/@web5/user-agent": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@web5/user-agent/-/user-agent-0.2.5.tgz",
+      "integrity": "sha512-qv5M698C5HSvq30xUgLWtcsbZppjfOH5qZthpTRx4ItL5UWA/eQ9DsQiQeb4vet3uIUy3NHRDIQezclOdwYErw==",
+      "dev": true,
+      "dependencies": {
+        "@web5/agent": "0.2.5",
+        "@web5/common": "0.2.2",
+        "@web5/crypto": "0.2.2",
+        "@web5/dids": "0.2.3"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "packages/identity-agent/node_modules/@web5/api/node_modules/@web5/user-agent/node_modules/@web5/dids": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@web5/dids/-/dids-0.2.3.tgz",
+      "integrity": "sha512-Y3PHOavNkSyjBxZQEpKE6XueaqemBO5w0UMOnFh4xH6+5B43ENEE4LHIqVyn2bCpfEBGLXENgDZYqyJphBu0pA==",
+      "dev": true,
+      "dependencies": {
+        "@decentralized-identity/ion-pow-sdk": "1.0.17",
+        "@decentralized-identity/ion-sdk": "1.0.1",
+        "@web5/common": "0.2.2",
+        "@web5/crypto": "0.2.2",
+        "did-resolver": "4.1.0",
+        "dns-packet": "5.6.1",
+        "level": "8.0.0",
+        "ms": "2.1.3",
+        "pkarr": "1.1.1",
+        "z32": "1.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "packages/identity-agent/node_modules/@web5/crypto": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/@web5/crypto/-/crypto-0.2.2.tgz",
@@ -16981,6 +17551,15 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true
     },
+    "packages/identity-agent/node_modules/lru-cache": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-9.1.2.tgz",
+      "integrity": "sha512-ERJq3FOzJTxBbFjZ7iDs+NiK4VI9Wz+RdrrAB8dio1oV+YvdPzUEE4QNiT2VD51DkIbCYRUUzCRkssXCHqSnKQ==",
+      "dev": true,
+      "engines": {
+        "node": "14 || >=16.14"
+      }
+    },
     "packages/identity-agent/node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -17139,6 +17718,24 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "packages/proxy-agent/node_modules/@web5/agent": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/@web5/agent/-/agent-0.2.6.tgz",
+      "integrity": "sha512-qBbFH7b08Sw8JCpPQ+ClbblL++hkSR25e1XNF46ToVTJJldLspLTcXjr2Oui1bpJZ3jppnZ9nvcQPfymtdM5fg==",
+      "dependencies": {
+        "@tbd54566975/dwn-sdk-js": "0.2.10",
+        "@web5/common": "0.2.3",
+        "@web5/crypto": "0.2.2",
+        "@web5/dids": "0.2.4",
+        "level": "8.0.0",
+        "readable-stream": "4.4.2",
+        "readable-web-to-node-stream": "3.0.2",
+        "ulidx": "2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "packages/proxy-agent/node_modules/@web5/crypto": {
@@ -17394,10 +17991,10 @@
     },
     "packages/user-agent": {
       "name": "@web5/user-agent",
-      "version": "0.2.6",
+      "version": "0.2.7",
       "license": "Apache-2.0",
       "dependencies": {
-        "@web5/agent": "0.2.6",
+        "@web5/agent": "0.2.7",
         "@web5/common": "0.2.3",
         "@web5/crypto": "0.2.2",
         "@web5/dids": "0.2.4"

--- a/package-lock.json
+++ b/package-lock.json
@@ -2531,47 +2531,6 @@
         "jwt-decode": "^3.1.2"
       }
     },
-    "node_modules/@tbd54566975/dwn-sdk-js": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/@tbd54566975/dwn-sdk-js/-/dwn-sdk-js-0.2.10.tgz",
-      "integrity": "sha512-CoKO8+NciwWNzD4xRoAAgeElqQCXKM4Fc+zEHsUWD0M3E9v67hRWiTHI6AenUfQv1RSEB2H4GHUeUOHuEV72uw==",
-      "dependencies": {
-        "@ipld/dag-cbor": "9.0.3",
-        "@js-temporal/polyfill": "0.4.4",
-        "@noble/ed25519": "2.0.0",
-        "@noble/secp256k1": "2.0.0",
-        "abstract-level": "1.0.3",
-        "ajv": "8.12.0",
-        "blockstore-core": "4.2.0",
-        "cross-fetch": "4.0.0",
-        "eciesjs": "0.4.5",
-        "interface-blockstore": "5.2.3",
-        "interface-store": "5.1.2",
-        "ipfs-unixfs-exporter": "13.1.5",
-        "ipfs-unixfs-importer": "15.1.5",
-        "level": "8.0.0",
-        "lodash": "4.17.21",
-        "lru-cache": "9.1.2",
-        "ms": "2.1.3",
-        "multiformats": "11.0.2",
-        "randombytes": "2.1.0",
-        "readable-stream": "4.4.2",
-        "ulidx": "2.1.0",
-        "uuid": "8.3.2",
-        "varint": "6.0.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/@tbd54566975/dwn-sdk-js/node_modules/lru-cache": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-9.1.2.tgz",
-      "integrity": "sha512-ERJq3FOzJTxBbFjZ7iDs+NiK4VI9Wz+RdrrAB8dio1oV+YvdPzUEE4QNiT2VD51DkIbCYRUUzCRkssXCHqSnKQ==",
-      "engines": {
-        "node": "14 || >=16.14"
-      }
-    },
     "node_modules/@tbd54566975/dwn-sql-store": {
       "version": "0.2.9",
       "resolved": "https://registry.npmjs.org/@tbd54566975/dwn-sql-store/-/dwn-sql-store-0.2.9.tgz",
@@ -17414,10 +17373,10 @@
     },
     "packages/proxy-agent": {
       "name": "@web5/proxy-agent",
-      "version": "0.2.6",
+      "version": "0.2.7",
       "license": "Apache-2.0",
       "dependencies": {
-        "@web5/agent": "0.2.6",
+        "@web5/agent": "0.2.7",
         "@web5/common": "0.2.3",
         "@web5/crypto": "0.2.2",
         "@web5/dids": "0.2.4"
@@ -17546,24 +17505,6 @@
         "typescript": {
           "optional": true
         }
-      }
-    },
-    "packages/proxy-agent/node_modules/@web5/agent": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@web5/agent/-/agent-0.2.6.tgz",
-      "integrity": "sha512-qBbFH7b08Sw8JCpPQ+ClbblL++hkSR25e1XNF46ToVTJJldLspLTcXjr2Oui1bpJZ3jppnZ9nvcQPfymtdM5fg==",
-      "dependencies": {
-        "@tbd54566975/dwn-sdk-js": "0.2.10",
-        "@web5/common": "0.2.3",
-        "@web5/crypto": "0.2.2",
-        "@web5/dids": "0.2.4",
-        "level": "8.0.0",
-        "readable-stream": "4.4.2",
-        "readable-web-to-node-stream": "3.0.2",
-        "ulidx": "2.1.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
       }
     },
     "packages/proxy-agent/node_modules/@web5/crypto": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17027,10 +17027,10 @@
     },
     "packages/identity-agent": {
       "name": "@web5/identity-agent",
-      "version": "0.2.6",
+      "version": "0.2.7",
       "license": "Apache-2.0",
       "dependencies": {
-        "@web5/agent": "0.2.6",
+        "@web5/agent": "0.2.7",
         "@web5/common": "0.2.3",
         "@web5/crypto": "0.2.2",
         "@web5/dids": "0.2.4"
@@ -17045,7 +17045,7 @@
         "@typescript-eslint/parser": "6.4.0",
         "@web/test-runner": "0.18.0",
         "@web/test-runner-playwright": "0.11.0",
-        "@web5/api": "0.8.4",
+        "@web5/api": "0.8.5",
         "c8": "9.0.0",
         "chai": "4.3.10",
         "chai-as-promised": "7.1.1",
@@ -17159,169 +17159,6 @@
         "typescript": {
           "optional": true
         }
-      }
-    },
-    "packages/identity-agent/node_modules/@web5/agent": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@web5/agent/-/agent-0.2.6.tgz",
-      "integrity": "sha512-qBbFH7b08Sw8JCpPQ+ClbblL++hkSR25e1XNF46ToVTJJldLspLTcXjr2Oui1bpJZ3jppnZ9nvcQPfymtdM5fg==",
-      "dependencies": {
-        "@tbd54566975/dwn-sdk-js": "0.2.10",
-        "@web5/common": "0.2.3",
-        "@web5/crypto": "0.2.2",
-        "@web5/dids": "0.2.4",
-        "level": "8.0.0",
-        "readable-stream": "4.4.2",
-        "readable-web-to-node-stream": "3.0.2",
-        "ulidx": "2.1.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "packages/identity-agent/node_modules/@web5/api": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/@web5/api/-/api-0.8.4.tgz",
-      "integrity": "sha512-3kqh7KQeeffsOBi+K5Vhpa59+ZgdI1em16drrRd7h59Jj4m8a09Enhw7WjWNLre7rTG84hQqB9+rpS1VHnOaKQ==",
-      "dev": true,
-      "dependencies": {
-        "@tbd54566975/dwn-sdk-js": "0.2.10",
-        "@web5/agent": "0.2.5",
-        "@web5/common": "0.2.2",
-        "@web5/crypto": "0.2.2",
-        "@web5/dids": "0.2.4",
-        "@web5/user-agent": "0.2.5",
-        "level": "8.0.0",
-        "ms": "2.1.3",
-        "readable-stream": "4.4.2",
-        "readable-web-to-node-stream": "3.0.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "packages/identity-agent/node_modules/@web5/api/node_modules/@web5/agent": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/@web5/agent/-/agent-0.2.5.tgz",
-      "integrity": "sha512-Z9JY/43Yrg0xKK26y/iZFdHNtVf/k9XLxw8mXP5zfYidrqfAgVR0i4LKA7qZKfUSxC7/uaD/STYYIKpNByd/cw==",
-      "dev": true,
-      "dependencies": {
-        "@tbd54566975/dwn-sdk-js": "0.2.8",
-        "@web5/common": "0.2.2",
-        "@web5/crypto": "0.2.2",
-        "@web5/dids": "0.2.3",
-        "level": "8.0.0",
-        "readable-stream": "4.4.2",
-        "readable-web-to-node-stream": "3.0.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "packages/identity-agent/node_modules/@web5/api/node_modules/@web5/agent/node_modules/@tbd54566975/dwn-sdk-js": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/@tbd54566975/dwn-sdk-js/-/dwn-sdk-js-0.2.8.tgz",
-      "integrity": "sha512-oiKk+ekAQO94bUkt6yk+xkDY8uCGmNC+rKaYQLhAoTrhYrczeRSuDT04F5/vPBT5K6NfAoRcQsIyBmvgRCUvgA==",
-      "dev": true,
-      "dependencies": {
-        "@ipld/dag-cbor": "9.0.3",
-        "@js-temporal/polyfill": "0.4.4",
-        "@noble/ed25519": "2.0.0",
-        "@noble/secp256k1": "2.0.0",
-        "abstract-level": "1.0.3",
-        "ajv": "8.12.0",
-        "blockstore-core": "4.2.0",
-        "cross-fetch": "4.0.0",
-        "eciesjs": "0.4.5",
-        "flat": "5.0.2",
-        "interface-blockstore": "5.2.3",
-        "interface-store": "5.1.2",
-        "ipfs-unixfs-exporter": "13.1.5",
-        "ipfs-unixfs-importer": "15.1.5",
-        "level": "8.0.0",
-        "lodash": "4.17.21",
-        "lru-cache": "9.1.2",
-        "ms": "2.1.3",
-        "multiformats": "11.0.2",
-        "randombytes": "2.1.0",
-        "readable-stream": "4.4.2",
-        "ulidx": "2.1.0",
-        "uuid": "8.3.2",
-        "varint": "6.0.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "packages/identity-agent/node_modules/@web5/api/node_modules/@web5/agent/node_modules/@web5/dids": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@web5/dids/-/dids-0.2.3.tgz",
-      "integrity": "sha512-Y3PHOavNkSyjBxZQEpKE6XueaqemBO5w0UMOnFh4xH6+5B43ENEE4LHIqVyn2bCpfEBGLXENgDZYqyJphBu0pA==",
-      "dev": true,
-      "dependencies": {
-        "@decentralized-identity/ion-pow-sdk": "1.0.17",
-        "@decentralized-identity/ion-sdk": "1.0.1",
-        "@web5/common": "0.2.2",
-        "@web5/crypto": "0.2.2",
-        "did-resolver": "4.1.0",
-        "dns-packet": "5.6.1",
-        "level": "8.0.0",
-        "ms": "2.1.3",
-        "pkarr": "1.1.1",
-        "z32": "1.0.1"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "packages/identity-agent/node_modules/@web5/api/node_modules/@web5/common": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@web5/common/-/common-0.2.2.tgz",
-      "integrity": "sha512-dRn6SmALExeTLMTK/W5ozGarfaddK+Lraf5OjuIGLAaLfcX1RWx3oDMoY5Hr9LjfxHJC8mGXB8DnKflbeYJRgA==",
-      "dev": true,
-      "dependencies": {
-        "level": "8.0.0",
-        "multiformats": "11.0.2",
-        "readable-stream": "4.4.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "packages/identity-agent/node_modules/@web5/api/node_modules/@web5/user-agent": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/@web5/user-agent/-/user-agent-0.2.5.tgz",
-      "integrity": "sha512-qv5M698C5HSvq30xUgLWtcsbZppjfOH5qZthpTRx4ItL5UWA/eQ9DsQiQeb4vet3uIUy3NHRDIQezclOdwYErw==",
-      "dev": true,
-      "dependencies": {
-        "@web5/agent": "0.2.5",
-        "@web5/common": "0.2.2",
-        "@web5/crypto": "0.2.2",
-        "@web5/dids": "0.2.3"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "packages/identity-agent/node_modules/@web5/api/node_modules/@web5/user-agent/node_modules/@web5/dids": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@web5/dids/-/dids-0.2.3.tgz",
-      "integrity": "sha512-Y3PHOavNkSyjBxZQEpKE6XueaqemBO5w0UMOnFh4xH6+5B43ENEE4LHIqVyn2bCpfEBGLXENgDZYqyJphBu0pA==",
-      "dev": true,
-      "dependencies": {
-        "@decentralized-identity/ion-pow-sdk": "1.0.17",
-        "@decentralized-identity/ion-sdk": "1.0.1",
-        "@web5/common": "0.2.2",
-        "@web5/crypto": "0.2.2",
-        "did-resolver": "4.1.0",
-        "dns-packet": "5.6.1",
-        "level": "8.0.0",
-        "ms": "2.1.3",
-        "pkarr": "1.1.1",
-        "z32": "1.0.1"
-      },
-      "engines": {
-        "node": ">=18.0.0"
       }
     },
     "packages/identity-agent/node_modules/@web5/crypto": {
@@ -17550,15 +17387,6 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true
-    },
-    "packages/identity-agent/node_modules/lru-cache": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-9.1.2.tgz",
-      "integrity": "sha512-ERJq3FOzJTxBbFjZ7iDs+NiK4VI9Wz+RdrrAB8dio1oV+YvdPzUEE4QNiT2VD51DkIbCYRUUzCRkssXCHqSnKQ==",
-      "dev": true,
-      "engines": {
-        "node": "14 || >=16.14"
-      }
     },
     "packages/identity-agent/node_modules/minimatch": {
       "version": "3.1.2",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "devDependencies": {
     "@npmcli/package-json": "5.0.0",
     "@typescript-eslint/eslint-plugin": "6.4.0",
-    "@web5/dwn-server": "0.1.9",
+    "@web5/dwn-server": "0.1.10",
     "eslint-plugin-mocha": "10.1.0"
   }
 }

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web5/agent",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "type": "module",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
@@ -68,7 +68,7 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
-    "@tbd54566975/dwn-sdk-js": "0.2.10",
+    "@tbd54566975/dwn-sdk-js": "0.2.16",
     "@web5/common": "0.2.3",
     "@web5/crypto": "0.2.2",
     "@web5/dids": "0.2.4",

--- a/packages/agent/src/dwn-manager.ts
+++ b/packages/agent/src/dwn-manager.ts
@@ -161,7 +161,7 @@ export class DwnManager {
 
     let reply: UnionMessageReply;
     if (request.store !== false) {
-      reply = await this._dwn.processMessage(request.target, message, dataStream);
+      reply = await this._dwn.processMessage(request.target, message, { dataStream });
     } else {
       reply = { status: { code: 202, detail: 'Accepted' }};
     }
@@ -435,6 +435,6 @@ export class DwnManager {
   }): Promise<UnionMessageReply> {
     const { dataStream, message, targetDid } = options;
 
-    return await this._dwn.processMessage(targetDid, message, dataStream);
+    return await this._dwn.processMessage(targetDid, message, { dataStream });
   }
 }

--- a/packages/agent/tests/dwn-manager.spec.ts
+++ b/packages/agent/tests/dwn-manager.spec.ts
@@ -116,7 +116,10 @@ describe('DwnManager', () => {
       });
 
       it('handles EventsGet', async () => {
-        const testCursor = 'foo';
+        const testCursor = {
+          messageCid : 'foo',
+          value      : 'bar'
+        };
 
         // Attempt to process the EventsGet.
         let eventsGetResponse = await testAgent.agent.dwnManager.processRequest({

--- a/packages/agent/tests/sync-manager.spec.ts
+++ b/packages/agent/tests/sync-manager.spec.ts
@@ -184,7 +184,7 @@ describe('SyncManagerLevel', () => {
       expect(remoteDwnQueryReply.entries).to.have.length(4);
       remoteRecordsFromQuery = remoteDwnQueryReply.entries?.map(entry => entry.recordId);
       expect(remoteRecordsFromQuery).to.have.members([...localRecords, ...remoteRecords]);
-    }).timeout(2_500);
+    }).timeout(3_000);
 
     describe('pull()', () => {
       it('takes no action if no identities are registered', async () => {
@@ -380,7 +380,7 @@ describe('SyncManagerLevel', () => {
         localDwnQueryReply = queryResponse.reply as RecordsQueryReply;
         expect(localDwnQueryReply.status.code).to.equal(200); // Query was successfully executed.
         expect(localDwnQueryReply.entries).to.have.length(1); // Record does exist on local DWN.
-      }).timeout(2_500);
+      }).timeout(3_000);
     });
 
     describe('push()', () => {
@@ -576,7 +576,7 @@ describe('SyncManagerLevel', () => {
         remoteDwnQueryReply = queryResponse.reply as RecordsQueryReply;
         expect(remoteDwnQueryReply.status.code).to.equal(200); // Query was successfully executed.
         expect(remoteDwnQueryReply.entries).to.have.length(1); // Record does exist on remote DWN.
-      }).timeout(2_500);
+      }).timeout(3_000);
     });
 
     describe('startSync()', () => {

--- a/packages/agent/tests/sync-manager.spec.ts
+++ b/packages/agent/tests/sync-manager.spec.ts
@@ -76,37 +76,53 @@ describe('SyncManagerLevel', () => {
       await testAgent.closeStorage();
     });
 
+    // NOTE: from `dwn-sdk-js` `v0.2.10` to `v0.2.16` this test saw a significant increase in time. TODO: investigate
     it('syncs multiple records in both directions', async () => {
-      // create 3 local records.
+      // create 2 local records.
       const localRecords: string[] = [];
-      for (let i = 0; i < 3; i++) {
-        const writeResponse = await testAgent.agent.dwnManager.processRequest({
-          author         : alice.did,
-          target         : alice.did,
-          messageType    : 'RecordsWrite',
-          messageOptions : {
-            dataFormat: 'text/plain'
-          },
-          dataStream: new Blob([`Hello, ${i}`])
-        });
+      const writeResponse1Promise = testAgent.agent.dwnManager.processRequest({
+        author         : alice.did,
+        target         : alice.did,
+        messageType    : 'RecordsWrite',
+        messageOptions : {
+          dataFormat: 'text/plain'
+        },
+        dataStream: new Blob(['Hello, 1'])
+      });
+      const writeResponse2Promise = testAgent.agent.dwnManager.processRequest({
+        author         : alice.did,
+        target         : alice.did,
+        messageType    : 'RecordsWrite',
+        messageOptions : {
+          dataFormat: 'text/plain'
+        },
+        dataStream: new Blob(['Hello, 2'])
+      });
+      localRecords.push(((await writeResponse1Promise).message as RecordsWriteMessage).recordId);
+      localRecords.push(((await writeResponse2Promise).message as RecordsWriteMessage).recordId);
 
-        localRecords.push((writeResponse.message as RecordsWriteMessage).recordId);
-      }
-
-      // create 3 remote records
+      // create 2 remote records
       const remoteRecords: string[] = [];
-      for (let i = 0; i < 3; i++) {
-        let writeResponse = await testAgent.agent.dwnManager.sendRequest({
-          author         : alice.did,
-          target         : alice.did,
-          messageType    : 'RecordsWrite',
-          messageOptions : {
-            dataFormat: 'text/plain'
-          },
-          dataStream: new Blob([`Hello, ${i}`])
-        });
-        remoteRecords.push((writeResponse.message as RecordsWriteMessage).recordId);
-      }
+      const writeResponse3Promise = testAgent.agent.dwnManager.sendRequest({
+        author         : alice.did,
+        target         : alice.did,
+        messageType    : 'RecordsWrite',
+        messageOptions : {
+          dataFormat: 'text/plain'
+        },
+        dataStream: new Blob(['Hello, 3'])
+      });
+      const writeResponse4Promise = testAgent.agent.dwnManager.sendRequest({
+        author         : alice.did,
+        target         : alice.did,
+        messageType    : 'RecordsWrite',
+        messageOptions : {
+          dataFormat: 'text/plain'
+        },
+        dataStream: new Blob(['Hello, 4'])
+      });
+      remoteRecords.push(((await writeResponse3Promise).message as RecordsWriteMessage).recordId);
+      remoteRecords.push(((await writeResponse4Promise).message as RecordsWriteMessage).recordId);
 
       // query local and check for only local records
       let localQueryResponse = await testAgent.agent.dwnManager.processRequest({
@@ -117,7 +133,7 @@ describe('SyncManagerLevel', () => {
       });
       let localDwnQueryReply = localQueryResponse.reply as RecordsQueryReply;
       expect(localDwnQueryReply.status.code).to.equal(200);
-      expect(localDwnQueryReply.entries).to.have.length(3);
+      expect(localDwnQueryReply.entries).to.have.length(2);
       let localRecordsFromQuery = localDwnQueryReply.entries?.map(entry => entry.recordId);
       expect(localRecordsFromQuery).to.have.members(localRecords);
 
@@ -130,7 +146,7 @@ describe('SyncManagerLevel', () => {
       });
       let remoteDwnQueryReply = remoteQueryResponse.reply as RecordsQueryReply;
       expect(remoteDwnQueryReply.status.code).to.equal(200);
-      expect(remoteDwnQueryReply.entries).to.have.length(3);
+      expect(remoteDwnQueryReply.entries).to.have.length(2);
       let remoteRecordsFromQuery = remoteDwnQueryReply.entries?.map(entry => entry.recordId);
       expect(remoteRecordsFromQuery).to.have.members(remoteRecords);
 
@@ -152,7 +168,7 @@ describe('SyncManagerLevel', () => {
       });
       localDwnQueryReply = localQueryResponse.reply as RecordsQueryReply;
       expect(localDwnQueryReply.status.code).to.equal(200);
-      expect(localDwnQueryReply.entries).to.have.length(6);
+      expect(localDwnQueryReply.entries).to.have.length(4);
       localRecordsFromQuery = localDwnQueryReply.entries?.map(entry => entry.recordId);
       expect(localRecordsFromQuery).to.have.members([...localRecords, ...remoteRecords]);
 
@@ -165,11 +181,10 @@ describe('SyncManagerLevel', () => {
       });
       remoteDwnQueryReply = remoteQueryResponse.reply as RecordsQueryReply;
       expect(remoteDwnQueryReply.status.code).to.equal(200);
-      expect(remoteDwnQueryReply.entries).to.have.length(6);
+      expect(remoteDwnQueryReply.entries).to.have.length(4);
       remoteRecordsFromQuery = remoteDwnQueryReply.entries?.map(entry => entry.recordId);
       expect(remoteRecordsFromQuery).to.have.members([...localRecords, ...remoteRecords]);
-
-    });
+    }).timeout(2_500);
 
     describe('pull()', () => {
       it('takes no action if no identities are registered', async () => {
@@ -365,7 +380,7 @@ describe('SyncManagerLevel', () => {
         localDwnQueryReply = queryResponse.reply as RecordsQueryReply;
         expect(localDwnQueryReply.status.code).to.equal(200); // Query was successfully executed.
         expect(localDwnQueryReply.entries).to.have.length(1); // Record does exist on local DWN.
-      });
+      }).timeout(2_500);
     });
 
     describe('push()', () => {
@@ -561,7 +576,7 @@ describe('SyncManagerLevel', () => {
         remoteDwnQueryReply = queryResponse.reply as RecordsQueryReply;
         expect(remoteDwnQueryReply.status.code).to.equal(200); // Query was successfully executed.
         expect(remoteDwnQueryReply.entries).to.have.length(1); // Record does exist on remote DWN.
-      });
+      }).timeout(2_500);
     });
 
     describe('startSync()', () => {

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web5/api",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "SDK for accessing the features and capabilities of Web5",
   "type": "module",
   "main": "./dist/cjs/index.js",
@@ -76,12 +76,12 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
-    "@tbd54566975/dwn-sdk-js": "0.2.10",
-    "@web5/agent": "0.2.6",
+    "@tbd54566975/dwn-sdk-js": "0.2.16",
+    "@web5/agent": "0.2.7",
     "@web5/common": "0.2.3",
     "@web5/crypto": "0.2.2",
     "@web5/dids": "0.2.4",
-    "@web5/user-agent": "0.2.6",
+    "@web5/user-agent": "0.2.7",
     "level": "8.0.0",
     "ms": "2.1.3",
     "readable-stream": "4.4.2",

--- a/packages/api/src/dwn-api.ts
+++ b/packages/api/src/dwn-api.ts
@@ -1,8 +1,8 @@
 import type { DwnResponse, Web5Agent } from '@web5/agent';
 import type {
+  PaginationCursor,
   RecordsQueryReply,
   RecordsReadOptions,
-  PaginationCursor,
   ProtocolsQueryReply,
   RecordsQueryOptions,
   RecordsWriteMessage,

--- a/packages/api/src/dwn-api.ts
+++ b/packages/api/src/dwn-api.ts
@@ -2,6 +2,7 @@ import type { DwnResponse, Web5Agent } from '@web5/agent';
 import type {
   RecordsQueryReply,
   RecordsReadOptions,
+  PaginationCursor,
   ProtocolsQueryReply,
   RecordsQueryOptions,
   RecordsWriteMessage,
@@ -135,7 +136,7 @@ export type RecordsQueryResponse = ResponseStatus & {
   records?: Record[]
 
   /** If there are additional results, the messageCid of the last record will be returned as a pagination cursor. */
-  cursor?: string;
+  cursor?: PaginationCursor;
 };
 
 /**

--- a/packages/dev-env/docker-compose.yaml
+++ b/packages/dev-env/docker-compose.yaml
@@ -3,6 +3,6 @@ version: "3.98"
 services:
   dwn-server:
     container_name: dwn-server
-    image: ghcr.io/tbd54566975/dwn-server:dwn-sdk-0.2.10
+    image: ghcr.io/tbd54566975/dwn-server:dwn-sdk-0.2.16
     ports:
       - "3000:3000"

--- a/packages/identity-agent/package.json
+++ b/packages/identity-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web5/identity-agent",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "type": "module",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
@@ -68,7 +68,7 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
-    "@web5/agent": "0.2.6",
+    "@web5/agent": "0.2.7",
     "@web5/common": "0.2.3",
     "@web5/crypto": "0.2.2",
     "@web5/dids": "0.2.4"
@@ -83,7 +83,7 @@
     "@typescript-eslint/parser": "6.4.0",
     "@web/test-runner": "0.18.0",
     "@web/test-runner-playwright": "0.11.0",
-    "@web5/api": "0.8.4",
+    "@web5/api": "0.8.5",
     "c8": "9.0.0",
     "chai": "4.3.10",
     "chai-as-promised": "7.1.1",

--- a/packages/proxy-agent/package.json
+++ b/packages/proxy-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web5/proxy-agent",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "type": "module",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
@@ -68,7 +68,7 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
-    "@web5/agent": "0.2.6",
+    "@web5/agent": "0.2.7",
     "@web5/common": "0.2.3",
     "@web5/crypto": "0.2.2",
     "@web5/dids": "0.2.4"

--- a/packages/user-agent/package.json
+++ b/packages/user-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web5/user-agent",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "type": "module",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
@@ -68,7 +68,7 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
-    "@web5/agent": "0.2.6",
+    "@web5/agent": "0.2.7",
     "@web5/common": "0.2.3",
     "@web5/crypto": "0.2.2",
     "@web5/dids": "0.2.4"


### PR DESCRIPTION
- Update `dwn-sdk-js` to `v0.2.16` across the `agent` and `api` package.
- Bump `agent`, `user-agent`, `proxy-agent` and `identity-agent` to `v0.2.7`
- Bump `api` to `v0.8.5`
- Bump `dwn-server` dev dependency version to `v0.1.10`