### PR TITLE
Bump DID package version and consume with creds

### DIFF
--- a/packages/credentials/package.json
+++ b/packages/credentials/package.json
@@ -77,7 +77,7 @@
     "@sphereon/pex": "2.1.0",
     "@web5/common": "0.2.3",
     "@web5/crypto": "0.4.0",
-    "@web5/dids": "0.4.0"
+    "@web5/dids": "0.4.2"
   },
   "devDependencies": {
     "@playwright/test": "1.40.1",

--- a/packages/credentials/src/jwt.ts
+++ b/packages/credentials/src/jwt.ts
@@ -8,7 +8,7 @@ import type {
 
 import { Convert } from '@web5/common';
 import { LocalKeyManager as CryptoApi  } from '@web5/crypto';
-import { DidDht, DidIon, DidKey, DidJwk, DidWeb, DidResolver, utils as didUtils } from '@web5/dids';
+import { DidDht, DidIon, DidKey, DidJwk, DidWeb, UniversalResolver, utils as didUtils } from '@web5/dids';
 
 const crypto = new CryptoApi();
 
@@ -67,7 +67,7 @@ export class Jwt {
   /**
    * DID Resolver instance for resolving decentralized identifiers.
    */
-  static didResolver: DidResolver = new DidResolver({ didResolvers: [DidDht, DidIon, DidKey, DidJwk, DidWeb] });
+  static didResolver: UniversalResolver = new UniversalResolver({ didResolvers: [DidDht, DidIon, DidKey, DidJwk, DidWeb] });
 
   /**
    * Creates a signed JWT.

--- a/packages/dids/package.json
+++ b/packages/dids/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web5/dids",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "TBD DIDs library",
   "type": "module",
   "main": "./dist/cjs/index.js",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -348,8 +348,8 @@ importers:
         specifier: 0.4.0
         version: link:../crypto
       '@web5/dids':
-        specifier: 0.4.0
-        version: 0.4.0
+        specifier: 0.4.2
+        version: link:../dids
     devDependencies:
       '@playwright/test':
         specifier: 1.40.1
@@ -3261,16 +3261,6 @@ packages:
       '@web5/common': 0.2.1
     dev: false
 
-  /@web5/crypto@0.4.0:
-    resolution: {integrity: sha512-GIKn2CizQKeATvHQqmC4ky26b3q2pJOd2GjIYsOSw/3Y3QIEm3holDGqu9FHs6kacmr6u0Pv5ELvccs58+cKEg==}
-    engines: {node: '>=18.0.0'}
-    dependencies:
-      '@noble/ciphers': 0.4.1
-      '@noble/curves': 1.3.0
-      '@noble/hashes': 1.3.3
-      '@web5/common': 0.2.3
-    dev: false
-
   /@web5/dids@0.2.4:
     resolution: {integrity: sha512-e+m+xgpiM8ydTJgWcPdwmjILLMZYdl2kwahlO22mK0azSKVrg1klpGrUODzqkrWrQ5O0tnOyqEy39FcD5Sy11w==}
     engines: {node: '>=18.0.0'}
@@ -3288,19 +3278,6 @@ packages:
     transitivePeerDependencies:
       - encoding
       - supports-color
-    dev: false
-
-  /@web5/dids@0.4.0:
-    resolution: {integrity: sha512-e+QcrKWlWPJVBbpz4QKrdcgPoj+uC8YUXt4tGKj1mC4kV0rCtIioMLw9Djg+54pp3VXl3eGKxju98UEddyZwqA==}
-    engines: {node: '>=18.0.0'}
-    dependencies:
-      '@decentralized-identity/ion-sdk': 1.0.1
-      '@dnsquery/dns-packet': 6.1.1
-      '@web5/common': 0.2.3
-      '@web5/crypto': 0.4.0
-      bencode: 4.0.0
-      level: 8.0.0
-      ms: 2.1.3
     dev: false
 
   /@web5/dwn-server@0.1.9:


### PR DESCRIPTION
This bumps the did version and updates the creds package to consume it and use the `UniversalResolver` class

This bumps the dids package version to:
* 0.4.2

This also updates the credentials package to use the `0.4.2` dids package and consume the `UniversalResolver` class