### PR TITLE
Fix VSCode workspace paths after switch to pnpm

### DIFF
--- a/packages/agent/.vscode/launch.json
+++ b/packages/agent/.vscode/launch.json
@@ -8,7 +8,7 @@
       "type": "node",
       "request": "launch",
       "name": "test:node",
-      "runtimeExecutable": "${workspaceFolder:root}/node_modules/.bin/mocha",
+      "runtimeExecutable": "${workspaceFolder:agent}/node_modules/.bin/mocha",
       "console": "internalConsole",
       "preLaunchTask": "build tests",
       "skipFiles": [

--- a/packages/api/.vscode/launch.json
+++ b/packages/api/.vscode/launch.json
@@ -15,7 +15,7 @@
       "type": "node",
       "request": "launch",
       "name": "test:node",
-      "runtimeExecutable": "${workspaceFolder:root}/node_modules/.bin/mocha",
+      "runtimeExecutable": "${workspaceFolder:api}/node_modules/.bin/mocha",
       "console": "internalConsole",
       "preLaunchTask": "build tests",
       "skipFiles": [

--- a/packages/common/.vscode/launch.json
+++ b/packages/common/.vscode/launch.json
@@ -8,7 +8,7 @@
       "type": "node",
       "request": "launch",
       "name": "test:node",
-      "runtimeExecutable": "${workspaceFolder:root}/node_modules/.bin/mocha",
+      "runtimeExecutable": "${workspaceFolder:common}/node_modules/.bin/mocha",
       "console": "internalConsole",
       "preLaunchTask": "build tests",
       "skipFiles": [

--- a/packages/credentials/.vscode/launch.json
+++ b/packages/credentials/.vscode/launch.json
@@ -8,7 +8,7 @@
       "type": "node",
       "request": "launch",
       "name": "test:node",
-      "runtimeExecutable": "${workspaceFolder:root}/node_modules/.bin/mocha",
+      "runtimeExecutable": "${workspaceFolder:credentials}/node_modules/.bin/mocha",
       "console": "internalConsole",
       "preLaunchTask": "build tests",
       "skipFiles": [

--- a/packages/crypto-aws-kms/.vscode/launch.json
+++ b/packages/crypto-aws-kms/.vscode/launch.json
@@ -8,7 +8,7 @@
       "type": "node",
       "request": "launch",
       "name": "test:node",
-      "runtimeExecutable": "${workspaceFolder:root}/node_modules/.bin/mocha",
+      "runtimeExecutable": "${workspaceFolder:crypto-aws-kms}/node_modules/.bin/mocha",
       "console": "internalConsole",
       "preLaunchTask": "build tests",
       "skipFiles": [

--- a/packages/crypto/.vscode/launch.json
+++ b/packages/crypto/.vscode/launch.json
@@ -8,7 +8,7 @@
       "type": "node",
       "request": "launch",
       "name": "test:node",
-      "runtimeExecutable": "${workspaceFolder:root}/node_modules/.bin/mocha",
+      "runtimeExecutable": "${workspaceFolder:crypto}/node_modules/.bin/mocha",
       "console": "internalConsole",
       "preLaunchTask": "build tests",
       "skipFiles": [

--- a/packages/dids/.vscode/launch.json
+++ b/packages/dids/.vscode/launch.json
@@ -8,7 +8,7 @@
       "type": "node",
       "request": "launch",
       "name": "test:node",
-      "runtimeExecutable": "${workspaceFolder:root}/node_modules/.bin/mocha",
+      "runtimeExecutable": "${workspaceFolder:dids}/node_modules/.bin/mocha",
       "console": "internalConsole",
       "preLaunchTask": "build tests",
       "skipFiles": [

--- a/packages/identity-agent/.vscode/launch.json
+++ b/packages/identity-agent/.vscode/launch.json
@@ -8,7 +8,7 @@
       "type": "node",
       "request": "launch",
       "name": "test:node",
-      "runtimeExecutable": "${workspaceFolder:root}/node_modules/.bin/mocha",
+      "runtimeExecutable": "${workspaceFolder:identity-agent}/node_modules/.bin/mocha",
       "console": "internalConsole",
       "preLaunchTask": "build tests",
       "skipFiles": [

--- a/packages/proxy-agent/.vscode/launch.json
+++ b/packages/proxy-agent/.vscode/launch.json
@@ -8,7 +8,7 @@
       "type": "node",
       "request": "launch",
       "name": "test:node",
-      "runtimeExecutable": "${workspaceFolder:root}/node_modules/.bin/mocha",
+      "runtimeExecutable": "${workspaceFolder:proxy-agent}/node_modules/.bin/mocha",
       "console": "internalConsole",
       "preLaunchTask": "build tests",
       "skipFiles": [

--- a/packages/user-agent/.vscode/launch.json
+++ b/packages/user-agent/.vscode/launch.json
@@ -8,7 +8,7 @@
       "type": "node",
       "request": "launch",
       "name": "test:node",
-      "runtimeExecutable": "${workspaceFolder:root}/node_modules/.bin/mocha",
+      "runtimeExecutable": "${workspaceFolder:user-agent}/node_modules/.bin/mocha",
       "console": "internalConsole",
       "preLaunchTask": "build tests",
       "skipFiles": [


### PR DESCRIPTION
## Summary

This PR will:
- Switch from `root` to package-specific workspace paths for the Mocha binary which restores ability to use VSCode debugging.

## Context

When the Web5 JS monorepo was migrated from `npm` to `pnpm` one of the consequences is that root `node_modules` directory no longer contains the kitchen sink of every dependency used by every package in the monorepo.  As a result, the path reference in each package's `launch.json` for the Mocha binary is no longer valid.