### PR TITLE
bump versions of various packages and dependencies for alignment

### DIFF
--- a/packages/credentials/package.json
+++ b/packages/credentials/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web5/credentials",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Verifiable Credentials",
   "type": "module",
   "main": "./dist/cjs/index.js",

--- a/packages/credentials/package.json
+++ b/packages/credentials/package.json
@@ -75,9 +75,9 @@
   },
   "dependencies": {
     "@sphereon/pex": "2.1.0",
-    "@web5/common": "0.2.3",
-    "@web5/crypto": "0.4.0",
-    "@web5/dids": "0.4.2"
+    "@web5/common": "0.2.4",
+    "@web5/crypto": "0.4.1",
+    "@web5/dids": "0.4.3"
   },
   "devDependencies": {
     "@playwright/test": "1.40.1",

--- a/packages/crypto-aws-kms/package.json
+++ b/packages/crypto-aws-kms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web5/crypto-aws-kms",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Web5 cryptographic library using AWS KMS",
   "type": "module",
   "main": "./dist/cjs/index.js",
@@ -70,7 +70,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-kms": "3.478.0",
-    "@web5/crypto": "0.4.0"
+    "@web5/crypto": "0.4.1"
   },
   "devDependencies": {
     "@playwright/test": "1.40.1",
@@ -84,7 +84,7 @@
     "@typescript-eslint/parser": "6.4.0",
     "@web/test-runner": "0.18.0",
     "@web/test-runner-playwright": "0.11.0",
-    "@web5/common": "0.2.3",
+    "@web5/common": "0.2.4",
     "c8": "9.0.0",
     "chai": "4.3.10",
     "chai-as-promised": "7.1.1",

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web5/crypto",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Web5 cryptographic library",
   "type": "module",
   "main": "./dist/cjs/index.js",
@@ -77,7 +77,7 @@
     "@noble/ciphers": "0.4.1",
     "@noble/curves": "1.3.0",
     "@noble/hashes": "1.3.3",
-    "@web5/common": "0.2.3"
+    "@web5/common": "0.2.4"
   },
   "devDependencies": {
     "@playwright/test": "1.40.1",

--- a/packages/dids/package.json
+++ b/packages/dids/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web5/dids",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "TBD DIDs library",
   "type": "module",
   "main": "./dist/cjs/index.js",
@@ -77,8 +77,8 @@
   "dependencies": {
     "@decentralized-identity/ion-sdk": "1.0.1",
     "@dnsquery/dns-packet": "6.1.1",
-    "@web5/common": "0.2.3",
-    "@web5/crypto": "0.4.0",
+    "@web5/common": "0.2.4",
+    "@web5/crypto": "0.4.1",
     "abstract-level": "1.0.4",
     "bencode": "4.0.0",
     "buffer": "6.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -342,13 +342,13 @@ importers:
         specifier: 2.1.0
         version: 2.1.0
       '@web5/common':
-        specifier: 0.2.3
-        version: 0.2.3
+        specifier: 0.2.4
+        version: link:../common
       '@web5/crypto':
-        specifier: 0.4.0
+        specifier: 0.4.1
         version: link:../crypto
       '@web5/dids':
-        specifier: 0.4.2
+        specifier: 0.4.3
         version: link:../dids
     devDependencies:
       '@playwright/test':
@@ -433,8 +433,8 @@ importers:
         specifier: 1.3.3
         version: 1.3.3
       '@web5/common':
-        specifier: 0.2.3
-        version: 0.2.3
+        specifier: 0.2.4
+        version: link:../common
     devDependencies:
       '@playwright/test':
         specifier: 1.40.1
@@ -515,7 +515,7 @@ importers:
         specifier: 3.478.0
         version: 3.478.0
       '@web5/crypto':
-        specifier: 0.4.0
+        specifier: 0.4.1
         version: link:../crypto
     devDependencies:
       '@playwright/test':
@@ -552,8 +552,8 @@ importers:
         specifier: 0.11.0
         version: 0.11.0
       '@web5/common':
-        specifier: 0.2.3
-        version: 0.2.3
+        specifier: 0.2.4
+        version: link:../common
       c8:
         specifier: 9.0.0
         version: 9.0.0
@@ -600,10 +600,10 @@ importers:
         specifier: 6.1.1
         version: 6.1.1
       '@web5/common':
-        specifier: 0.2.3
-        version: 0.2.3
+        specifier: 0.2.4
+        version: link:../common
       '@web5/crypto':
-        specifier: 0.4.0
+        specifier: 0.4.1
         version: link:../crypto
       abstract-level:
         specifier: 1.0.4
@@ -3250,6 +3250,7 @@ packages:
       level: 8.0.0
       multiformats: 11.0.2
       readable-stream: 4.4.2
+    dev: false
 
   /@web5/crypto@0.2.2:
     resolution: {integrity: sha512-vHFg0wXQSQXrwuBNQyDHnmSZchfTfO6/Sv+7rDsNkvofs+6lGTE8CZ02cwUYMeIwTRMLer12c+fMfzYrXokEUQ==}


### PR DESCRIPTION
`@web5/crypto`:
- bump the `@web5/common` dep to `0.2.4`
- bump the package version to `0.4.1`

`@web5/dids`:
- Bump the `@web5/common` dep to `0.2.4`
- Bump the `@web5/crypto` dep to `0.4.1`
- Bump the package version to `0.4.3`

`@web5/credentials`:
- Bump the `@web5/common` dep to `0.2.4`
- Bump the `@web5/crypto` dep to `0.4.1`
- Bump the `@web5/dids` dep to `0.4.3`
- Bump the package version to `0.4.4`

`@web5/crypto-aws-kms`:
- Bump `@web5/crypto` to `0.4.1`
- Bump dev dep `@web5/common` to `0.2.4`
- Bump package version to `0.2.1`