### PR TITLE
Fix broken link docs warnings

### DIFF
--- a/packages/api/src/web5.ts
+++ b/packages/api/src/web5.ts
@@ -26,16 +26,16 @@ export type TechPreviewOptions = {
  */
 export type Web5ConnectOptions = {
   /**
-   * Provide a {@link @web5/agent#Web5Agent} implementation. Defaults to creating a local
-   * {@link @web5/user-agent#Web5UserAgent} if one isn't provided
+   * Provide a {@link Web5Agent} implementation. Defaults to creating a local
+   * {@link Web5UserAgent} if one isn't provided
    **/
   agent?: Web5Agent;
 
   /**
-   * Provide an instance of a {@link @web5/agent#AppDataStore} implementation. Defaults to
+   * Provide an instance of a {@link AppDataStore} implementation. Defaults to
    * a LevelDB-backed store with an insecure, static unlock passphrase if one
    * isn't provided. To allow the app user to enter a secure passphrase of
-   * their choosing, provide an initialized {@link @web5/agent#AppDataStore} instance.
+   * their choosing, provide an initialized {@link AppDataStore} instance.
    **/
   appData?: AppDataStore;
 
@@ -98,7 +98,7 @@ export class Web5 {
   }
 
   /**
-   * Connects to a {@link @web5/agent#Web5Agent}. Defaults to creating a local {@link @web5/user-agent#Web5UserAgent}
+   * Connects to a {@link Web5Agent}. Defaults to creating a local {@link Web5UserAgent}
    * if one isn't provided.
    *
    * @param options - optional overrides

--- a/packages/crypto-aws-kms/src/ecdsa.ts
+++ b/packages/crypto-aws-kms/src/ecdsa.ts
@@ -162,8 +162,8 @@ export class EcdsaAlgorithm implements
    *
    * Note: The signature returned is normalized to low-S to prevent signature malleability. This
    * ensures that the signature can be verified by other libraries that enforce strict verification.
-   * More information on signature malleability can be found
-   * {@link @web5/crypto#Secp256k1.adjustSignatureToLowS | here}.
+   * More information on signature malleability can be found on
+   * {@link Secp256k1.adjustSignatureToLowS | here}.
    *
    * @example
    * ```ts

--- a/packages/dids/src/methods/did-dht.ts
+++ b/packages/dids/src/methods/did-dht.ts
@@ -609,7 +609,7 @@ export class DidDht extends DidMethod {
    * ```
    *
    * @param params - The parameters for the import operation.
-   * @param params.portableDid - The PortableDid object to import.
+   * @param params.portableDid - The {@link PortableDid} object to import.
    * @param params.keyManager - Optionally specify an external Key Management System (KMS) used to
    *                            generate keys and sign data. If not given, a new
    *                            {@link LocalKeyManager} instance will be created and


### PR DESCRIPTION
Fixes all the `typedoc:invalid-link` warnings.

To be merged on top of #402, or to be rebased after that one is merged.