### PR TITLE
Add evidence field to VerifiableCredential

### DIFF
--- a/packages/credentials/README.md
+++ b/packages/credentials/README.md
@@ -63,7 +63,7 @@ Create a new `VerifiableCredential` with the following parameters:
 - `issuer`: Issuer URI.
 - `subject`: Subject URI.
 - `data`: Credential data.
-- `issuanceData?` (Optional) The Issuance Date. Defaults to current date if not specified
+- `issuanceDate?` (Optional) The Issuance Date. Defaults to current date if not specified
 - `expirationDate?`: (Optional) Expiration Date
 - `evidence?`: (Optional) Evidence can be included by an issuer to provide the verifier with additional supporting information in a verifiable credential.
 

--- a/packages/credentials/README.md
+++ b/packages/credentials/README.md
@@ -64,7 +64,7 @@ Create a new `VerifiableCredential` with the following parameters:
 - `subject`: Subject URI.
 - `data`: Credential data.
 - `issuanceData?` (Optional) The Issuance Date. Defaults to current date if not specified
-- `expirationDate?`: (Optinal) Expiration Date
+- `expirationDate?`: (Optional) Expiration Date
 - `evidence?`: (Optional) Evidence can be included by an issuer to provide the verifier with additional supporting information in a verifiable credential.
 
 ```javascript

--- a/packages/credentials/README.md
+++ b/packages/credentials/README.md
@@ -63,7 +63,9 @@ Create a new `VerifiableCredential` with the following parameters:
 - `issuer`: Issuer URI.
 - `subject`: Subject URI.
 - `data`: Credential data.
-- `expirationDate?`: (optinal) Expiration Date
+- `issuanceData?` (Optional) The Issuance Date. Defaults to current date if not specified
+- `expirationDate?`: (Optinal) Expiration Date
+- `evidence?`: (Optional) Evidence can be included by an issuer to provide the verifier with additional supporting information in a verifiable credential.
 
 ```javascript
 class StreetCredibility {

--- a/packages/credentials/src/verifiable-credential.ts
+++ b/packages/credentials/src/verifiable-credential.ts
@@ -26,6 +26,7 @@ export type VcDataModel = ICredential;
  * @param issuanceDate Optional. The issuance date of the credential, as a string.
  *               Defaults to the current date if not specified.
  * @param expirationDate Optional. The expiration date of the credential, as a string.
+ * @param evidence Optional. Evidence can be included by an issuer to provide the verifier with additional supporting information in a verifiable credential.
  */
 export type VerifiableCredentialCreateOptions = {
   type?: string | string[];
@@ -34,6 +35,7 @@ export type VerifiableCredentialCreateOptions = {
   data: any;
   issuanceDate?: string;
   expirationDate?: string;
+  evidence?: any[];
 };
 
 /**
@@ -131,7 +133,7 @@ export class VerifiableCredential {
    * @returns A [VerifiableCredential] instance.
    */
   public static async create(options: VerifiableCredentialCreateOptions): Promise<VerifiableCredential> {
-    const { type, issuer, subject, data, issuanceDate, expirationDate } = options;
+    const { type, issuer, subject, data, issuanceDate, expirationDate, evidence } = options;
 
     const jsonData = JSON.parse(JSON.stringify(data));
 
@@ -159,9 +161,11 @@ export class VerifiableCredential {
         : (type ? [DEFAULT_VC_TYPE, type] : [DEFAULT_VC_TYPE]),
       id                : `urn:uuid:${cryptoUtils.randomUuid()}`,
       issuer            : issuer,
-      issuanceDate      : issuanceDate || getCurrentXmlSchema112Timestamp(), // use default if undefined
+      issuanceDate      : issuanceDate || getCurrentXmlSchema112Timestamp(),
       credentialSubject : credentialSubject,
-      ...(expirationDate && { expirationDate }), // optional property
+      // Include optional properties only if they have values
+      ...(expirationDate && { expirationDate }),
+      ...(evidence && { evidence }),
     };
 
     validatePayload(vcDataModel);


### PR DESCRIPTION
Resoles this issue - https://github.com/TBD54566975/web5-js/issues/379

Adds evidence to our vc data model

```
@param evidence Optional. Evidence can be included by an issuer to provide the verifier with additional supporting information in a verifiable credential.
```

<img width="878" alt="image" src="https://github.com/TBD54566975/web5-js/assets/5314059/d54342fe-0f31-416f-bb60-b30b7fd76415">
