### PR TITLE
bumping submodule commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   "scripts": {
     "clean": "pnpm npkill -d $(pwd)/packages -t dist && pnpm npkill -d $(pwd) -t node_modules",
     "build": "pnpm --recursive --stream build",
-    "dwn-server": "node node_modules/@web5/dwn-server/dist/esm/src/main.js || true"
+    "dwn-server": "node node_modules/@web5/dwn-server/dist/esm/src/main.js || true",
+    "test:node": "pnpm --recursive test:node"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
bumping submodule to https://github.com/TBD54566975/web5-spec/pull/130

also added a helper pnpm run script to run all tests at the top level

~once the above PR is merged, will point submodule of this repo to the merge commit~

submodule commit now pointing to https://github.com/TBD54566975/web5-spec/commit/1f0c51f52e27bde2947aadadd5d6e10238c8698e