### PR TITLE
`@web5/agent` DWN Subscriptions Support

### DIFF
--- a/.changeset/six-pandas-tell.md
+++ b/.changeset/six-pandas-tell.md
@@ -1,0 +1,11 @@
+---
+"@web5/agent": patch
+"@web5/api": patch
+"@web5/identity-agent": patch
+"@web5/proxy-agent": patch
+"@web5/user-agent": patch
+---
+
+- `@web5/agent` DWN Subscriptions Support
+- `@web5/agent` and `@web5/api` support `prune` feature from `RecordsWriteDelete`
+

--- a/.changeset/six-pandas-tell.md
+++ b/.changeset/six-pandas-tell.md
@@ -1,11 +1,10 @@
 ---
 "@web5/agent": patch
-"@web5/api": patch
 "@web5/identity-agent": patch
 "@web5/proxy-agent": patch
 "@web5/user-agent": patch
 ---
 
 - `@web5/agent` DWN Subscriptions Support
-- `@web5/agent` and `@web5/api` support `prune` feature from `RecordsWriteDelete`
+- `@web5/agent` supports latest `dwn-sdk-js` with `prune` feature from `RecordsWriteDelete`
 

--- a/.changeset/twelve-trainers-wonder.md
+++ b/.changeset/twelve-trainers-wonder.md
@@ -1,0 +1,5 @@
+---
+"@web5/api": patch
+---
+
+`@web5/api` supports `prune` via `RecordsWriteDelete`

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@changesets/cli": "^2.27.1",
     "@npmcli/package-json": "5.0.0",
     "@typescript-eslint/eslint-plugin": "6.4.0",
