### PR TITLE
Add crypto utility function and use in BearerDid

### DIFF
--- a/packages/crypto/src/utils.ts
+++ b/packages/crypto/src/utils.ts
@@ -1,3 +1,5 @@
+import type { Jwk } from './jose/jwk.js';
+
 import { crypto } from '@noble/hashes/crypto';
 import { randomBytes as nobleRandomBytes } from '@noble/hashes/utils';
 
@@ -61,6 +63,54 @@ export function checkValidProperty(params: {
     const validProperties = Array.from((allowedProperties instanceof Map) ? allowedProperties.keys() : allowedProperties).join(', ');
     throw new TypeError(`Out of range: '${property}'. Must be one of '${validProperties}'`);
   }
+}
+
+/**
+ * Determines the JOSE algorithm identifier of the digital signature algorithm based on the `alg` or
+ * `crv` property of a {@link Jwk | JWK}.
+ *
+ * If the `alg` property is present, its value takes precedence and is returned. Otherwise, the
+ * `crv` property is used to determine the algorithm.
+ *
+ * @see {@link https://www.iana.org/assignments/jose/jose.xhtml#web-signature-encryption-algorithms | JOSE Algorithms}
+ * @see {@link https://datatracker.ietf.org/doc/draft-ietf-jose-fully-specified-algorithms/ | Fully-Specified Algorithms for JOSE and COSE}
+ *
+ * @example
+ * ```ts
+ * const publicKey: Jwk = {
+ *   "kty": "OKP",
+ *   "crv": "Ed25519",
+ *   "x": "FEJG7OakZi500EydXxuE8uMc8uaAzEJkmQeG8khXANw"
+ * }
+ * const algorithm = getJoseSignatureAlgorithmFromPublicKey(publicKey);
+ * console.log(algorithm); // Output: "EdDSA"
+ * ```
+ *
+ * @param publicKey - A JWK containing the `alg` and/or `crv` properties.
+ * @returns The name of the algorithm associated with the key.
+ * @throws Error if the algorithm cannot be determined from the provided input.
+ */
+export function getJoseSignatureAlgorithmFromPublicKey(publicKey: Jwk): string {
+  const curveToJoseAlgorithm: Record<string, string> = {
+    'Ed25519'   : 'EdDSA',
+    'P-256'     : 'ES256',
+    'P-384'     : 'ES384',
+    'P-521'     : 'ES512',
+    'secp256k1' : 'ES256K',
+  };
+
+  // If the key contains an `alg` property that matches a JOSE registered algorithm identifier,
+  // return its value.
+  if (publicKey.alg && Object.values(curveToJoseAlgorithm).includes(publicKey.alg)) {
+    return publicKey.alg;
+  }
+
+  // If the key contains a `crv` property, return the corresponding algorithm.
+  if (publicKey.crv && Object.keys(curveToJoseAlgorithm).includes(publicKey.crv)) {
+    return curveToJoseAlgorithm[publicKey.crv];
+  }
+
+  throw new Error(`Unable to determine algorithm based on provided input: alg=${publicKey.alg}, crv=${publicKey.crv}`);
 }
 
 /**

--- a/packages/crypto/src/utils.ts
+++ b/packages/crypto/src/utils.ts
@@ -110,7 +110,11 @@ export function getJoseSignatureAlgorithmFromPublicKey(publicKey: Jwk): string {
     return curveToJoseAlgorithm[publicKey.crv];
   }
 
-  throw new Error(`Unable to determine algorithm based on provided input: alg=${publicKey.alg}, crv=${publicKey.crv}`);
+  throw new Error(
+    `Unable to determine algorithm based on provided input: alg=${publicKey.alg}, crv=${publicKey.crv}. ` +
+    `Supported 'alg' values: ${Object.values(curveToJoseAlgorithm).join(', ')}. ` +
+    `Supported 'crv' values: ${Object.keys(curveToJoseAlgorithm).join(', ')}.`
+  );
 }
 
 /**


### PR DESCRIPTION
This PR will:
- Move a crypto utility function from within `BearerDid` to the `@web5/crypto` package.
- Update `BearerDid` to use the utility function.
- Update the docs for `BearerDid` to close #418.

> [!NOTE]
> The package versions for `@web5/crypto` and `@web5/dids` are not incremented in this PR as this change is rather minimal, has no immediate impact on external API consumers, and consequently, isn't worth publishing a new release.
> A future PR will bump the versions and publish new releases as the utility function added to `@web5/crypto` is consumed in other packages in this monorepo (which is already the case for a branch that is still a WIP.