### PR TITLE
add identifier to pkarr error for debugging purposes

### DIFF
--- a/.changeset/tall-mugs-wink.md
+++ b/.changeset/tall-mugs-wink.md
@@ -1,0 +1,5 @@
+---
+"@web5/dids": patch
+---
+
+We sometimes get failures in CI publishing to the DHT. In order to make debugging these errors easier, we add the identifier to the error thrown.

--- a/packages/dids/src/methods/did-dht.ts
+++ b/packages/dids/src/methods/did-dht.ts
@@ -948,7 +948,7 @@ export class DidDhtDocument {
       });
 
     } catch (error: any) {
-      throw new DidError(DidErrorCode.InternalError, `Failed to put Pkarr record: ${error.message}`);
+      throw new DidError(DidErrorCode.InternalError, `Failed to put Pkarr record for identifier ${identifier}: ${error.message}`);
     }
 
     // Return `true` if the DHT request was successful, otherwise return `false`.


### PR DESCRIPTION
We sometimes get failures in CI publishing to the DHT. In order to make debugging these errors easier, we add the identifier to the error thrown.