-    "@web5/dwn-server": "0.2.1",
+    "@web5/dwn-server": "0.2.2",
     "eslint-plugin-mocha": "10.1.0",
     "npkill": "0.11.3"
   },

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -71,7 +71,7 @@
   "dependencies": {
     "@noble/ciphers": "0.4.1",
     "@scure/bip39": "1.2.2",
-    "@tbd54566975/dwn-sdk-js": "0.3.1",
+    "@tbd54566975/dwn-sdk-js": "0.3.2",
     "@web5/common": "1.0.0",
     "@web5/crypto": "1.0.0",
     "@web5/dids": "1.0.1",

--- a/packages/agent/src/did-api.ts
+++ b/packages/agent/src/did-api.ts
@@ -231,7 +231,7 @@ export class AgentDidApi<TKeyManager extends AgentKeyManager = AgentKeyManager> 
     // Resolve the DID document.
     const { didDocument, didResolutionMetadata } = await this.resolve(didUri);
     if (!didDocument) {
-      throw new Error(`DID resolution failed for '${didUri}': ${didResolutionMetadata.error}`);
+      throw new Error(`DID resolution failed for '${didUri}': ${JSON.stringify(didResolutionMetadata)}`);
     }
 
     // Retrieve the method-specific verification method to be used for signing operations.

--- a/packages/agent/src/dwn-api.ts
+++ b/packages/agent/src/dwn-api.ts
@@ -4,10 +4,10 @@ import type { DwnConfig, GenericMessage, UnionMessageReply } from '@tbd54566975/
 import { Convert, NodeStream } from '@web5/common';
 import { utils as cryptoUtils } from '@web5/crypto';
 import { DidDht, DidJwk, DidResolverCacheLevel, UniversalResolver } from '@web5/dids';
-import { Cid, DataStoreLevel, Dwn, EventLogLevel, Message, MessageStoreLevel } from '@tbd54566975/dwn-sdk-js';
+import { Cid, DataStoreLevel, Dwn, DwnMethodName, EventLogLevel, Message, MessageStoreLevel } from '@tbd54566975/dwn-sdk-js';
 
 import type { Web5PlatformAgent } from './types/agent.js';
-import type { DwnMessage, DwnMessageInstance, DwnMessageParams, DwnMessageReply, DwnMessageWithData, DwnResponse, DwnSigner, ProcessDwnRequest, SendDwnRequest } from './types/dwn.js';
+import type { DwnMessage, DwnMessageInstance, DwnMessageParams, DwnMessageReply, DwnMessageWithData, DwnResponse, DwnSigner, MessageHandler, ProcessDwnRequest, SendDwnRequest } from './types/dwn.js';
 
 import { DwnInterface, dwnMessageConstructors } from './types/dwn.js';
 import { blobToIsomorphicNodeReadable, getDwnServiceEndpointUrls, isRecordsWrite, webReadableToIsomorphicNodeReadable } from './utils.js';
@@ -154,6 +154,7 @@ export class AgentDwnApi {
     let messageCid: string | undefined;
     let message: DwnMessage[T];
     let data: Blob | undefined;
+    let subscriptionHandler: MessageHandler[T] | undefined;
 
     // If `messageCid` is given, retrieve message and data, if any.
     if ('messageCid' in request) {
@@ -171,6 +172,7 @@ export class AgentDwnApi {
         throw new Error('AgentDwnApi: DataStream must be provided as a Blob');
       }
       data = request.dataStream;
+      subscriptionHandler = request.subscriptionHandler;
     }
 
     // Send the RPC request to the target DID's DWN service endpoint using the Agent's RPC client.
@@ -178,7 +180,8 @@ export class AgentDwnApi {
       targetDid: request.target,
       dwnEndpointUrls,
       message,
-      data
+      data,
+      subscriptionHandler
     });
 
     // If the message CID was not given in the `request`, compute it.
@@ -190,25 +193,53 @@ export class AgentDwnApi {
   }
 
   private async sendDwnRpcRequest<T extends DwnInterface>({
-    targetDid, dwnEndpointUrls, message, data
+    targetDid, dwnEndpointUrls, message, data, subscriptionHandler
   }: {
       targetDid: string;
       dwnEndpointUrls: string[];
       message: DwnMessage[T];
       data?: Blob;
+      subscriptionHandler?: MessageHandler[T];
     }
   ): Promise<DwnMessageReply[T]> {
     const errorMessages: { url: string, message: string }[] = [];
 
+    if (message.descriptor.method === DwnMethodName.Subscribe && subscriptionHandler === undefined) {
+      throw new Error('AgentDwnApi: Subscription handler is required for subscription requests.');
+    } else if (subscriptionHandler !== undefined && message.descriptor.method !== DwnMethodName.Subscribe) {
+      throw new Error('AgentDwnApi: Subscription handler is only allowed for subscription requests.');
+    }
+
     // Try sending to author's publicly addressable DWNs until the first request succeeds.
     for (let dwnUrl of dwnEndpointUrls) {
       try {
+        if (subscriptionHandler !== undefined) {
+          // we get the server info to check if the server supports WebSocket for subscription requests
+          const serverInfo = await this.agent.rpc.getServerInfo(dwnUrl);
+          if (!serverInfo.webSocketSupport) {
+            // If the server does not support WebSocket, add an error message and continue to the next URL.
+            errorMessages.push({
+              url     : dwnUrl,
+              message : 'WebSocket support is not enabled on the server.'
+            });
+            continue;
+          }
+
+          // If the server supports WebSocket, replace the subscription URL with a socket transport.
+          // For `http` we use the unsecured `ws` protocol, and for `https` we use the secured `wss` protocol.
+          const parsedUrl = new URL(dwnUrl);
+          parsedUrl.protocol = parsedUrl.protocol === 'http:' ? 'ws:' : 'wss:';
+          dwnUrl = parsedUrl.toString();
+        }
+
         const dwnReply = await this.agent.rpc.sendDwnRequest({
           dwnUrl,
           targetDid,
           message,
           data,
+          subscriptionHandler
         });
+
         return dwnReply;
       } catch(error: any) {
         errorMessages.push({

--- a/packages/agent/src/dwn-api.ts
+++ b/packages/agent/src/dwn-api.ts
@@ -206,8 +206,6 @@ export class AgentDwnApi {
 
     if (message.descriptor.method === DwnMethodName.Subscribe && subscriptionHandler === undefined) {
       throw new Error('AgentDwnApi: Subscription handler is required for subscription requests.');
-    } else if (subscriptionHandler !== undefined && message.descriptor.method !== DwnMethodName.Subscribe) {
-      throw new Error('AgentDwnApi: Subscription handler is only allowed for subscription requests.');
     }
 
     // Try sending to author's publicly addressable DWNs until the first request succeeds.

--- a/packages/agent/src/prototyping/clients/dwn-rpc-types.ts
+++ b/packages/agent/src/prototyping/clients/dwn-rpc-types.ts
@@ -1,10 +1,10 @@
-import type { MessageEvent, RecordsReadReply, UnionMessageReply } from '@tbd54566975/dwn-sdk-js';
+import type { RecordsReadReply, UnionMessageReply, EventSubscriptionHandler, RecordSubscriptionHandler } from '@tbd54566975/dwn-sdk-js';
 
 export interface SerializableDwnMessage {
   toJSON(): string;
 }
 
-export type DwnEventSubscriptionHandler = (event: MessageEvent) => void;
+export type DwnSubscriptionHandler = EventSubscriptionHandler | RecordSubscriptionHandler;
 
 /**
  * Interface for communicating with {@link https://github.com/TBD54566975/dwn-server | DWN Servers}
@@ -45,7 +45,7 @@ export type DwnRpcRequest = {
   targetDid: string;
 
   /** Optional subscription handler for DWN events. */
-  subscriptionHandler?: DwnEventSubscriptionHandler;
+  subscriptionHandler?: DwnSubscriptionHandler;
 }
 
 /**

--- a/packages/agent/src/prototyping/clients/web-socket-clients.ts
+++ b/packages/agent/src/prototyping/clients/web-socket-clients.ts
@@ -1,4 +1,4 @@
-import type { DwnEventSubscriptionHandler, DwnRpc, DwnRpcRequest, DwnRpcResponse } from './dwn-rpc-types.js';
+import type { DwnRpc, DwnRpcRequest, DwnRpcResponse, DwnSubscriptionHandler } from './dwn-rpc-types.js';
 import type { GenericMessage, MessageSubscription, UnionMessageReply } from '@tbd54566975/dwn-sdk-js';
 
 import { utils as cryptoUtils } from '@web5/crypto';
@@ -60,7 +60,7 @@ export class WebSocketDwnRpcClient implements DwnRpc {
     return result.reply as DwnRpcResponse;
   }
 
-  private static async subscriptionRequest(connection: SocketConnection, target:string, message: GenericMessage, messageHandler: DwnEventSubscriptionHandler): Promise<DwnRpcResponse> {
+  private static async subscriptionRequest(connection: SocketConnection, target:string, message: GenericMessage, messageHandler: DwnSubscriptionHandler): Promise<DwnRpcResponse> {
     const requestId = cryptoUtils.randomUuid();
     const subscriptionId = cryptoUtils.randomUuid();
     const request = createJsonRpcSubscriptionRequest(requestId, 'dwn.processMessage', subscriptionId, { target, message });

--- a/packages/agent/src/rpc-client.ts
+++ b/packages/agent/src/rpc-client.ts
@@ -51,9 +51,9 @@ export class Web5RpcClient implements Web5Rpc {
   constructor(clients: Web5Rpc[] = []) {
     this.transportClients = new Map();
 
-    // include http client as default. can be overwritten for 'http:' or 'https:' if instantiator provides
-    // their own.
-    clients = [new HttpWeb5RpcClient(), ...clients];
+    // include http and socket clients as default.
+    // can be overwritten for 'http:', 'https:', 'ws: or ':wss' if instantiated with other clients.
+    clients = [new HttpWeb5RpcClient(), new WebSocketWeb5RpcClient(), ...clients];
 
     for (let client of clients) {
       for (let transportScheme of client.transportProtocols) {

--- a/packages/agent/src/test-harness.ts
+++ b/packages/agent/src/test-harness.ts
@@ -3,7 +3,7 @@ import type { AbstractLevel } from 'abstract-level';
 
 import { Level } from 'level';
 import { LevelStore, MemoryStore } from '@web5/common';
-import { DataStoreLevel, Dwn, EventLogLevel, MessageStoreLevel } from '@tbd54566975/dwn-sdk-js';
+import { DataStoreLevel, Dwn, EventEmitterStream, EventLogLevel, MessageStoreLevel } from '@tbd54566975/dwn-sdk-js';
 import { DidDht, DidJwk, DidResolutionResult, DidResolverCache, DidResolverCacheLevel } from '@web5/dids';
 
 import type { Web5PlatformAgent } from './types/agent.js';
@@ -180,6 +180,8 @@ export class PlatformAgentTestHarness {
     // Note: There is no in-memory store for DWN, so we always use LevelDB-based disk stores.
     const dwnDataStore = new DataStoreLevel({ blockstoreLocation: testDataPath('DWN_DATASTORE') });
     const dwnEventLog = new EventLogLevel({ location: testDataPath('DWN_EVENTLOG') });
+    const dwnEventStream = new EventEmitterStream();
+
     const dwnMessageStore = new MessageStoreLevel({
       blockstoreLocation : testDataPath('DWN_MESSAGESTORE'),
       indexLocation      : testDataPath('DWN_MESSAGEINDEX')
@@ -191,7 +193,8 @@ export class PlatformAgentTestHarness {
       dataStore    : dwnDataStore,
       didResolver  : didApi,
       eventLog     : dwnEventLog,
-      messageStore : dwnMessageStore
+      eventStream  : dwnEventStream,
+      messageStore : dwnMessageStore,
     });
 
     // Instantiate Agent's DWN API using the custom DWN instance.

--- a/packages/agent/src/types/dwn.ts
+++ b/packages/agent/src/types/dwn.ts
@@ -264,6 +264,8 @@ export {
   DateSort as DwnDateSort,
   PublicJwk as DwnPublicKeyJwk, // TODO: Remove once DWN SDK switches to Jwk from @web5/crypto
   PaginationCursor as DwnPaginationCursor,
+  EventSubscriptionHandler as DwnEventSubscriptionHandler,
+  RecordSubscriptionHandler as DwnRecordSubscriptionHandler,
   EncryptionAlgorithm as DwnEncryptionAlgorithm,
   KeyDerivationScheme as DwnKeyDerivationScheme,
 } from '@tbd54566975/dwn-sdk-js';

--- a/packages/agent/src/types/dwn.ts
+++ b/packages/agent/src/types/dwn.ts
@@ -266,6 +266,7 @@ export {
   PaginationCursor as DwnPaginationCursor,
   EventSubscriptionHandler as DwnEventSubscriptionHandler,
   RecordSubscriptionHandler as DwnRecordSubscriptionHandler,
+  MessageSubscription as DwnMessageSubscription,
   EncryptionAlgorithm as DwnEncryptionAlgorithm,
   KeyDerivationScheme as DwnKeyDerivationScheme,
 } from '@tbd54566975/dwn-sdk-js';

--- a/packages/agent/tests/dwn-api.spec.ts
+++ b/packages/agent/tests/dwn-api.spec.ts
@@ -1428,6 +1428,41 @@ describe('AgentDwnApi', () => {
       }
     });
 
+    it('throws an error when a Subscribe method is called without a subscriptionHandler', async () => {
+
+      // RecordsSubscribe message without a subscriptionHandler
+      try {
+        await testHarness.agent.dwn.sendRequest({
+          author        : alice.did.uri,
+          target        : alice.did.uri,
+          messageType   : DwnInterface.RecordsSubscribe,
+          messageParams : {
+            filter: {
+              schema: 'https://schemas.xyz/example'
+            }
+          }
+        });
+        expect.fail('Expected an error to be thrown');
+
+      } catch (error: any) {
+        expect(error.message).to.include('AgentDwnApi: Subscription handler is required for subscription requests.');
+      }
+
+      // EventsSubscribe message without a subscriptionHandler
+      try {
+        await testHarness.agent.dwn.sendRequest({
+          author        : alice.did.uri,
+          target        : alice.did.uri,
+          messageType   : DwnInterface.EventsSubscribe,
+          messageParams : {}
+        });
+        expect.fail('Expected an error to be thrown');
+
+      } catch (error: any) {
+        expect(error.message).to.include('AgentDwnApi: Subscription handler is required for subscription requests.');
+      }
+    });
+
     it('throws an error when DwnRequest fails validation', async () => {
       try {
         await testHarness.agent.dwn.sendRequest({

--- a/packages/agent/tests/prototyping/clients/ws-dwn-rpc-client.spec.ts
+++ b/packages/agent/tests/prototyping/clients/ws-dwn-rpc-client.spec.ts
@@ -1,4 +1,4 @@
-import type { Persona, RecordsWriteMessage } from '@tbd54566975/dwn-sdk-js';
+import type { Persona, RecordSubscriptionHandler, RecordsWriteMessage } from '@tbd54566975/dwn-sdk-js';
 
 import sinon from 'sinon';
 
@@ -11,7 +11,6 @@ import { testDwnUrl } from '../../utils/test-config.js';
 import { JsonRpcSocket } from '../../../src/prototyping/clients/json-rpc-socket.js';
 import { JsonRpcErrorCodes, createJsonRpcErrorResponse } from '../../../src/prototyping/clients/json-rpc.js';
 import { HttpDwnRpcClient } from '../../../src/prototyping/clients/http-dwn-rpc-client.js';
-import { DwnEventSubscriptionHandler } from '../../../src/prototyping/clients/dwn-rpc-types.js';
 
 /** helper method to sleep while waiting for events to process/arrive */
 async function sleepWhileWaitingForEvents(override?: number):Promise<void> {
@@ -174,7 +173,7 @@ describe('WebSocketDwnRpcClient', () => {
       });
 
       const dataCids:string[] = [];
-      const subscriptionHandler: DwnEventSubscriptionHandler = (event) => {
+      const subscriptionHandler: RecordSubscriptionHandler = (event) => {
         const { message, initialWrite } = event;
         expect(initialWrite!.recordId).to.equal(writeMessage.recordId);
         expect(initialWrite!.descriptor.dataCid).to.equal(writeMessage.descriptor.dataCid);

--- a/packages/agent/tests/rpc-client.spec.ts
+++ b/packages/agent/tests/rpc-client.spec.ts
@@ -122,7 +122,7 @@ describe('RPC Clients', () => {
 
         // confirm it was called once per each transport
         expect(socketClientSpy.callCount).to.equal(2);
-      });      
+      });
     });
 
     describe('sendDwnRequest', () => {

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -85,7 +85,7 @@
   },
   "devDependencies": {
     "@playwright/test": "1.40.1",
-    "@tbd54566975/dwn-sdk-js": "0.3.1",
+    "@tbd54566975/dwn-sdk-js": "0.3.2",
     "@types/chai": "4.3.6",
     "@types/eslint": "8.44.2",
     "@types/mocha": "10.0.1",

--- a/packages/dev-env/docker-compose.yaml
+++ b/packages/dev-env/docker-compose.yaml
@@ -3,6 +3,6 @@ version: "3.98"
 services:
   dwn-server:
     container_name: dwn-server
-    image: ghcr.io/tbd54566975/dwn-server:dwn-sdk-0.3.1
+    image: ghcr.io/tbd54566975/dwn-server:dwn-sdk-0.3.2
     ports:
       - "3000:3000"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,8 +42,8 @@ importers:
         specifier: 1.2.2
         version: 1.2.2
       '@tbd54566975/dwn-sdk-js':
-        specifier: 0.3.1
-        version: 0.3.1
+        specifier: 0.3.2
+        version: 0.3.2
       '@web5/common':
         specifier: 1.0.0
         version: link:../common
@@ -2799,6 +2799,39 @@ packages:
     transitivePeerDependencies:
       - encoding
       - supports-color
+
+  /@tbd54566975/dwn-sdk-js@0.3.2:
+    resolution: {integrity: sha512-MMBau0Snkfnw4pCyBAzOneniUPVOBD1+m/Wj5rVgkDJNPIRkbFMcJ7auEmc4Pm0w+7pgm/ToPXDaSix+2Qob1w==}
+    engines: {node: '>= 18'}
+    dependencies:
+      '@ipld/dag-cbor': 9.0.3
+      '@js-temporal/polyfill': 0.4.4
+      '@noble/ed25519': 2.0.0
+      '@noble/secp256k1': 2.0.0
+      '@web5/dids': 1.0.1
+      abstract-level: 1.0.3
+      ajv: 8.12.0
+      blockstore-core: 4.2.0
+      cross-fetch: 4.0.0
+      eciesjs: 0.4.5
+      interface-blockstore: 5.2.3
+      interface-store: 5.1.2
+      ipfs-unixfs-exporter: 13.1.5
+      ipfs-unixfs-importer: 15.1.5
+      level: 8.0.0
+      lodash: 4.17.21
+      lru-cache: 9.1.2
+      ms: 2.1.3
+      multiformats: 11.0.2
+      randombytes: 2.1.0
+      readable-stream: 4.5.2
+      ulidx: 2.1.0
+      uuid: 8.3.2
+      varint: 6.0.0
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    dev: false
 
   /@tbd54566975/dwn-sql-store@0.4.1:
     resolution: {integrity: sha512-ndslsbtNjkIuNu8ytNZnKjH4uWoxWFzt+L/8ok5giVmgrjTh/+XDU23LQYJjRHC/RusjpDNjlt77PhL2qbXxmQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: 6.4.0
         version: 6.4.0(@typescript-eslint/parser@6.4.0)(eslint@8.47.0)(typescript@5.1.6)
       '@web5/dwn-server':
-        specifier: 0.2.1
-        version: 0.2.1
+        specifier: 0.2.2
+        version: 0.2.2
       eslint-plugin-mocha:
         specifier: 10.1.0
         version: 10.1.0(eslint@8.47.0)
@@ -2768,39 +2768,6 @@ packages:
       jwt-decode: 3.1.2
     dev: true
 
-  /@tbd54566975/dwn-sdk-js@0.3.1:
-    resolution: {integrity: sha512-G73ixUGieRBE4kYxLlYu/9wN36RUBGp5nvDrlAWZsNUXEXWnhCS3qTYFnUqzPEXjoE0z8EVRtpMU/eITM8ZcDA==}
-    engines: {node: '>= 18'}
-    dependencies:
-      '@ipld/dag-cbor': 9.0.3
-      '@js-temporal/polyfill': 0.4.4
-      '@noble/ed25519': 2.0.0
-      '@noble/secp256k1': 2.0.0
-      '@web5/dids': 1.0.1
-      abstract-level: 1.0.3
-      ajv: 8.12.0
-      blockstore-core: 4.2.0
-      cross-fetch: 4.0.0
-      eciesjs: 0.4.5
-      interface-blockstore: 5.2.3
-      interface-store: 5.1.2
-      ipfs-unixfs-exporter: 13.1.5
-      ipfs-unixfs-importer: 15.1.5
-      level: 8.0.0
-      lodash: 4.17.21
-      lru-cache: 9.1.2
-      ms: 2.1.3
-      multiformats: 11.0.2
-      randombytes: 2.1.0
-      readable-stream: 4.5.2
-      ulidx: 2.1.0
-      uuid: 8.3.2
-      varint: 6.0.0
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
-    dev: true
-
   /@tbd54566975/dwn-sdk-js@0.3.2:
     resolution: {integrity: sha512-MMBau0Snkfnw4pCyBAzOneniUPVOBD1+m/Wj5rVgkDJNPIRkbFMcJ7auEmc4Pm0w+7pgm/ToPXDaSix+2Qob1w==}
     engines: {node: '>= 18'}
@@ -2833,12 +2800,12 @@ packages:
       - encoding
       - supports-color
 
-  /@tbd54566975/dwn-sql-store@0.4.1:
-    resolution: {integrity: sha512-ndslsbtNjkIuNu8ytNZnKjH4uWoxWFzt+L/8ok5giVmgrjTh/+XDU23LQYJjRHC/RusjpDNjlt77PhL2qbXxmQ==}
+  /@tbd54566975/dwn-sql-store@0.4.2:
+    resolution: {integrity: sha512-KdLk5PUaAuONr/xLOQN6LSVwVV/JQ3kn7ozlj74f9MRoBjL2iIiowCocCe6sAhzKCYmrT+xSdYP+M3e9moJ6Yw==}
     engines: {node: '>=18'}
     dependencies:
       '@ipld/dag-cbor': 9.2.0
-      '@tbd54566975/dwn-sdk-js': 0.3.1
+      '@tbd54566975/dwn-sdk-js': 0.3.2
       kysely: 0.26.3
       multiformats: 12.0.1
       readable-stream: 4.4.2
@@ -3510,12 +3477,12 @@ packages:
       level: 8.0.0
       ms: 2.1.3
 
-  /@web5/dwn-server@0.2.1:
-    resolution: {integrity: sha512-RMt+YjVF3qru6zpjIdqB9vlCBfBt+H7QrrE/VsX8/VoQVRdrRPLnMIUVeYnfOn1pjXMWQs8cZjBypD04lMYZCA==}
+  /@web5/dwn-server@0.2.2:
+    resolution: {integrity: sha512-jUd02x1aWvDFVzOdi1KFfB816fMmOJSM9lPY1hi4uFww8r7sx3YU00LH5q+/odJXM3FDwHTX8yDncL8GS9xQEg==}
     hasBin: true
     dependencies:
-      '@tbd54566975/dwn-sdk-js': 0.3.1
-      '@tbd54566975/dwn-sql-store': 0.4.1
+      '@tbd54566975/dwn-sdk-js': 0.3.2
+      '@tbd54566975/dwn-sql-store': 0.4.2
       better-sqlite3: 8.7.0
       body-parser: 1.20.2
       bytes: 3.1.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -170,8 +170,8 @@ importers:
         specifier: 1.40.1
         version: 1.40.1
       '@tbd54566975/dwn-sdk-js':
-        specifier: 0.3.1
-        version: 0.3.1
+        specifier: 0.3.2
+        version: 0.3.2
       '@types/chai':
         specifier: 4.3.6
         version: 4.3.6
@@ -2799,6 +2799,7 @@ packages:
     transitivePeerDependencies:
       - encoding
       - supports-color
+    dev: true
 
   /@tbd54566975/dwn-sdk-js@0.3.2:
     resolution: {integrity: sha512-MMBau0Snkfnw4pCyBAzOneniUPVOBD1+m/Wj5rVgkDJNPIRkbFMcJ7auEmc4Pm0w+7pgm/ToPXDaSix+2Qob1w==}
@@ -2831,7 +2832,6 @@ packages:
     transitivePeerDependencies:
       - encoding
       - supports-color
-    dev: false
 
   /@tbd54566975/dwn-sql-store@0.4.1:
     resolution: {integrity: sha512-ndslsbtNjkIuNu8ytNZnKjH4uWoxWFzt+L/8ok5giVmgrjTh/+XDU23LQYJjRHC/RusjpDNjlt77PhL2qbXxmQ==}


### PR DESCRIPTION
Implements support for `RecordsSubscribe` and `EventsSubscribe` in `@web5/agent`

inherited change from latest `dwn-sdk-js` to allow pruning when issuing a `RecordsDelete` message.