### PR TITLE
Implement a `delete` method and state on the `@web5/api` `Record` class

### DIFF
--- a/.changeset/eighty-spoons-cross.md
+++ b/.changeset/eighty-spoons-cross.md
@@ -1,0 +1,5 @@
+---
+"@web5/api": minor
+---
+
+Implement a `delete` method and state on the `@web5/api` `Record` class

--- a/packages/api/src/record.ts
+++ b/packages/api/src/record.ts
@@ -26,19 +26,19 @@ import { Convert, isEmptyObject, NodeStream, removeUndefinedProperties, Stream }
 import { dataToBlob, SendCache } from './utils.js';
 
 /**
- * Represents Immutable Record properties
+ * Represents Immutable Record properties that cannot be changed after the record is created.
  *
  * @beta
  * */
-type ImmutableRecordProperties =
+export type ImmutableRecordProperties =
   Pick<DwnMessageDescriptor[DwnInterface.RecordsWrite], 'dateCreated' | 'parentId' | 'protocol' | 'protocolPath' | 'recipient' | 'schema'>;
 
 /**
- * Represents Optional Record properties
+ * Represents Optional Record properties that depend on the Record's current state.
  *
  * @beta
 */
-type OptionalRecordProperties =
+export type OptionalRecordProperties =
   Pick<DwnMessage[DwnInterface.RecordsWrite], 'authorization' | 'attestation' | 'encryption' | 'contextId' > &
   Pick<DwnMessageDescriptor[DwnInterface.RecordsWrite], 'dataFormat' | 'dataCid' | 'dataSize' | 'datePublished' | 'published' | 'tags'>;
 
@@ -164,8 +164,11 @@ export type RecordDeleteParams = {
 };
 
 /**
- * Record wrapper class with convenience methods to send and update,
- * aside from manipulating and reading the record data.
+ * The `Record` class encapsulates a single record's data and metadata, providing a more
+ * developer-friendly interface for working with Decentralized Web Node (DWN) records.
+ *
+ * Methods are provided to read, update, and manage the record's lifecycle, including writing to
+ * remote DWNs.
  *
  * Note: The `messageTimestamp` of the most recent RecordsWrite message is
  *       logically equivalent to the date/time at which a Record was most
@@ -173,15 +176,6 @@ export type RecordDeleteParams = {
  *       intended to simplify the developer experience of working with
  *       logical records (and not individual DWN messages) the
  *       `messageTimestamp` is mapped to `dateModified`.
- *
- * @beta
- */
-/**
- * The `Record` class encapsulates a single record's data and metadata, providing a more
- * developer-friendly interface for working with Decentralized Web Node (DWN) records.
- *
- * Methods are provided to read, update, and manage the record's lifecycle, including writing to
- * remote DWNs.
  *
  * @beta
  */

--- a/packages/api/src/record.ts
+++ b/packages/api/src/record.ts
@@ -7,29 +7,37 @@
 import type { Readable } from '@web5/common';
 import {
   Web5Agent,
+  DwnInterface,
   DwnMessage,
   DwnMessageParams,
   DwnResponseStatus,
   ProcessDwnRequest,
   DwnMessageDescriptor,
   getPaginationCursor,
+  getRecordAuthor,
   DwnDateSort,
   DwnPaginationCursor,
   isDwnMessage,
   SendDwnRequest
 } from '@web5/agent';
 
-import { DwnInterface } from '@web5/agent';
 import { Convert, isEmptyObject, NodeStream, removeUndefinedProperties, Stream } from '@web5/common';
 
 import { dataToBlob, SendCache } from './utils.js';
-import { getRecordAuthor } from '@web5/agent';
 
-/** Represents Immutable Record properties */
+/**
+ * Represents Immutable Record properties
+ *
+ * @beta
+ * */
 type ImmutableRecordProperties =
   Pick<DwnMessageDescriptor[DwnInterface.RecordsWrite], 'dateCreated' | 'parentId' | 'protocol' | 'protocolPath' | 'recipient' | 'schema'>;
 
-/** Represents Optional Record properties */
+/**
+ * Represents Optional Record properties
+ *
+ * @beta
+*/
 type OptionalRecordProperties =
   Pick<DwnMessage[DwnInterface.RecordsWrite], 'authorization' | 'attestation' | 'encryption' | 'contextId' > &
   Pick<DwnMessageDescriptor[DwnInterface.RecordsWrite], 'dataFormat' | 'dataCid' | 'dataSize' | 'datePublished' | 'published' | 'tags'>;

