### PR TITLE
Remove typedoc warnings in credentials package

### DIFF
--- a/packages/credentials/src/jwt.ts
+++ b/packages/credentials/src/jwt.ts
@@ -13,14 +13,28 @@ import { DidDht, DidIon, DidKey, DidJwk, DidWeb, UniversalResolver, utils as did
 const crypto = new CryptoApi();
 
 /**
- * Result of parsing a JWT.
+ * Represents the result of parsing a JWT (JSON Web Token).
  */
 export type JwtParseResult = {
+  /**
+   * The decoded part of the JWT, which includes the verified results.
+   * This contains the JWT's payload and other data that has been
+   * validated against the JWT's signature to ensure its integrity and authenticity.
+   */
   decoded: JwtVerifyResult
+
+  /**
+   * The encoded components of the JWT, including the header, payload,
+   * and signature, each as a separate string. These are the raw, encoded
+   * parts of the JWT as they were received or transmitted.
+   */
   encoded: {
-    header: string
-    payload: string
-    signature: string
+    /** The encoded header of the JWT. */
+    header: string,
+    /** The encoded payload of the JWT. */
+    payload: string,
+    /** The encoded signature of the JWT. */
+    signature: string,
   }
 }
 
@@ -40,6 +54,7 @@ export interface JwtVerifyResult {
  * used in {@link Jwt.parse}
  */
 export type ParseJwtOptions = {
+  /** The JWT string to parse. */
   jwt: string
 }
 
@@ -47,7 +62,9 @@ export type ParseJwtOptions = {
  * Parameters for signing a JWT.
  */
 export type SignJwtOptions = {
+  /** The DID of the signer. */
   signerDid: BearerDid
+  /** The payload to sign. */
   payload: JwtPayload
 }
 
@@ -55,6 +72,7 @@ export type SignJwtOptions = {
  * Parameters for verifying a JWT.
  */
 export type VerifyJwtOptions = {
+  /** The JWT string to verify. */
   jwt: string
 }
 

--- a/packages/credentials/src/presentation-exchange.ts
+++ b/packages/credentials/src/presentation-exchange.ts
@@ -9,23 +9,28 @@ import type {
 
 import { PEX } from '@sphereon/pex';
 
+/** The Presentation Definition V2 as defined in the PEX models. */
 export interface PresentationDefinitionV2 extends PexPresDefV2 { }
 
+/** The validated object as defined in the PEX models. */
 export type Validated = PexValidated;
 
+/**
+ * The Presentation Exchange (PEX) Library implements the functionality described in the DIF Presentation Exchange specification
+ */
 export class PresentationExchange {
-  /**
-   * The Presentation Exchange (PEX) Library implements the functionality described in the DIF Presentation Exchange specification
-   */
+  /** The Presentation Exchange (PEX) instance. */
   private static pex: PEX = new PEX();
 
   /**
    * Selects credentials that satisfy a given presentation definition.
    *
-   * @param {string[]} vcJwts The list of Verifiable Credentials to select from.
-   * @param {PresentationDefinitionV2} presentationDefinition The Presentation Definition to match against.
+   * @param params - The parameters for the credential selection.
+   * @param params.vcJwts  The list of Verifiable Credentials to select from.
+   * @param params.presentationDefinition The Presentation Definition to match against.
    * @returns {string[]} selectedVcJwts A list of Verifiable Credentials that satisfy the Presentation Definition.
    */
+
   public static selectCredentials({ vcJwts, presentationDefinition }: {
     vcJwts: string[],
     presentationDefinition: PresentationDefinitionV2
@@ -44,8 +49,9 @@ export class PresentationExchange {
   /**
    * Validates if a list of VC JWTs satisfies the given presentation definition.
    *
-   * @param vcJwts - An array of VC JWTs as strings.
-   * @param presentationDefinition - The criteria to validate against.
+   * @param params - The parameters for the satisfaction check.
+   * @param params.vcJwts - An array of VC JWTs as strings.
+   * @param params.presentationDefinition - The criteria to validate against.
    * @throws Error if the evaluation results in warnings or errors.
    */
   public static satisfiesPresentationDefinition({ vcJwts, presentationDefinition }: {
@@ -78,8 +84,9 @@ export class PresentationExchange {
    * evaluates the credentials against the definition, and finally constructs the presentation result if the
    * evaluation is successful.
    *
-   * @param {string[]} vcJwts The list of Verifiable Credentials (VCs) in JWT format to be evaluated.
-   * @param {PresentationDefinitionV2} presentationDefinition The Presentation Definition V2 to match the VCs against.
+   * @param params - The parameters for the presentation creation.
+   * @param params.vcJwts The list of Verifiable Credentials (VCs) in JWT format to be evaluated.
+   * @param params.presentationDefinition The Presentation Definition V2 to match the VCs against.
    * @returns {PresentationResult} The result of the presentation creation process, containing a presentation submission
    *                               that satisfies the presentation definition criteria.
    * @throws {Error} If the evaluation results in warnings or errors, or if the required credentials are not present,
@@ -158,6 +165,7 @@ export class PresentationExchange {
     return this.pex.evaluatePresentation(presentationDefinition, presentation);
   }
 
+  /** Resets the PEX instance. */
   private static resetPex() {
     this.pex = new PEX();
   }

--- a/packages/credentials/src/verifiable-credential.ts
+++ b/packages/credentials/src/verifiable-credential.ts
@@ -7,7 +7,9 @@ import { Jwt } from './jwt.js';
 import { SsiValidator } from './validators.js';
 import { getCurrentXmlSchema112Timestamp, getXmlSchema112Timestamp } from './utils.js';
 
+/** The default Verifiable Credential context. */
 export const DEFAULT_VC_CONTEXT = 'https://www.w3.org/2018/credentials/v1';
+/** The default Verifiable Credential type. */
 export const DEFAULT_VC_TYPE = 'VerifiableCredential';
 
 /**
@@ -29,12 +31,19 @@ export type VcDataModel = ICredential;
  * @param evidence Optional. Evidence can be included by an issuer to provide the verifier with additional supporting information in a verifiable credential.
  */
 export type VerifiableCredentialCreateOptions = {
+  /** The type of the credential, can be a string or an array of strings. */
   type?: string | string[];
+  /** The issuer URI of the credential, as a string. */
   issuer: string;
+  /** The subject URI of the credential, as a string. */
   subject: string;
+  /** The credential data, as a generic type any. */
   data: any;
+  /** The issuance date of the credential, as a string. */
   issuanceDate?: string;
+  /** The expiration date of the credential, as a string. */
   expirationDate?: string;
+  /** The evidence of the credential, as an array of any. */
   evidence?: any[];
 };
 
@@ -43,9 +52,11 @@ export type VerifiableCredentialCreateOptions = {
  * @param did - The issuer DID of the credential, represented as a PortableDid.
  */
 export type VerifiableCredentialSignOptions = {
+  /** The issuer DID of the credential, represented as a PortableDid. */
   did: BearerDid;
 };
 
+/** The credential subject of a verifiable credential. */
 type CredentialSubject = ICredentialSubject;
 
 /**
@@ -61,14 +72,17 @@ type CredentialSubject = ICredentialSubject;
 export class VerifiableCredential {
   constructor(public vcDataModel: VcDataModel) {}
 
+  /** The type of the credential. */
   get type(): string {
     return this.vcDataModel.type[this.vcDataModel.type.length - 1];
   }
 
+  /** The issuer of the credential. */
   get issuer(): string {
     return this.vcDataModel.issuer.toString();
   }
 
+  /** The subject of the credential. */
   get subject(): string {
     if (Array.isArray(this.vcDataModel.credentialSubject)) {
       return this.vcDataModel.credentialSubject[0].id!;
@@ -207,8 +221,8 @@ export class VerifiableCredential {
    *     console.log("VC Verification failed: ${e.message}")
    * }
    * ```
-   *
-   * @param vcJwt The Verifiable Credential in JWT format as a [string].
+   * @param param - The parameters for the verification process.
+   * @param param.vcJwt The Verifiable Credential in JWT format as a [string].
    * @throws Error if the verification fails at any step, providing a message with failure details.
    * @throws Error if critical JWT header elements are absent.
    */
@@ -278,8 +292,11 @@ export class VerifiableCredential {
     validatePayload(vcTyped);
 
     return {
+      /** The issuer of the VC. */
       issuer  : payload.iss!,
+      /** The subject of the VC. */
       subject : payload.sub!,
+      /** The VC data model object. */
       vc      : vcTyped
     };
   }

--- a/packages/credentials/src/verifiable-presentation.ts
+++ b/packages/credentials/src/verifiable-presentation.ts
@@ -8,6 +8,7 @@ import { SsiValidator } from './validators.js';
 
 import { VerifiableCredential, DEFAULT_VC_CONTEXT } from './verifiable-credential.js';
 
+/** The default type for a Verifiable Presentation. */
 export const DEFAULT_VP_TYPE = 'VerifiablePresentation';
 
 /**
@@ -25,9 +26,13 @@ export type VpDataModel = IPresentation;
  * @param additionalData Optional additional data to be included in the presentation.
  */
 export type VerifiablePresentationCreateOptions = {
+  /** The holder URI of the presentation, as a string. */
   holder: string,
+  /** The JWTs of the credentials to be included in the presentation. */
   vcJwts: string[],
+  /** The type of the presentation, can be a string or an array of strings. */
   type?: string | string[];
+  /** Optional additional data to be included in the presentation. */
   additionalData?: Record<string, any>
 };
 
@@ -36,6 +41,7 @@ export type VerifiablePresentationCreateOptions = {
  * @param did - The holder DID of the presentation, represented as a PortableDid.
  */
 export type VerifiablePresentationSignOptions = {
+  /** The holder DID of the presentation, represented as a PortableDid. */
   did: BearerDid;
 };
 
@@ -53,14 +59,17 @@ export type VerifiablePresentationSignOptions = {
 export class VerifiablePresentation {
   constructor(public vpDataModel: VpDataModel) {}
 
+  /** The type of the Verifiable Presentation. */
   get type(): string {
     return this.vpDataModel.type![this.vpDataModel.type!.length - 1];
   }
 
+  /** The holder of the Verifiable Presentation. */
   get holder(): string {
     return this.vpDataModel.holder!.toString();
   }
 
+  /** The verifiable credentials contained in the Verifiable Presentation. */
   get verifiableCredential(): string[] {
     return this.vpDataModel.verifiableCredential! as string[];
   }
@@ -194,9 +203,12 @@ export class VerifiablePresentation {
     }
 
     return {
+      /** The issuer of the VP */
       issuer  : payload.iss!,
+      /** The subject of the VP. */
       subject : payload.sub!,
-      vc      : payload['vp'] as VpDataModel
+      /** The VP data model object. */
+      vp      : payload['vp'] as VpDataModel
     };
   }
 


### PR DESCRIPTION
This adds comments to remove the warnings that were generated by 

`pnpx typedoc --validation --entryPoints src/index.ts`

in the credentials package