### PR TITLE
Fix NPM Token Auth Issue

### DIFF
--- a/.github/workflows/alpha-npm.yml
+++ b/.github/workflows/alpha-npm.yml
@@ -33,6 +33,10 @@ jobs:
         with:
           cache: "true"
 
+      - name: Store NPM Registry Settings to .npmrc
+        run: |
+          echo -e "//registry.npmjs.org/:_authToken=\${NODE_AUTH_TOKEN}" > ~/.npmrc
+
       # Note - this is not required but it gives a clean failure prior to attempting a release if
       # the GH workflow runner is not authenticated with NPMjs.com
       - name: Verify NPM token is authenticated with NPMjs.com

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -46,6 +46,10 @@ jobs:
         with:
           cache: "true"
 
+      - name: Store NPM Registry Settings to .npmrc
+        run: |
+          echo -e "//registry.npmjs.org/:_authToken=\${NODE_AUTH_TOKEN}" > ~/.npmrc
+
       - name: Install semver utility
         run: pnpm install -g semver@7.5.1
 

--- a/.gitignore
+++ b/.gitignore
@@ -165,3 +165,6 @@ results.xml
 
 .tbdocs
 temp
+
+# Hermit build output
+.hermit


### PR DESCRIPTION
Similar to https://github.com/TBD54566975/tbdex-js/pull/200

With the introduction of Hermit we erased the magic setup done by the `setup-node` action. Here we are just reintroducing the relevant part for the registry auth setting.