### PR TITLE
fix a couple of actions and bump

### DIFF
--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -70,7 +70,7 @@ jobs:
               readmeFile: packages/credentials/README.md
 
       - name: Upload documentation artifacts
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 #v3.1.3
+        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 #v4.3.1
         with:
           name: tbdocs-output
           path: ./.tbdocs
@@ -97,19 +97,19 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
 
       - name: Setup Pages
-        uses: actions/configure-pages@b8130d9ab958b325bbde9786d62f2c97a9885a0e #v3.0.7
+        uses: actions/configure-pages@1f0c5cde4bc74cd7e1254d0cb4de8d49e9068c7d #v4.0.0
 
       - name: Download TBDocs Artifacts
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a #v3.0.2
+        uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 #v4.1.4
         with:
           name: tbdocs-output
           path: ./tbdocs
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@84bb4cd4b733d5c320c9c9cfbc354937524f4d64 #v1.0.10
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa #v3.0.1
         with:
           path: "./tbdocs/docs"
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@de14547edc9944350dc0481aa5b7afb08e75f254 #v2.0.5
+        uses: actions/deploy-pages@decdde0ac072f6dcbe43649d82d9c635fff5b4e4 #v4.0.4

--- a/.github/workflows/release-notify.yml
+++ b/.github/workflows/release-notify.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
     - name: Create Issue
-      uses: actions/github-script@v6
+      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
       with:
         github-token: ${{ secrets.DOCS_PAT }}  # Assuming 'PAT' is your Personal Access Token stored as a secret
         script: |

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -59,7 +59,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 #v3.1.3
+        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 #v4.3.1
         with:
           name: SARIF file
           path: results.sarif

--- a/.github/workflows/tests-ci.yml
+++ b/.github/workflows/tests-ci.yml
@@ -55,8 +55,11 @@ jobs:
           node node_modules/@web5/dwn-server/dist/esm/src/main.js &
           echo "DWN_SERVER_BACKGROUND_PROCESS=$!" >> $GITHUB_ENV
 
+      - name: Build tests for all packages
+        run: pnpm --recursive --stream --sequential build:tests:node
+
       - name: Run tests for all packages
-        run: npm run test:node --ws -- --color
+        run: pnpm --recursive --stream exec c8 mocha -- --color --reporter mocha-junit-reporter --reporter-options mochaFile=./results.xml
         env:
           TEST_DWN_URL: http://localhost:3000
 

--- a/.github/workflows/tests-ci.yml
+++ b/.github/workflows/tests-ci.yml
@@ -59,7 +59,7 @@ jobs:
         run: pnpm --recursive --stream --sequential build:tests:node
 
       - name: Run tests for all packages
-        run: npm run test:node --ws -- --color
+        run: pnpm --recursive --stream exec c8 mocha -- --color --reporter mocha-junit-reporter --reporter-options mochaFile=./results.xml
         env:
           TEST_DWN_URL: http://localhost:3000
 

--- a/.github/workflows/tests-ci.yml
+++ b/.github/workflows/tests-ci.yml
@@ -56,7 +56,7 @@ jobs:
           echo "DWN_SERVER_BACKGROUND_PROCESS=$!" >> $GITHUB_ENV
 
       - name: Run tests for all packages
-        run: pnpm --recursive --no-stream --sequential test:node -- --color --reporter mocha-junit-reporter --reporter-options mochaFile=./results.xml
+        run: npm run test:node --ws -- --color
         env:
           TEST_DWN_URL: http://localhost:3000
 

--- a/.github/workflows/tests-ci.yml
+++ b/.github/workflows/tests-ci.yml
@@ -18,15 +18,11 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
 
-      - uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d #v3.0.0
+      # https://cashapp.github.io/hermit/usage/ci/
+      - name: Init Hermit
+        uses: cashapp/activate-hermit@v1
         with:
-          version: 8
-
-      - name: Set up Node.js
-        uses: actions/setup-node@5ef044f9d09786428e6e895be6be17937becee3a #v4.0.0
-        with:
-          node-version: 18
-          cache: 'pnpm'
+          cache: "true"
 
       - name: Report known vulnerabilities
         run: pnpm audit
@@ -39,16 +35,11 @@ jobs:
         with:
           submodules: true
     
