### PR TITLE
extract parentContextId from record when updating

### DIFF
--- a/.changeset/big-tomatoes-obey.md
+++ b/.changeset/big-tomatoes-obey.md
@@ -1,0 +1,5 @@
+---
+"@web5/api": patch
+---
+
+When updating a record, we must include the `parentContextId` in the create options

--- a/packages/api/src/record.ts
+++ b/packages/api/src/record.ts
@@ -572,10 +572,16 @@ export class Record implements RecordModel {
    * @beta
    */
   async update({ dateModified, data, ...params }: RecordUpdateParams): Promise<DwnResponseStatus> {
+
+    // if there is a parentId, we remove it from the descriptor and set a parentContextId
+    const { parentId, ...descriptor } = this._descriptor;
+    const parentContextId = parentId ? this._contextId.split('/').slice(0, -1).join('/') : undefined;
+
     // Begin assembling the update message.
     let updateMessage: DwnMessageParams[DwnInterface.RecordsWrite] = {
-      ...this._descriptor,
+      ...descriptor,
       ...params,
+      parentContextId,
       messageTimestamp : dateModified, // Map Record class `dateModified` property to DWN SDK `messageTimestamp`
       recordId         : this._recordId
     };

--- a/packages/api/tests/record.spec.ts
+++ b/packages/api/tests/record.spec.ts
@@ -2278,7 +2278,7 @@ describe('Record', () => {
         data    : 'Hello, world!',
         message : {
           protocol     : protocol.definition.protocol,
-          schema       : emailProtocolDefinition.types.thread.schema, 
+          schema       : emailProtocolDefinition.types.thread.schema,
           protocolPath : 'thread'
         }
       });


### PR DESCRIPTION
When updating a record, we currently pass in the record descriptor int the create options, however if the record has a parent we must set the `parentContextId`.

In order to do this we extract the parentId from the descriptor, and if it exists we set a `parentContextId`.