### PR TITLE
DID Resolution Caching

### DIFF
--- a/.changeset/tall-toes-remember.md
+++ b/.changeset/tall-toes-remember.md
@@ -1,0 +1,5 @@
+---
+"@web5/dids": patch
+---
+
+Do not cache results that contain a resolution error.

--- a/packages/dids/src/resolver/universal-resolver.ts
+++ b/packages/dids/src/resolver/universal-resolver.ts
@@ -126,8 +126,10 @@ export class UniversalResolver implements DidResolver, DidUrlDereferencer {
       return cachedResolutionResult;
     } else {
       const resolutionResult = await resolver.resolve(parsedDid.uri, options);
-
-      await this.cache.set(parsedDid.uri, resolutionResult);
+      if (!resolutionResult.didResolutionMetadata.error) {
+        // Cache the resolution result if it was successful.
+        await this.cache.set(parsedDid.uri, resolutionResult);
+      }
 
       return resolutionResult;
     }


### PR DESCRIPTION
Currently we are running into a problem where a DID's cache TTL is up and it is evicted from the cache, but a subsequent call may return a `notFound` error and it currently caches it.

The goal for this PR is to:
- Not cache results that contain a resolution error.