-      - uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d #v3.0.0
+      # https://cashapp.github.io/hermit/usage/ci/
+      - name: Init Hermit
+        uses: cashapp/activate-hermit@v1
         with:
-          version: 8
-
-      - name: Set up Node.js
-        uses: actions/setup-node@5ef044f9d09786428e6e895be6be17937becee3a #v4.0.0
-        with:
-          node-version: 18
-          registry-url: https://registry.npmjs.org/
-          cache: 'pnpm'
+          cache: "true"
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -78,13 +69,13 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Upload test results to update SDK reports
-        uses: actions/upload-artifact@1eb3cb2b3e0f29609092a73eb033bb759a334595 # v4.1.0
+        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
         with:
           name: junit-results
           path: packages/*/results.xml
 
       - name: Generate an access token to trigger downstream repo
-        uses: actions/create-github-app-token@2986852ad836768dfea7781f31828eb3e17990fa # v1.6.2
+        uses: actions/create-github-app-token@f2acddfb5195534d487896a656232b016a682f3c # v1.9.0
         id: generate_token
         if: github.ref == 'refs/heads/main'
         with:
@@ -144,7 +135,7 @@ jobs:
 
       - name: Restore Cached Playwright Browsers
         id: cache-playwright-restore
-        uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 #v3.3.2
+        uses: actions/cache@ab5e6d0c87105b4c9c2047343972218f562e4319 #v4.0.1
         with:
           path: ~/Library/Caches/ms-playwright
           key: ${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}

--- a/.github/workflows/tests-ci.yml
+++ b/.github/workflows/tests-ci.yml
@@ -59,7 +59,7 @@ jobs:
         run: pnpm --recursive --stream --sequential build:tests:node
 
       - name: Run tests for all packages
-        run: pnpm --recursive --stream exec c8 mocha -- --color --reporter mocha-junit-reporter --reporter-options mochaFile=./results.xml
+        run: npm run test:node --ws -- --color
         env:
           TEST_DWN_URL: http://localhost:3000
 

--- a/packages/agent/.mocharc.json
+++ b/packages/agent/.mocharc.json
@@ -1,6 +1,5 @@
 {
   "enable-source-maps": true,
   "exit": true,
-  "spec": ["tests/compiled/**/*.spec.js"],
-  "timeout": 5000
+  "spec": ["tests/compiled/**/*.spec.js"]
 }

--- a/packages/agent/.mocharc.json
+++ b/packages/agent/.mocharc.json
@@ -1,5 +1,6 @@
 {
   "enable-source-maps": true,
   "exit": true,
-  "spec": ["tests/compiled/**/*.spec.js"]
+  "spec": ["tests/compiled/**/*.spec.js"],
+  "timeout": 5000
 }

--- a/packages/agent/tests/sync-manager.spec.ts
+++ b/packages/agent/tests/sync-manager.spec.ts
@@ -292,7 +292,7 @@ describe('SyncManagerLevel', () => {
         expect(reply.status.code).to.equal(200);
         expect(reply.record).to.not.be.undefined;
         expect(reply.record!.data).to.not.be.undefined; // record data exists
-      });
+      }).timeout(5000);
 
       it('synchronizes records for multiple identities from remote DWN to local DWN', async () => {
         // Create a second Identity to author the DWN messages.
@@ -488,7 +488,7 @@ describe('SyncManagerLevel', () => {
         expect(reply.status.code).to.equal(200);
         expect(reply.record).to.not.be.undefined;
         expect(reply.record!.data).to.not.be.undefined;
-      });
+      }).timeout(5000);
 
       it('synchronizes records for multiple identities from local DWN to remote DWN', async () => {
         // Create a second Identity to author the DWN messages.


### PR DESCRIPTION
- I noticed the `node:test` action failed on main from #436 where there was a bump to Node v20. 

- Also noticed that a couple of the CI steps were still using node v18, so I have updated those to also use the same setup as what was introduced in #436. 

- I also bumped the actions versions to newer ones

- There is a perceptible regression in node performance between node v18 and node v20 which caused the  `SyncManagerLevel` test timeout to be exceeded. By bumping the timeout of the `agent` test suite I was able to account for the larger test time. 

- I was able to parallelize `test-with-node` which reduced that CI step's runtime by about 8%

- The mocha junit reporter is obscuring test results on CI so failures are unknown at the moment. I think this is an outstanding problem, and the junit reporter is doing more harm than good. 