### PR TITLE
Update `dids` package CJS bundling

### DIFF
--- a/packages/dids/build/cjs-bundle.js
+++ b/packages/dids/build/cjs-bundle.js
@@ -4,11 +4,11 @@ import packageJson from '../package.json' assert { type: 'json' };
 // list of dependencies that _dont_ ship cjs
 const includeList = new Set([
   '@decentralized-identity/ion-sdk',
-  'pkarr'
+  'bencode'
 ]);
 
 // create list of dependencies that we _do not_ want to include in our bundle
-const excludeList = ['sodium-universal'];
+const excludeList = [];
 for (const dependency in packageJson.dependencies) {
   if (includeList.has(dependency)) {
     continue;


### PR DESCRIPTION
## Summary

This PR will make the following changes to the `@web5/dids` package:
- Discontinue CJS bundling of the `pkarr` package.  It is no longer a dependency of `@web5/dids`.
- Remove bundling exclusion for `sodium-universal`.  It is no longer a dependency of `@web5/dids`.
- Begin CJS bundling of the `bencode` package. It is needed for DID DHT and does not ship a CJS distribution.