### PR TITLE
Add tests subfolders to `esbuild`

### DIFF
--- a/packages/agent/build/esbuild-tests.cjs
+++ b/packages/agent/build/esbuild-tests.cjs
@@ -5,7 +5,7 @@ const browserConfig = require('./esbuild-browser-config.cjs');
 esbuild.build({
   ...browserConfig,
   format      : 'esm',
-  entryPoints : ['./tests/*.spec.*'],
+  entryPoints : ['./tests/**/*.spec.*'],
   bundle      : true,
   minify      : false,
   outdir      : 'tests/compiled',

--- a/packages/agent/tests/prototyping/crypto/algorithms/aes-kw.spec.ts
+++ b/packages/agent/tests/prototyping/crypto/algorithms/aes-kw.spec.ts
@@ -4,6 +4,7 @@ import { expect } from 'chai';
 import { Convert } from '@web5/common';
 
 import { AesKwAlgorithm } from '../../../../src/prototyping/crypto/algorithms/aes-kw.js';
+import { isChrome } from '../../../utils/runtimes.js';
 
 describe('AesKwAlgorithm', () => {
   let aesKw: AesKwAlgorithm;
@@ -58,11 +59,14 @@ describe('AesKwAlgorithm', () => {
       privateKeyBytes = Convert.base64Url(privateKey.k!).toUint8Array();
       expect(privateKeyBytes.byteLength).to.equal(16);
 
-      // 192 bits
-      privateKey = await aesKw.generateKey({ algorithm: 'A192KW' }) as Jwk;
-      expect(privateKey.alg).to.equal('A192KW');
-      privateKeyBytes = Convert.base64Url(privateKey.k!).toUint8Array();
-      expect(privateKeyBytes.byteLength).to.equal(24);
+      // Skip this test in Chrome browser because it does not support AES with 192-bit keys.
+      if (!isChrome) {
+        // 192 bits
+        privateKey = await aesKw.generateKey({ algorithm: 'A192KW' }) as Jwk;
+        expect(privateKey.alg).to.equal('A192KW');
+        privateKeyBytes = Convert.base64Url(privateKey.k!).toUint8Array();
+        expect(privateKeyBytes.byteLength).to.equal(24);
+      }
 
       // 256 bits
       privateKey = await aesKw.generateKey({ algorithm: 'A256KW' }) as Jwk;

--- a/packages/agent/tests/prototyping/crypto/primitives/aes-kw.spec.ts
+++ b/packages/agent/tests/prototyping/crypto/primitives/aes-kw.spec.ts
@@ -4,6 +4,7 @@ import { expect } from 'chai';
 import { Convert } from '@web5/common';
 
 import { AesKw } from '../../../../src/prototyping/crypto/primitives/aes-kw.js';
+import { isChrome } from '../../../utils/runtimes.js';
 
 describe('AesKw', () => {
   describe('bytesToPrivateKey()', () => {
@@ -52,11 +53,14 @@ describe('AesKw', () => {
       privateKeyBytes = Convert.base64Url(privateKey.k!).toUint8Array();
       expect(privateKeyBytes.byteLength).to.equal(16);
 
-      // 192 bits
-      privateKey = await AesKw.generateKey({ length: 192 }) as Jwk;
-      expect(privateKey.alg).to.equal('A192KW');
-      privateKeyBytes = Convert.base64Url(privateKey.k!).toUint8Array();
-      expect(privateKeyBytes.byteLength).to.equal(24);
+      // Skip this test in Chrome browser because it does not support AES with 192-bit keys.
+      if (!isChrome) {
+        // 192 bits
+        privateKey = await AesKw.generateKey({ length: 192 }) as Jwk;
+        expect(privateKey.alg).to.equal('A192KW');
+        privateKeyBytes = Convert.base64Url(privateKey.k!).toUint8Array();
+        expect(privateKeyBytes.byteLength).to.equal(24);
+      }
 
       // 256 bits
       privateKey = await AesKw.generateKey({ length: 256 }) as Jwk;


### PR DESCRIPTION
`esbuild` was not including the `prototyping` tests within the build.

- Replaced `./tests/*.spec.*` with `./tests/**/*.spec.*`
- Skipped over `AES-192` tests for `chrome` as it does not support 192 bit keys.