### PR TITLE
Fixed annoy TypeDoc errors that have been there for a while

### DIFF
--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           report_changed_scope_only: false
-          fail_on_error: false
+          fail_on_error: true
           group_docs: true
           entry_points: |
             - file: packages/api/src/index.ts

--- a/packages/api/src/record.ts
+++ b/packages/api/src/record.ts
@@ -250,6 +250,7 @@ export class Record implements RecordModel {
   /** Record's published status (true/false) */
   get published() { return this._descriptor.published; }
 
+  /** Tags of the record */
   get tags() { return this._descriptor.tags; }
 
   /**

--- a/packages/credentials/src/verifiable-credential.ts
+++ b/packages/credentials/src/verifiable-credential.ts
@@ -23,7 +23,9 @@ export type VcDataModel = ICredential;
  * A credential schema defines the structure and content of the data, enabling verifiers to assess if the data adheres to the established schema.
  */
 export type CredentialSchema = {
+  /** Credential schema ID */
   id: string;
+  /** Credential schema type */
   type: string;
 };
 

--- a/packages/crypto-aws-kms/src/ecdsa.ts
+++ b/packages/crypto-aws-kms/src/ecdsa.ts
@@ -47,6 +47,9 @@ export interface EcdsaSignParams extends KmsSignParams {
   algorithm: 'ES256K';
 }
 
+/**
+ * The `EcdsaAlgorithm` class is an implementation of the `KeyGenerator` and `Signer` interfaces for the ECDSA algorithm.
+ */
 export class EcdsaAlgorithm implements
     KeyGenerator<EcdsaGenerateKeyParams, KeyIdentifier>,
     Signer<KmsSignParams, KmsVerifyParams> {

--- a/packages/crypto-aws-kms/src/key-manager.ts
+++ b/packages/crypto-aws-kms/src/key-manager.ts
@@ -97,6 +97,9 @@ export interface AwsKeyManagerGenerateKeyParams extends KmsGenerateKeyParams {
   algorithm: 'ES256K';
 }
 
+/**
+ * The `AwsKeyManager` class is an implementation of the `CryptoApi` interface tailored for AWS KMS.
+ */
 export class AwsKeyManager implements CryptoApi<AwsKeyManagerGenerateKeyParams> {
   /**
    * A private map that stores instances of cryptographic algorithm implementations. Each key in

--- a/packages/crypto-aws-kms/src/utils.ts
+++ b/packages/crypto-aws-kms/src/utils.ts
@@ -94,6 +94,9 @@ export async function createKeyAlias({ alias, awsKeyId, kmsClient }: {
   );
 }
 
+/**
+ * Gets the `KeySpec` of the key specified.
+ */
 export async function getKeySpec({ keyUri, kmsClient }: {
     keyUri: KeyIdentifier;
     kmsClient: KMSClient;


### PR DESCRIPTION
1. Fixed annoy TypeDoc errors that have been polluting every PR opened for a while
1. Also turned on fail-on-error for TypeDoc generation during CI so TypeDoc warnings only annoys the person who introduces it.