### PR TITLE
publish snapshot releases on every merge to main

### DIFF
--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -1,0 +1,100 @@
+name: release snapshot to jfrog
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+# Allow only one concurrent deployment, but do NOT cancel in-progress runs as
+# we want to allow these release deployments to complete.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish-npm:
+    name: Snapshot Publish
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        package:
+          [
+            "agent",
+            "api",
+            "common",
+            "credentials",
+            "crypto",
+            "crypto-aws-kms",
+            "dids",
+            "identity-agent",
+            "proxy-agent",
+            "user-agent",
+          ]
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
+        with:
+          fetch-depth: 0
+
+      # https://cashapp.github.io/hermit/usage/ci/
+      - name: Init Hermit
+        uses: cashapp/activate-hermit@v1
+        with:
+          cache: "true"
+
+      - uses: jfrog/setup-jfrog-cli@v4
+        with:
+          version: latest
+          oidc-provider-name: github # must match the OpenID Connect name from https://blockxyz.jfrog.io/ui/admin/configuration/integrations
+        env:
+          JF_URL: https://blockxyz.jfrog.io
+
+      - name: Publish @web5/${{ matrix.package }} snapshot
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.npm_token}}
+        run: |
+          set -exuo pipefail
+
+          package_name="${{ matrix.package }}"
+          cd "packages/${package_name}"
+
+          base_version=$(jq -r .version package.json)
+
+          # I'm not seeing a great way to determine the commit of the last release of a given package, so I'm using a not-so-great way
+          version_line=$(grep -n "\"version\": \"${base_version}\"" package.json | cut -d: -f1) # determine which line in package.json specifies the version
+          version_bump_commit=$(git blame --porcelain -L "${version_line},${version_line}" -- package.json | head -n1 | awk '{ print $1 }') # ask git when the last commit to that line was
+          commits_since_version_bump=$(git rev-list HEAD ${version_bump_commit} --count -- .) # count the number of commits that changed this package since the version change commit
+
+
+          snapshot_version="${base_version}-SNAPSHOT.${commits_since_version_bump}"
+
+          # check if that snapshot version has already been published
+          if curl -f --silent "https://blockxyz.jfrog.io/artifactory/tbd-oss-snapshots-npm/@web5/${package_name}/-/${package_name}-${snapshot_version}.tgz" > /dev/null; then
+              echo "release for @web5/${package_name}-${snapshot_version} already exists, not re-publishing"
+              exit 0
+          fi
+
+          pushd ../..
+          pnpm install
+          pnpm build
+          popd
+
+          # set the snapshot version
+          jq --arg version "${snapshot_version}" '.version = $version' package.json > package-new.json
+          mv package-new.json package.json
+
+          # set publishing config in package.json
+          jq '.publishConfig.registry = "https://blockxyz.jfrog.io/artifactory/api/npm/tbd-oss-snapshots-npm/"' package.json > package-new.json
+          mv package-new.json package.json
+
+          # login to jfrog and publish
+          jf npm-config --global=true --repo-resolve=tbd-oss-snapshots-npm --repo-deploy=tbd-oss-snapshots-npm
+          jf npm publish --registry https://blockxyz.jfrog.io/artifactory/api/npm/tbd-oss-snapshots-npm/
+        shell: bash

--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -45,11 +45,11 @@ jobs:
 
       # https://cashapp.github.io/hermit/usage/ci/
       - name: Init Hermit
-        uses: cashapp/activate-hermit@v1
+        uses: cashapp/activate-hermit@31ce88b17a84941bb1b782f1b7b317856addf286 #v1.1.0
         with:
           cache: "true"
 
-      - uses: jfrog/setup-jfrog-cli@v4
+      - uses: jfrog/setup-jfrog-cli@d82fe26823e1f25529250895d5673f65b02af085 #v4.0.1
         with:
           version: latest
           oidc-provider-name: github # must match the OpenID Connect name from https://blockxyz.jfrog.io/ui/admin/configuration/integrations

--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -59,6 +59,7 @@ jobs:
       - name: Publish @web5/${{ matrix.package }} snapshot
         env:
           NODE_AUTH_TOKEN: ${{secrets.npm_token}}
+          REGISTRY: https://blockxyz.jfrog.io/artifactory/api/npm/tbd-oss-snapshots-npm/
         run: |
           set -exuo pipefail
 
@@ -71,13 +72,13 @@ jobs:
           version_line=$(grep -n "\"version\": \"${base_version}\"" package.json | cut -d: -f1) # determine which line in package.json specifies the version
           version_bump_commit=$(git blame --porcelain -L "${version_line},${version_line}" -- package.json | head -n1 | awk '{ print $1 }') # ask git when the last commit to that line was
           commits_since_version_bump=$(git rev-list HEAD ${version_bump_commit} --count -- .) # count the number of commits that changed this package since the version change commit
