### PR TITLE
upgrade to latest dwn-sdk-js `v0.2.22`

### DIFF
--- a/.changeset/blue-papayas-leave.md
+++ b/.changeset/blue-papayas-leave.md
@@ -1,0 +1,6 @@
+---
+"@web5/agent": patch
+"@web5/api": patch
+---
+
+Upgrade `dwn-sdk-js` to the latest version consuming `1.0.0` of `@web5/dids`

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@changesets/cli": "^2.27.1",
     "@npmcli/package-json": "5.0.0",
     "@typescript-eslint/eslint-plugin": "6.4.0",
-    "@web5/dwn-server": "0.1.16",
+    "@web5/dwn-server": "0.1.17",
     "eslint-plugin-mocha": "10.1.0",
     "npkill": "0.11.3"
   },

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -71,7 +71,7 @@
   "dependencies": {
     "@noble/ciphers": "0.4.1",
     "@scure/bip39": "1.2.2",
-    "@tbd54566975/dwn-sdk-js": "0.2.21",
+    "@tbd54566975/dwn-sdk-js": "0.2.22",
     "@web5/common": "1.0.0",
     "@web5/crypto": "1.0.0",
     "@web5/dids": "1.0.0",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -85,7 +85,7 @@
   },
   "devDependencies": {
     "@playwright/test": "1.40.1",
-    "@tbd54566975/dwn-sdk-js": "0.2.21",
+    "@tbd54566975/dwn-sdk-js": "0.2.22",
     "@types/chai": "4.3.6",
     "@types/eslint": "8.44.2",
     "@types/mocha": "10.0.1",

--- a/packages/dev-env/docker-compose.yaml
+++ b/packages/dev-env/docker-compose.yaml
@@ -3,6 +3,6 @@ version: "3.98"
 services:
   dwn-server:
     container_name: dwn-server
-    image: ghcr.io/tbd54566975/dwn-server:dwn-sdk-0.2.21
+    image: ghcr.io/tbd54566975/dwn-server:dwn-sdk-0.2.22
     ports:
       - "3000:3000"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: 6.4.0
         version: 6.4.0(@typescript-eslint/parser@6.4.0)(eslint@8.47.0)(typescript@5.1.6)
       '@web5/dwn-server':
-        specifier: 0.1.16
-        version: 0.1.16
+        specifier: 0.1.17
+        version: 0.1.17
       eslint-plugin-mocha:
         specifier: 10.1.0
         version: 10.1.0(eslint@8.47.0)
@@ -42,8 +42,8 @@ importers:
         specifier: 1.2.2
         version: 1.2.2
       '@tbd54566975/dwn-sdk-js':
-        specifier: 0.2.21
-        version: 0.2.21
+        specifier: 0.2.22
+        version: 0.2.22
       '@web5/common':
         specifier: 1.0.0
         version: link:../common
@@ -167,8 +167,8 @@ importers:
         specifier: 1.40.1
         version: 1.40.1
       '@tbd54566975/dwn-sdk-js':
-        specifier: 0.2.21
-        version: 0.2.21
+        specifier: 0.2.22
+        version: 0.2.22
       '@types/chai':
         specifier: 4.3.6
         version: 4.3.6
@@ -2755,15 +2755,15 @@ packages:
       jwt-decode: 3.1.2
     dev: true
 
-  /@tbd54566975/dwn-sdk-js@0.2.21:
-    resolution: {integrity: sha512-rave+6mwn2/YBYu5LRwDWaOxvHV51DdMO6OFCLC3gJVOiAAYCmtPlebpdVCanBzqhWITh2qPcIZa7BefoxOPmQ==}
+  /@tbd54566975/dwn-sdk-js@0.2.22:
+    resolution: {integrity: sha512-TBobNAWt09bsAKADiiWNcdgiuuWNkHAumPvuYM9d+V/Brcl99Q9jg3ssVQhMfhV3TN8zxCbAGWYALUfxgX4N3w==}
     engines: {node: '>= 18'}
     dependencies:
       '@ipld/dag-cbor': 9.0.3
       '@js-temporal/polyfill': 0.4.4
       '@noble/ed25519': 2.0.0
       '@noble/secp256k1': 2.0.0
-      '@web5/dids': 0.4.3
+      '@web5/dids': 1.0.0
       abstract-level: 1.0.3
       ajv: 8.12.0
       blockstore-core: 4.2.0
@@ -2787,12 +2787,12 @@ packages:
       - encoding
       - supports-color
 
-  /@tbd54566975/dwn-sql-store@0.2.12:
-    resolution: {integrity: sha512-URcxrgRWTW7et5EH3+P5vK9qp2pmzwq9Yvrp8GRdWG8pwmBZ+poku2QSICE6E3liVYimaI1QDC/7/F2XJbRwhg==}
+  /@tbd54566975/dwn-sql-store@0.2.13:
+    resolution: {integrity: sha512-TYl16RwExcasH1UTNEQDwcGJbDA96hYQ4iVdpJc7xVfwGwtLzJWR1jSkCugP3BbLJ7lPPy0pywysZ1fW4b/bJg==}
     engines: {node: '>=18'}
     dependencies:
       '@ipld/dag-cbor': 9.2.0
-      '@tbd54566975/dwn-sdk-js': 0.2.21
+      '@tbd54566975/dwn-sdk-js': 0.2.22
       kysely: 0.26.3
       multiformats: 12.0.1
       readable-stream: 4.4.2
@@ -3430,36 +3430,46 @@ packages:
       level: 8.0.0
       multiformats: 11.0.2
       readable-stream: 4.4.2
+    dev: true
 
-  /@web5/crypto@0.4.1:
-    resolution: {integrity: sha512-23LxbdnpTnHBfspqin2L+qy0UKPgdx212SUg6K1pgj2oTvP7gyCKDOyN6yJ4HhexlT0AQxZ6TJ5reoTVn8Cu+g==}
+  /@web5/common@1.0.0:
+    resolution: {integrity: sha512-3JHF6X5o0h+3oAVQeBC4XpMoZeEYZYdEmQdgpOfKv/rnSru2yHQSAM+0wbIvEFcSCmelBT3u7rUAcpJjelLB0w==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@isaacs/ttlcache': 1.4.1
+      level: 8.0.0
+      multiformats: 11.0.2
+      readable-stream: 4.4.2
+
+  /@web5/crypto@1.0.0:
+    resolution: {integrity: sha512-z1CsgycTqiXEsS6pPlJDDLGAeGsgzfdBeWvyxLXTgh08Q8ACULmEGRXjSsgWHFn6DO6MpWFn55h/hF4wZZRxvA==}
     engines: {node: '>=18.0.0'}
     dependencies:
       '@noble/ciphers': 0.4.1
       '@noble/curves': 1.3.0
       '@noble/hashes': 1.3.3
-      '@web5/common': 0.2.4
+      '@web5/common': 1.0.0
 
-  /@web5/dids@0.4.3:
-    resolution: {integrity: sha512-VyTG8dY7iY3j8O055/wBFoGU5Xu1rwTF0RJpFazUE/6W3IuZEYAFTNl2mZ5KSuNRDT1f0VcwebuXW9PbzGuAaw==}
+  /@web5/dids@1.0.0:
+    resolution: {integrity: sha512-TJPRyNIuS50Za3qMHBgNDgwbJQUcVVWXm3Uc3UsDtZIpTLjYb+4LRaynlKzjRPAOR44Q185a+59//5Lyffon+Q==}
     engines: {node: '>=18.0.0'}
     dependencies:
       '@decentralized-identity/ion-sdk': 1.0.1
       '@dnsquery/dns-packet': 6.1.1
-      '@web5/common': 0.2.4
-      '@web5/crypto': 0.4.1
+      '@web5/common': 1.0.0
+      '@web5/crypto': 1.0.0
       abstract-level: 1.0.4
       bencode: 4.0.0
       buffer: 6.0.3
       level: 8.0.0
       ms: 2.1.3
 
-  /@web5/dwn-server@0.1.16:
-    resolution: {integrity: sha512-aenZC3lFs5nyq9XHLnn2HtZ1jYHFdDIpGypI5HwrSoCfqLBByB888GOXa6VmOH2o4sAEdXd3oQmrb/mbxCPQ3Q==}
+  /@web5/dwn-server@0.1.17:
+    resolution: {integrity: sha512-JkcZ4dQCZi6fCbEdyqqVqjDKE/AbaJj0auppgSnV5XxqjhKOtelvm+lLtppzyhcuPStlrem/9LkXR7yIgJ/JhQ==}
     hasBin: true
     dependencies:
-      '@tbd54566975/dwn-sdk-js': 0.2.21
-      '@tbd54566975/dwn-sql-store': 0.2.12
+      '@tbd54566975/dwn-sdk-js': 0.2.22
+      '@tbd54566975/dwn-sql-store': 0.2.13
       better-sqlite3: 8.7.0
       body-parser: 1.20.2
       bytes: 3.1.2


### PR DESCRIPTION
- upgrade `dwn-sdk-js` to `0.2.22`

This version of `dwn-sdk-js` consumes `1.0.0` of the `@web5/dids` package. 🎉 