### PR TITLE
Fixed DID DHT library regression where `kid` becomes `undefined`

### DIFF
--- a/.changeset/few-glasses-brake.md
+++ b/.changeset/few-glasses-brake.md
@@ -1,0 +1,5 @@
+---
+"@web5/dids": patch
+---
+
+Fixed DID DHT library regression where `kid` becomes `undefined`

--- a/packages/dids/src/methods/did-dht.ts
+++ b/packages/dids/src/methods/did-dht.ts
@@ -1022,7 +1022,7 @@ export class DidDhtDocument {
 
         // Process verification methods.
         case dnsRecordId.startsWith('k'): {
-          // Get the method ID fragment (id), key type (t), Base64URL-encoded public key (k), and
+          // Get the key type (t), Base64URL-encoded public key (k), and
           // optionally, controller (c) from the decoded TXT record data.
           const { t, k, c, a: parsedAlg } = DidDhtUtils.parseTxtDataToObject(answer.data);
 

--- a/packages/dids/src/methods/did-dht.ts
+++ b/packages/dids/src/methods/did-dht.ts
@@ -1024,7 +1024,7 @@ export class DidDhtDocument {
         case dnsRecordId.startsWith('k'): {
           // Get the method ID fragment (id), key type (t), Base64URL-encoded public key (k), and
           // optionally, controller (c) from the decoded TXT record data.
-          const { id, t, k, c, a: parsedAlg } = DidDhtUtils.parseTxtDataToObject(answer.data);
+          const { t, k, c, a: parsedAlg } = DidDhtUtils.parseTxtDataToObject(answer.data);
 
           // Convert the public key from Base64URL format to a byte array.
           const publicKeyBytes = Convert.base64Url(k).toUint8Array();
@@ -1038,13 +1038,14 @@ export class DidDhtDocument {
           publicKey.alg = parsedAlg || KeyTypeToDefaultAlgorithmMap[Number(t) as DidDhtRegisteredKeyType];
 
           // Determine the Key ID (kid): '0' for the identity key or JWK thumbprint for others.
-          publicKey.kid = dnsRecordId.endsWith('0') ? '0' : await computeJwkThumbprint({ jwk: publicKey });
+          const kid = dnsRecordId.endsWith('0') ? '0' : await computeJwkThumbprint({ jwk: publicKey });
+          publicKey.kid = kid;
 
           // Initialize the `verificationMethod` array if it does not already exist.
           didDocument.verificationMethod ??= [];
 
           // Prepend the DID URI to the ID fragment to form the full verification method ID.
-          const methodId = `${didUri}#${id}`;
+          const methodId = `${didUri}#${kid}`;
 
           // Add the verification method to the DID document.
           didDocument.verificationMethod.push({

--- a/packages/dids/tests/methods/did-dht.spec.ts
+++ b/packages/dids/tests/methods/did-dht.spec.ts
@@ -1172,8 +1172,9 @@ describe('DidDhtDocument', () => {
 // vectors come from https://did-dht.com/#test-vectors
 describe('Official DID:DHT Vector tests', () => {
   it('vector 1', async () => {
+    const inputDidDocument = officialTestVector1.didDocument as DidDocument;
     const dnsPacket = await DidDhtDocument.toDnsPacket({
-      didDocument : officialTestVector1.didDocument as DidDocument,
+      didDocument : inputDidDocument,
       didMetadata : { published: false }
     });
 
@@ -1181,11 +1182,19 @@ describe('Official DID:DHT Vector tests', () => {
 
     const normalizedConstructedRecords = normalizeDnsRecords(dnsPacket.answers!);
     expect(normalizedConstructedRecords).to.deep.include.members(officialTestVector1.dnsRecords);
+
+    const didResolutionResult = await DidDhtDocument.fromDnsPacket({
+      didUri    : inputDidDocument.id,
+      dnsPacket : dnsPacket
+    });
+
+    expect(didResolutionResult.didDocument).to.deep.equal(inputDidDocument);
   });
 
   it('vector 2', async () => {
+    const inputDidDocument = officialTestVector2.didDocument as DidDocument;
     const dnsPacket = await DidDhtDocument.toDnsPacket({
-      didDocument : officialTestVector2.didDocument as DidDocument,
+      didDocument : inputDidDocument,
       didMetadata : {
         published : false,
         types     : [DidDhtRegisteredDidType.Organization, DidDhtRegisteredDidType.Government, DidDhtRegisteredDidType.Corporation]
@@ -1197,6 +1206,13 @@ describe('Official DID:DHT Vector tests', () => {
 
     const normalizedConstructedRecords = normalizeDnsRecords(dnsPacket.answers!);
     expect(normalizedConstructedRecords).to.deep.include.members(officialTestVector2.dnsRecords);
+
+    const didResolutionResult = await DidDhtDocument.fromDnsPacket({
+      didUri    : inputDidDocument.id,
+      dnsPacket : dnsPacket
+    });
+
+    expect(didResolutionResult.didDocument).to.deep.equal(inputDidDocument);
   });
 });
 


### PR DESCRIPTION
1. Fixed DID DHT library regression where `kid` becomes `undefined`
1. Added tests to prevent this from happening again in vector tests.