### PR TITLE
Always set alg and kid on expansion

### DIFF
--- a/packages/dids/src/methods/did-dht.ts
+++ b/packages/dids/src/methods/did-dht.ts
@@ -32,7 +32,6 @@ import { extractDidFragment } from '../utils.js';
 import { DidError, DidErrorCode } from '../did-error.js';
 import { DidVerificationRelationship } from '../types/did-core.js';
 import { EMPTY_DID_RESOLUTION_RESULT } from '../types/did-resolution.js';
-import { getJoseSignatureAlgorithmFromPublicKey } from '@web5/crypto/utils';
 
 /**
  * Represents a BEP44 message, which is used for storing and retrieving data in the Mainline DHT
@@ -1036,8 +1035,7 @@ export class DidDhtDocument {
           // Convert the public key from a byte array to JWK format.
           let publicKey = await DidDhtUtils.keyConverter(namedCurve).bytesToPublicKey({ publicKeyBytes });
 
-          // DID DHT spec requires `alg` in keys in the DID document
-          publicKey.alg = parsedAlg || getJoseSignatureAlgorithmFromPublicKey(publicKey);
+          publicKey.alg = parsedAlg || KeyTypeToDefaultAlgorithmMap[Number(t) as DidDhtRegisteredKeyType];
 
           // Determine the Key ID (kid): '0' for the identity key or JWK thumbprint for others.
           publicKey.kid = dnsRecordId.endsWith('0') ? '0' : await computeJwkThumbprint({ jwk: publicKey });

--- a/packages/dids/src/methods/did-dht.ts
+++ b/packages/dids/src/methods/did-dht.ts
@@ -32,6 +32,7 @@ import { extractDidFragment } from '../utils.js';
 import { DidError, DidErrorCode } from '../did-error.js';
 import { DidVerificationRelationship } from '../types/did-core.js';
 import { EMPTY_DID_RESOLUTION_RESULT } from '../types/did-resolution.js';
+import { getJoseSignatureAlgorithmFromPublicKey } from '@web5/crypto/utils';
 
 /**
  * Represents a BEP44 message, which is used for storing and retrieving data in the Mainline DHT
@@ -393,6 +394,15 @@ const AlgorithmToKeyTypeMap = {
   secp256k1 : DidDhtRegisteredKeyType.secp256k1,
   secp256r1 : DidDhtRegisteredKeyType.secp256r1
 } as const;
+
+/**
+ * Private helper that maps did dht registered key types to their corresponding default algorithm identifiers.
+ */
+const KeyTypeToDefaultAlgorithmMap = {
+  [DidDhtRegisteredKeyType.Ed25519]   : 'Ed25519',
+  [DidDhtRegisteredKeyType.secp256k1] : 'ES256K',
+  [DidDhtRegisteredKeyType.secp256r1] : 'ES256',
+};
 
 /**
  * The `DidDht` class provides an implementation of the `did:dht` DID method.
@@ -1015,7 +1025,7 @@ export class DidDhtDocument {
         case dnsRecordId.startsWith('k'): {
           // Get the method ID fragment (id), key type (t), Base64URL-encoded public key (k), and
           // optionally, controller (c) from the decoded TXT record data.
-          const { id, t, k, c } = DidDhtUtils.parseTxtDataToObject(answer.data);
+          const { id, t, k, c, a: parsedAlg } = DidDhtUtils.parseTxtDataToObject(answer.data);
 
           // Convert the public key from Base64URL format to a byte array.
           const publicKeyBytes = Convert.base64Url(k).toUint8Array();
@@ -1025,6 +1035,12 @@ export class DidDhtDocument {
 
           // Convert the public key from a byte array to JWK format.
           let publicKey = await DidDhtUtils.keyConverter(namedCurve).bytesToPublicKey({ publicKeyBytes });
+
+          // DID DHT spec requires `alg` in keys in the DID document
+          publicKey.alg = parsedAlg || getJoseSignatureAlgorithmFromPublicKey(publicKey);
+
+          // Determine the Key ID (kid): '0' for the identity key or JWK thumbprint for others.
+          publicKey.kid = dnsRecordId.endsWith('0') ? '0' : await computeJwkThumbprint({ jwk: publicKey });
 
           // Initialize the `verificationMethod` array if it does not already exist.
           didDocument.verificationMethod ??= [];
@@ -1180,6 +1196,11 @@ export class DidDhtDocument {
 
       // Define the data for the DNS TXT record.
       const txtData = [`t=${keyType}`, `k=${publicKeyBase64Url}`];
+
+      // Only set the algorithm property (`a`) if it differs from the default algorithm for the key type.
+      if(publicKey.alg !== KeyTypeToDefaultAlgorithmMap[keyType]) {
+        txtData.push(`a=${publicKey.alg}`);
+      }
 
       // Add the controller property, if set to a value other than the Identity Key (DID Subject).
       if (verificationMethod.controller !== didDocument.id) txtData.push(`c=${verificationMethod.controller}`);


### PR DESCRIPTION
This pr resolves https://github.com/TBD54566975/web5-js/issues/3 from this issue:
https://github.com/TBD54566975/web5-js/issues/497

Always set alg and kid on expansion (to the values in the registry), support overriding of alg values

toDnsPacket:
* check if the alg on the JWK == the alg in the default registry for the given key type. Otherwise add it to the txt document as `a`

fromDnsPacket:
* KID is always either 0 for the identity key or the JWK thumbprint for all other keys (no overriding it)
* the alg is always set to the default from the registry (https://did-dht.com/registry/#key-type-index) but can be overriden if you specify the alg property