### PR TITLE
add reference types from dwn-sdk-js to avoid pnpm build error

### DIFF
--- a/.changeset/beige-tools-yawn.md
+++ b/.changeset/beige-tools-yawn.md
@@ -1,0 +1,7 @@
+---
+"@web5/api": patch
+---
+
+add reference types from dwn-sdk-js to avoid pnpm build error
+
+https://github.com/microsoft/TypeScript/issues/47663#issuecomment-1962129199

--- a/packages/api/src/protocol.ts
+++ b/packages/api/src/protocol.ts
@@ -1,3 +1,7 @@
+/**
+ * NOTE: Added reference types here to avoid a `pnpm` bug during build.
+ * https://github.com/TBD54566975/web5-js/pull/507
+ */
 /// <reference types="@tbd54566975/dwn-sdk-js" />
 
 import type { DwnMessage, DwnResponseStatus, Web5Agent } from '@web5/agent';

--- a/packages/api/src/protocol.ts
+++ b/packages/api/src/protocol.ts
@@ -1,3 +1,5 @@
+/// <reference types="@tbd54566975/dwn-sdk-js" />
+
 import type { DwnMessage, DwnResponseStatus, Web5Agent } from '@web5/agent';
 
 import { DwnInterface } from '@web5/agent';

--- a/packages/api/src/record.ts
+++ b/packages/api/src/record.ts
@@ -1,3 +1,5 @@
+/// <reference types="@tbd54566975/dwn-sdk-js" />
+
 import type { Readable } from '@web5/common';
 import type {
   Web5Agent,

--- a/packages/api/src/record.ts
+++ b/packages/api/src/record.ts
@@ -1,3 +1,7 @@
+/**
+ * NOTE: Added reference types here to avoid a `pnpm` bug during build.
+ * https://github.com/TBD54566975/web5-js/pull/507
+ */
 /// <reference types="@tbd54566975/dwn-sdk-js" />
 
 import type { Readable } from '@web5/common';


### PR DESCRIPTION
`pnpm` encounters some build errors for inferred types when there are 2 different versions of the same package in a monorepo.

https://github.com/microsoft/TypeScript/issues/47663#issuecomment-1962129199

Adding `/// <reference types="@tbd54566975/dwn-sdk-js" />` at the top of files which would infer these types allows the build system to understand them, i believe while keeping this package as a devDependency.

I don't think that this is the long-term solution here, but may be a temporary fix until we decide on a permanent one potentially bringing in `dwn-sdk-js` as a first class dependency of `api` and get rid of the type-wrapping we are doing in `agent`