### PR TITLE
split changesets so agent and api changesets are in separate files

### DIFF
--- a/.changeset/ninety-cows-hear.md
+++ b/.changeset/ninety-cows-hear.md
@@ -1,0 +1,5 @@
+---
+"@web5/api": patch
+---
+
+Add a helper methods for generating a PaginationCursor from `api` without importing `dwn-sdk-js` directly.

--- a/.changeset/odd-eels-rest.md
+++ b/.changeset/odd-eels-rest.md
@@ -3,7 +3,6 @@
 "@web5/proxy-agent": patch
 "@web5/user-agent": patch
 "@web5/agent": patch
-"@web5/api": patch
 ---
 
 Add a helper methods for generating a PaginationCursor from `api` without importing `dwn-sdk-js` directly


### PR DESCRIPTION
If we are not releasing a package, it cannot be included in the same changeset as packages which are being released.

This really only affects the `api` package which does not get released automatically.