### PR TITLE
Did Dht Resolve Web5 Test Vector Impl

### DIFF
--- a/packages/dids/src/methods/did-dht.ts
+++ b/packages/dids/src/methods/did-dht.ts
@@ -889,6 +889,10 @@ export class DidDhtDocument {
     // Read the Fetch Response stream into a byte array.
     const messageBytes = await response.arrayBuffer();
 
+    if(!messageBytes) {
+      throw new DidError(DidErrorCode.NotFound, `Pkarr record not found for: ${identifier}`);
+    }
+
     if (messageBytes.byteLength < 72) {
       throw new DidError(DidErrorCode.InvalidDidDocumentLength, `Pkarr response must be at least 72 bytes but got: ${messageBytes.byteLength}`);
     }

--- a/packages/dids/tests/methods/did-dht.spec.ts
+++ b/packages/dids/tests/methods/did-dht.spec.ts
@@ -6,6 +6,8 @@ import type { PortableDid } from '../../src/types/portable-did.js';
 
 import { DidErrorCode } from '../../src/did-error.js';
 import { DidDht, DidDhtRegisteredDidType } from '../../src/methods/did-dht.js';
+import DidDhtResolveTestVector from '../../../../web5-spec/test-vectors/did_dht/resolve.json' assert { type: 'json' };
+
 
 // Helper function to create a mocked fetch response that fails and returns a 404 Not Found.
 const fetchNotFoundResponse = () => ({
@@ -800,6 +802,16 @@ describe('DidDht', () => {
       const didResolutionResult = await DidDht.resolve(did);
 
       expect(didResolutionResult.didResolutionMetadata).to.have.property('error', 'invalidDidDocumentLength');
+    });
+  });
+
+
+  describe('Web5TestVectorsDidDht', () => {
+    it('resolve', async () => {
+      for (const vector of DidDhtResolveTestVector.vectors) {
+        const didResolutionResult = await DidDht.resolve(vector.input.didUri);
+        expect(didResolutionResult.didResolutionMetadata.error).to.equal(vector.output.didResolutionMetadata.error);
+      }
     });
   });
 });


### PR DESCRIPTION
This change consumes the Web5 Test Vectors for Did:Dht Resolve

This will make the web5-js resolve be a checkmark
<img width="537" alt="image" src="https://github.com/TBD54566975/web5-js/assets/5314059/1b501168-510b-45f7-be04-20da9ee4605a">

