### PR TITLE
Update alpha-npm.yml to fix publish

### DIFF
--- a/.github/workflows/alpha-npm.yml
+++ b/.github/workflows/alpha-npm.yml
@@ -62,7 +62,7 @@ jobs:
         run: |
           for package in $PACKAGES; do
             cd packages/$package
-            pnpm publish --tag alpha --no-git-tag-version --access public --provenance
+            pnpm publish --tag alpha --access public --provenance
             cd ../..
           done
         shell: bash


### PR DESCRIPTION
successful runs with npm:
![image](https://github.com/TBD54566975/web5-js/assets/5314059/ee426a47-b6d4-4c39-82ea-7b4dfc9da710)

unsuccessful run with pnpm:
![image](https://github.com/TBD54566975/web5-js/assets/5314059/dd0af831-5724-4037-8acd-dc92b94dec17)

there is no option `--no-git-tag-version` in the documentation https://pnpm.io/cli/publish#--tag-tag

I removed it, but please check if this is how we want alpha releases handled, or if we ant to create a custom tag (of if there is an option for removing the tag that I'm not aware of)