--- a/packages/api/src/record.ts
+++ b/packages/api/src/record.ts
@@ -632,9 +632,15 @@ export class Record implements RecordModel {
     str += this.contextId ? `  Context ID: ${this.contextId}\n` : '';
     str += this.protocol ? `  Protocol: ${this.protocol}\n` : '';
     str += this.schema ? `  Schema: ${this.schema}\n` : '';
-    str += `  Data CID: ${this.dataCid}\n`;
-    str += `  Data Format: ${this.dataFormat}\n`;
-    str += `  Data Size: ${this.dataSize}\n`;
+
+    // Only display data properties if the record has not been deleted.
+    if (!this.deleted) {
+      str += `  Data CID: ${this.dataCid}\n`;
+      str += `  Data Format: ${this.dataFormat}\n`;
+      str += `  Data Size: ${this.dataSize}\n`;
+    }
+
+    str += `  Deleted: ${this.deleted}\n`;
     str += `  Created: ${this.dateCreated}\n`;
     str += `  Modified: ${this.dateModified}\n`;
     str += `}`;

--- a/packages/api/src/record.ts
+++ b/packages/api/src/record.ts
@@ -25,10 +25,12 @@ import { Convert, isEmptyObject, NodeStream, removeUndefinedProperties, Stream }
 import { dataToBlob, SendCache } from './utils.js';
 import { getRecordAuthor } from '@web5/agent';
 
-export type ImmutableRecordProperties =
+/** Represents Immutable Record properties */
+type ImmutableRecordProperties =
   Pick<DwnMessageDescriptor[DwnInterface.RecordsWrite], 'dateCreated' | 'parentId' | 'protocol' | 'protocolPath' | 'recipient' | 'schema'>;
 
-export type OptionalRecordProperties =
+/** Represents Optional Record properties */
+type OptionalRecordProperties =
   Pick<DwnMessage[DwnInterface.RecordsWrite], 'authorization' | 'attestation' | 'encryption' | 'contextId' > &
   Pick<DwnMessageDescriptor[DwnInterface.RecordsWrite], 'dataFormat' | 'dataCid' | 'dataSize' | 'datePublished' | 'published' | 'tags'>;
 
@@ -221,7 +223,7 @@ export class Record implements RecordModel {
   private _protocolRole?: RecordOptions['protocolRole'];
 
   /** The `RecordsWriteMessage` descriptor unless the record is in a deleted state */
-  get _recordsWriteDescriptor() {
+  private get _recordsWriteDescriptor() {
     if (isDwnMessage(DwnInterface.RecordsWrite, this.rawMessage)) {
       return this._descriptor as DwnMessageDescriptor[DwnInterface.RecordsWrite];
     }
@@ -229,7 +231,8 @@ export class Record implements RecordModel {
     return undefined; // returns undefined if the descriptor does not represent a RecordsWrite message.
   }
 
-  get _immutableProperties(): ImmutableRecordProperties {
+  /** The `RecordsWrite` descriptor from the current record or the initial write if the record is in a delete state. */
+  private get _immutableProperties(): ImmutableRecordProperties {
     return this._recordsWriteDescriptor || this._initialWrite.descriptor;
   }
 

--- a/packages/api/src/record.ts
+++ b/packages/api/src/record.ts
@@ -285,7 +285,7 @@ export class Record implements RecordModel {
 
 
   // Getters for for properties that depend on the current state of the Record.
-  /** DID that signed the record. */
+  /** DID that is the logical author of the Record. */
   get author(): string { return this._author; }
 
   /** Record's modified date */

--- a/packages/api/tests/record.spec.ts
+++ b/packages/api/tests/record.spec.ts
@@ -2031,8 +2031,6 @@ describe('Record', () => {
       expect(record.attestation).to.have.property('signatures');
 
       // Retained RecordsWriteDescriptor properties.
-      expect(recordJson.interface).to.equal('Records');
-      expect(recordJson.method).to.equal('Write');
       expect(recordJson.protocol).to.equal(protocol);
       expect(recordJson.protocolPath).to.equal(protocolPath);
       expect(recordJson.recipient).to.equal(recipient);

--- a/packages/api/tests/record.spec.ts
+++ b/packages/api/tests/record.spec.ts
@@ -2049,6 +2049,88 @@ describe('Record', () => {
     });
   });
 
+  describe('toString()', () => {
+    it('should return a string representation of the record', async () => {
+      // install a protocol to use for the record
+      let { protocol: aliceProtocol, status: aliceStatus } = await dwnAlice.protocols.configure({
+        message: {
+          definition: emailProtocolDefinition,
+        }
+      });
+      expect(aliceStatus.code).to.equal(202);
+      expect(aliceProtocol).to.exist;
+
+      // create a record
+      const { record, status } = await dwnAlice.records.write({
+        data    : 'Hello, world!',
+        message : {
+          protocol     : emailProtocolDefinition.protocol,
+          protocolPath : 'thread',
+          schema       : emailProtocolDefinition.types.thread.schema,
+          dataFormat   : 'text/plain'
+        }
+      });
+      expect(status.code).to.equal(202);
+
+      const recordString = record!.toString();
+      expect(recordString).to.be.a('string');
+      expect(recordString).to.contain(`ID: ${record.id}`);
+      expect(recordString).to.contain(`Context ID: ${record.contextId}`);
+      expect(recordString).to.contain(`Protocol: ${record.protocol}`);
+      expect(recordString).to.contain(`Schema : ${record.schema}`);
+      expect(recordString).to.contain(`Deleted: ${false}`); // record is not deleted
+      expect(recordString).to.contain(`Created: ${record.dateCreated}`);
+      expect(recordString).to.contain(`Modified: ${record.dateModified}`);
+
+      // data related properties
+      expect(recordString).to.contain(`Data CID: ${record.dataCid}`);
+      expect(recordString).to.contain(`Data Format: ${record.dataFormat}`);
+      expect(recordString).to.contain(`Data Size: ${record.dataSize}`);
+    });
+
+    it('should return a string representation of the record in a deleted state', async () => {
+      // install a protocol to use for the record
+      let { protocol: aliceProtocol, status: aliceStatus } = await dwnAlice.protocols.configure({
+        message: {
+          definition: emailProtocolDefinition,
+        }
+      });
+      expect(aliceStatus.code).to.equal(202);
+      expect(aliceProtocol).to.exist;
+
+      // create a record
+      const { record, status } = await dwnAlice.records.write({
+        data    : 'Hello, world!',
+        message : {
+          protocol     : emailProtocolDefinition.protocol,
+          protocolPath : 'thread',
+          schema       : emailProtocolDefinition.types.thread.schema,
+          dataFormat   : 'text/plain'
+        }
+      });
+      expect(status.code).to.equal(202);
+
+      // delete the record
+      const { status: deleteStatus } = await record!.delete();
+      expect(deleteStatus.code).to.equal(202);
+
+      const recordString = record!.toString();
+      expect(recordString).to.be.a('string');
+      expect(recordString).to.contain(`ID: ${record.id}`);
+      expect(recordString).to.contain(`Context ID: ${record.contextId}`);
+      expect(recordString).to.contain(`Protocol: ${record.protocol}`);
+      expect(recordString).to.contain(`Schema : ${record.schema}`);
+      expect(recordString).to.contain(`Deleted: ${true}`); // record is deleted
+      expect(recordString).to.contain(`Created: ${record.dateCreated}`);
+      expect(recordString).to.contain(`Modified: ${record.dateModified}`);
+
+      // data related properties
+      expect(recordString).to.not.contain('Data CID');
+      expect(recordString).to.not.contain('Data Format');
+      expect(recordString).to.not.contain('Data Size');
+    });
+  });
+
   describe('update()', () => {
     it('updates a local record on the local DWN', async () => {
       const { status, record } = await dwnAlice.records.write({


### PR DESCRIPTION
This PR Allows a `Record` class to include a `deleted` state based on a `RecordsDeleteMessage` being applied to it.

We update the `RecordModel` to reflect the immutable properties that a record may contain, as well as the optional mutable properties that are only relevant to a record that is in a non-deleted state.

When a record is in a deleted state, it derives the immutable properties from the `initialWrite` of that record.

Currently when dealing with a remote DWN, the user cannot be notified of a deleted state through a Query, however when Subscriptions are brought up to the API a user could receive a message from the remote which signals that the record has been deleted, more useful scenario testing will be implemented when `record.subscribe()` feature is added.

- Implements a `delete()` method on the `Record` class that behaves similarly to `update()`.
- Implements a `deleted` property on the `Record` class to indicate if the record is in a deleted state.