### PR TITLE
revert node engines package json change

### DIFF
--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -65,7 +65,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=20.9.0"
+    "node": ">=18.0.0"
   },
   "dependencies": {
     "@noble/hashes": "1.3.3",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -73,7 +73,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=20.9.0"
+    "node": ">=18.0.0"
   },
   "dependencies": {
     "@tbd54566975/dwn-sdk-js": "0.2.10",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -65,7 +65,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=20.9.0"
+    "node": ">=18.0.0"
   },
   "dependencies": {
     "@isaacs/ttlcache": "1.4.1",

--- a/packages/credentials/package.json
+++ b/packages/credentials/package.json
@@ -71,7 +71,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=20.9.0"
+    "node": ">=18.0.0"
   },
   "dependencies": {
     "@sphereon/pex": "2.1.0",

--- a/packages/crypto-aws-kms/package.json
+++ b/packages/crypto-aws-kms/package.json
@@ -66,7 +66,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=20.9.0"
+    "node": ">=18.0.0"
   },
   "dependencies": {
     "@aws-sdk/client-kms": "3.478.0",

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -71,7 +71,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=20.9.0"
+    "node": ">=18.0.0"
   },
   "dependencies": {
     "@noble/ciphers": "0.4.1",

--- a/packages/dids/package.json
+++ b/packages/dids/package.json
@@ -72,7 +72,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=20.9.0"
+    "node": ">=18.0.0"
   },
   "dependencies": {
     "@decentralized-identity/ion-sdk": "1.0.1",

--- a/packages/identity-agent/package.json
+++ b/packages/identity-agent/package.json
@@ -65,7 +65,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=20.9.0"
+    "node": ">=18.0.0"
   },
   "dependencies": {
     "@web5/agent": "0.2.6",

--- a/packages/proxy-agent/package.json
+++ b/packages/proxy-agent/package.json
@@ -65,7 +65,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=20.9.0"
+    "node": ">=18.0.0"
   },
   "dependencies": {
     "@web5/agent": "0.2.6",

--- a/packages/user-agent/package.json
+++ b/packages/user-agent/package.json
@@ -65,7 +65,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=20.9.0"
+    "node": ">=18.0.0"
   },
   "dependencies": {
     "@web5/agent": "0.2.6",


### PR DESCRIPTION
engines in package json is treated as minimum supported version. not accurate to have it set to `"node": ">=20.9.0"` which is not the minimum supported node version. I believe 18.0.0 or later is still reasonable.