### PR TITLE
Bundle `ed25519-keygen` CJS with `@web5/agent`

### DIFF
--- a/packages/agent/build/cjs-bundle.js
+++ b/packages/agent/build/cjs-bundle.js
@@ -1,0 +1,26 @@
+import esbuild from 'esbuild';
+import packageJson from '../package.json' assert { type: 'json' };
+
+// list of dependencies that _dont_ ship cjs
+const includeList = new Set(['ed25519-keygen']);
+
+// create list of dependencies that we _do not_ want to include in our bundle
+const excludeList = [];
+for (const dependency in packageJson.dependencies) {
+  if (includeList.has(dependency)) {
+    continue;
+  } else {
+    excludeList.push(dependency);
+  }
+}
+
+esbuild.build({
+  entryPoints    : [ './src/index.ts' ],
+  bundle         : true,
+  external       : excludeList,
+  format         : 'cjs',
+  sourcemap      : true,
+  platform       : 'node',
+  outfile        : 'dist/cjs/index.js',
+  allowOverwrite : true
+});

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "clean": "rimraf dist coverage tests/compiled",
     "build:esm": "rimraf dist/esm dist/types && pnpm tsc -p tsconfig.json",
-    "build:cjs": "rimraf dist/cjs && pnpm tsc -p tsconfig.cjs.json && echo '{\"type\": \"commonjs\"}' > ./dist/cjs/package.json",
+    "build:cjs": "rimraf dist/cjs && node build/cjs-bundle.js && echo '{\"type\": \"commonjs\"}' > ./dist/cjs/package.json",
     "build:browser": "rimraf dist/browser.mjs dist/browser.js && node build/bundles.js",
     "build:tests:node": "rimraf tests/compiled && pnpm tsc -p tests/tsconfig.json",
     "build:tests:browser": "rimraf tests/compiled && node build/esbuild-tests.cjs",


### PR DESCRIPTION
## Summary

Since the version of `ed25519-keygen` used in `@web5/agent` does not publish `CommonJS` builds, we bundle it along with our own `CommonJS` build using `esbuild`.

Changes to `@web5/agent`:
- create a `cjs-bundle.js` file in the `build` directory.
- set `ed25519-keygen` explicitly to the include list for bundling.
- use `cjs-bundle.js` in the `build:cjs` script to build.

## Context

At the current time `web5-js` and `tbdex-js` both support downstream CJS-only projects in case there are teams that have older projects that only support CJS.  The test suite in [`bundler-bonanza`](https://github.com/TBD54566975/bundler-bonanza) includes a test to validate usage in Electron versions prior to v28 that don't yet support ESM.