-          last_commit_to_package=$(git log -1 --pretty=format:%H -- .)
+          last_commit_to_package="$(git log -1 --pretty=format:%H -- .)"
 
 
           snapshot_version="${base_version}-SNAPSHOT.${commits_since_version_bump}-${last_commit_to_package:0:7}"
 
           # check if that snapshot version has already been published
-          if curl -f --silent "https://blockxyz.jfrog.io/artifactory/tbd-oss-snapshots-npm/@web5/${package_name}/-/${package_name}-${snapshot_version}.tgz" > /dev/null; then
+          if npm view --registry "${REGISTRY}" "@web5/${package_name}@${snapshot_version}" > /dev/null; then
               echo "release for @web5/${package_name}-${snapshot_version} already exists, not re-publishing"
               exit 0
           fi
@@ -92,10 +93,10 @@ jobs:
           mv package-new.json package.json
 
           # set publishing config in package.json
-          jq '.publishConfig.registry = "https://blockxyz.jfrog.io/artifactory/api/npm/tbd-oss-snapshots-npm/"' package.json > package-new.json
+          jq --arg registry "${REGISTRY}" '.publishConfig.registry = $registry' package.json > package-new.json
           mv package-new.json package.json
 
           # login to jfrog and publish
           jf npm-config --global=true --repo-resolve=tbd-oss-snapshots-npm --repo-deploy=tbd-oss-snapshots-npm
-          jf npm publish --registry https://blockxyz.jfrog.io/artifactory/api/npm/tbd-oss-snapshots-npm/
+          jf npm publish --registry "${REGISTRY}"
         shell: bash

--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -74,7 +74,6 @@ jobs:
           commits_since_version_bump=$(git rev-list HEAD ${version_bump_commit} --count -- .) # count the number of commits that changed this package since the version change commit
           last_commit_to_package="$(git log -1 --pretty=format:%H -- .)"
 
-
           snapshot_version="${base_version}-SNAPSHOT.${commits_since_version_bump}-${last_commit_to_package:0:7}"
 
           # check if that snapshot version has already been published

--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -71,9 +71,10 @@ jobs:
           version_line=$(grep -n "\"version\": \"${base_version}\"" package.json | cut -d: -f1) # determine which line in package.json specifies the version
           version_bump_commit=$(git blame --porcelain -L "${version_line},${version_line}" -- package.json | head -n1 | awk '{ print $1 }') # ask git when the last commit to that line was
           commits_since_version_bump=$(git rev-list HEAD ${version_bump_commit} --count -- .) # count the number of commits that changed this package since the version change commit
+          last_commit_to_package=$(git log -1 --pretty=format:%H -- .)
 
 
-          snapshot_version="${base_version}-SNAPSHOT.${commits_since_version_bump}"
+          snapshot_version="${base_version}-SNAPSHOT.${commits_since_version_bump}-${last_commit_to_package:0:7}"
 
           # check if that snapshot version has already been published
           if curl -f --silent "https://blockxyz.jfrog.io/artifactory/tbd-oss-snapshots-npm/@web5/${package_name}/-/${package_name}-${snapshot_version}.tgz" > /dev/null; then


### PR DESCRIPTION
This is part of a project being undertaken by OSP to help new code make it's way to TBD's downstream projects faster. It creates a snapshot release for each merge to main, which is published to our Artifactory* registry. Once this is done, downstream projects (ie. tbdex-js and developer.tbd.website) can pull in new web5-js features before a real release has been produced by depending on the snapshot version.

It creates snapshot release for any packages that have changed since the last snapshot version. It does this by counting the number of commits in each package since the last time the `package.json` version was changed, and producing a snapshot release name in the format `<version>-SNAPSHOT.<commit count>` (for example, there have been 55 commits that touched `packages/api` since it was bumped to `0.8.4`, so it will produce snapshot version `0.8.4-SNAPSHOT.55`). EDIT: this format has changed slightly to include the sha of the last commit as well, see thread. It checks if a snapshot with this version has already been published, and if not it builds and publishes the snapshot release.

Once that has been published, someone writing documentation for developer.tbd.website can set the example to depend on `@web5/api` version `0.8.4-SNAPSHOT.55` and write sample code that can be validated against that snapshot.

*Artifactory: behaves like npmjs.com, but isn't real npmjs.com so the high number of releases this creates will not spam up our npmjs.com page.