### PR TITLE
Fix several minor issues in `@web5/dids`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15394,6 +15394,23 @@
         }
       }
     },
+    "packages/credentials/node_modules/@web5/dids": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@web5/dids/-/dids-0.4.0.tgz",
+      "integrity": "sha512-e+QcrKWlWPJVBbpz4QKrdcgPoj+uC8YUXt4tGKj1mC4kV0rCtIioMLw9Djg+54pp3VXl3eGKxju98UEddyZwqA==",
+      "dependencies": {
+        "@decentralized-identity/ion-sdk": "1.0.1",
+        "@dnsquery/dns-packet": "6.1.1",
+        "@web5/common": "0.2.3",
+        "@web5/crypto": "0.4.0",
+        "bencode": "4.0.0",
+        "level": "8.0.0",
+        "ms": "2.1.3"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "packages/credentials/node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -16184,7 +16201,7 @@
     },
     "packages/dids": {
       "name": "@web5/dids",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@decentralized-identity/ion-sdk": "1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15292,7 +15292,7 @@
     },
     "packages/credentials": {
       "name": "@web5/credentials",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@sphereon/pex": "2.1.0",

--- a/packages/dids/package.json
+++ b/packages/dids/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web5/dids",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "TBD DIDs library",
   "type": "module",
   "main": "./dist/cjs/index.js",

--- a/packages/dids/src/bearer-did.ts
+++ b/packages/dids/src/bearer-did.ts
@@ -198,7 +198,7 @@ export class BearerDid {
   }
 
   /**
-   * Instantiates a {@link BearerDid} object for the DID DHT method from a given {@link PortableDid}.
+   * Instantiates a {@link BearerDid} object from a given {@link PortableDid}.
    *
    * This method allows for the creation of a `BearerDid` object using a previously created DID's
    * key material, DID document, and metadata.
@@ -208,7 +208,7 @@ export class BearerDid {
    * // Export an existing BearerDid to PortableDid format.
    * const portableDid = await did.export();
    * // Reconstruct a BearerDid object from the PortableDid.
-   * const did = await DidDht.import({ portableDid });
+   * const did = await BearerDid.import({ portableDid });
    * ```
    *
    * @param params - The parameters for the import operation.

--- a/packages/dids/src/methods/did-jwk.ts
+++ b/packages/dids/src/methods/did-jwk.ts
@@ -84,7 +84,7 @@ export interface DidJwkCreateOptions<TKms> extends DidCreateOptions<TKms> {
    * Alternatively, specify the algorithm to be used for key generation of the single verification
    * method in the DID Document.
    */
-  verificationMethods?: [DidCreateVerificationMethod<TKms>];
+  verificationMethods?: DidCreateVerificationMethod<TKms>[];
 }
 
 /**

--- a/packages/dids/src/methods/did-key.ts
+++ b/packages/dids/src/methods/did-key.ts
@@ -139,7 +139,7 @@ export interface DidKeyCreateOptions<TKms> extends DidCreateOptions<TKms> {
    * Alternatively, specify the algorithm to be used for key generation of the single verification
    * method in the DID Document.
    */
-  verificationMethods?: [DidCreateVerificationMethod<TKms>];
+  verificationMethods?: DidCreateVerificationMethod<TKms>[];
 }
 
 /**

--- a/packages/dids/src/methods/did-method.ts
+++ b/packages/dids/src/methods/did-method.ts
@@ -82,9 +82,9 @@ export interface DidCreateVerificationMethod<TKms> extends Pick<Partial<DidVerif
  * @typeparam O - The type of the options used for creating the DID.
  */
 export interface DidMethodApi<
-    TDid extends BearerDid,
-    TOptions extends DidCreateOptions<TKms>,
-    TKms extends CryptoApi | undefined = undefined
+    TKms extends CryptoApi | undefined = CryptoApi,
+    TDid extends BearerDid = BearerDid,
+    TOptions extends DidCreateOptions<TKms> = DidCreateOptions<TKms>
   > extends DidMethodResolver {
   /**
    * The name of the DID method.
@@ -106,7 +106,27 @@ export interface DidMethodApi<
    * @param params.options - Optional. The options used for creating the DID.
    * @returns A promise that resolves to the newly created DID instance.
    */
-  create(params: { keyManager?: TKms, options?: TOptions }): Promise<TDid>;
+  create(params: {
+    keyManager?: TKms;
+    options?: TOptions;
+  }): Promise<TDid>;
+
+  /**
+   * Given a DID Document, return the verification method that will be used for signing messages and
+   * credentials.
+   *
+   * If given, the `methodId` parameter is used to select the verification method. If not given, a
+   * DID method specific approach is taken to selecting the verification method to return.
+   *
+   * @param params - The parameters for the `getSigningMethod` operation.
+   * @param params.didDocument - DID Document to get the verification method from.
+   * @param params.methodId - ID of the verification method to use for signing.
+   * @returns A promise that resolves to the erification method to use for signing.
+   */
+  getSigningMethod(params: {
+    didDocument: DidDocument;
+    methodId?: string;
+  }): Promise<DidVerificationMethod>;
 }
 
 /**

--- a/packages/dids/tests/methods/did-jwk.spec.ts
+++ b/packages/dids/tests/methods/did-jwk.spec.ts
@@ -105,7 +105,6 @@ describe('DidJwk', () => {
 
     it('throws an error if zero verificationMethods are given', async () => {
       try {
-        // @ts-expect-error - Test case where verificationMethods is undefined.
         await DidJwk.create({ keyManager, options: { verificationMethods: [] } });
         expect.fail('Expected an error to be thrown.');
       } catch (error: any) {
@@ -117,7 +116,6 @@ describe('DidJwk', () => {
       try {
         await DidJwk.create({
           keyManager,
-          // @ts-expect-error - Test case where verificationMethods has too many entries.
           options: { verificationMethods: [{ algorithm: 'secp256k1' }, { algorithm: 'Ed25519' }] }
         });
         expect.fail('Expected an error to be thrown.');

--- a/packages/dids/tests/methods/did-key.spec.ts
+++ b/packages/dids/tests/methods/did-key.spec.ts
@@ -125,7 +125,6 @@ describe('DidKey', () => {
 
     it('throws an error if zero verificationMethods are given', async () => {
       try {
-        // @ts-expect-error - Test case where verificationMethods is undefined.
         await DidKey.create({ keyManager, options: { verificationMethods: [] } });
         expect.fail('Expected an error to be thrown.');
       } catch (error: any) {
@@ -137,7 +136,6 @@ describe('DidKey', () => {
       try {
         await DidKey.create({
           keyManager,
-          // @ts-expect-error - Test case where verificationMethods has too many entries.
           options: { verificationMethods: [{ algorithm: 'secp256k1' }, { algorithm: 'Ed25519' }] }
         });
         expect.fail('Expected an error to be thrown.');


### PR DESCRIPTION
This PR will:
- Correct typos in comments.
- Improve type inference in `DidMethodApi` generics.
- Add `getSigningMethod()` to `DidMethodApi` to ensure all implementations include it.
- Make the `verificationMethods` type in `DidJwk` and `DidKey` to be consistent with `DidDht`.
- Bump `@web5/dids` to `0.4.1` so that the changes can be published to NPM Registry.

> [!IMPORTANT]
> Should be merged _after_ #413 