### PR TITLE
Add credentials to published api reference docs

### DIFF
--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -56,6 +56,10 @@ jobs:
               docsReporter: typedoc
               docsGenerator: typedoc-html
               readmeFile: packages/dids/README.md
+            - file: packages/credentials/src/index.ts
+              docsReporter: typedoc
+              docsGenerator: typedoc-html
+              readmeFile: packages/credentials/README.md
 
       - name: Save Artifacts
         uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 #v3.1.3

--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -2,13 +2,14 @@
 name: Build and Deploy Docs
 
 on:
-  # Runs on pushes targeting the default branch
-  # push:
-  #   branches:
-  #     - main
-
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
+
+  # Automatically triggers when a new release is published
+  workflow_run:
+    workflows: ["Release to NPM Registry"]
+    types:
+      - completed
 
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
@@ -32,7 +33,7 @@ jobs:
         with:
           node-version: 18
           registry-url: https://registry.npmjs.org/
-          cache: 'npm'
+          cache: "npm"
 
       - name: Install dependencies
         run: |
@@ -65,6 +66,10 @@ jobs:
               docsReporter: typedoc
               docsGenerator: typedoc-html
               readmeFile: packages/dids/README.md
+            - file: packages/credentials/src/index.ts
+              docsReporter: typedoc
+              docsGenerator: typedoc-html
+              readmeFile: packages/credentials/README.md
 
       - name: Upload documentation artifacts
         uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 #v3.1.3

--- a/scripts/tbdocs-check-local.sh
+++ b/scripts/tbdocs-check-local.sh
@@ -24,6 +24,10 @@ INPUT_ENTRY_POINTS="
   docsReporter: typedoc
   docsGenerator: typedoc-html
   readmeFile: packages/dids/README.md
+- file: packages/credentials/src/index.ts
+  docsReporter: typedoc
+  docsGenerator: typedoc-html
+  readmeFile: packages/credentials/README.md
 "
 
 # Default docker image


### PR DESCRIPTION
- publishes `@web5/credentials` to https://tbd54566975.github.io/web5-js/
- add automation to publish docs whenever a new release is made (somehow I forgot in the initial PR)