### PR TITLE
Update `@web5/agent` to consume `dwn-sdk-js` `v0.3.5`

### DIFF
--- a/.changeset/fresh-mayflies-cross.md
+++ b/.changeset/fresh-mayflies-cross.md
@@ -1,0 +1,10 @@
+---
+"@web5/api": patch
+---
+
+Update `@web5/api` to the latest `@web5/agent` `v0.3.7`
+
+Includes upgrade to `dwn-sdk-js`@`v0.3.5`
+
+Features:
+ - Ability to apply the `prune` property to a `RecordsWriteDelete`

--- a/.changeset/tough-numbers-notice.md
+++ b/.changeset/tough-numbers-notice.md
@@ -1,0 +1,8 @@
+---
+"@web5/identity-agent": patch
+"@web5/proxy-agent": patch
+"@web5/user-agent": patch
+"@web5/agent": patch
+---
+
+Upgrade `dwn-sdk-js` to `v0.3.5`

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@changesets/cli": "^2.27.1",
     "@npmcli/package-json": "5.0.0",
     "@typescript-eslint/eslint-plugin": "7.9.0",
-    "@web5/dwn-server": "0.2.2",
+    "@web5/dwn-server": "0.2.3",
     "eslint-plugin-mocha": "10.4.3",
     "npkill": "0.11.3"
   },

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -71,10 +71,10 @@
   "dependencies": {
     "@noble/ciphers": "0.4.1",
     "@scure/bip39": "1.2.2",
-    "@tbd54566975/dwn-sdk-js": "0.3.2",
+    "@tbd54566975/dwn-sdk-js": "0.3.5",
     "@web5/common": "1.0.0",
     "@web5/crypto": "1.0.0",
-    "@web5/dids": "1.0.1",
+    "@web5/dids": "1.1.0",
     "abstract-level": "1.0.4",
     "ed25519-keygen": "0.4.11",
     "isomorphic-ws": "^5.0.0",

--- a/packages/agent/src/utils.ts
+++ b/packages/agent/src/utils.ts
@@ -1,11 +1,10 @@
 import type { DidUrlDereferencer } from '@web5/dids';
-import type { PaginationCursor, RecordsWriteMessage } from '@tbd54566975/dwn-sdk-js';
+import type { PaginationCursor, RecordsDeleteMessage, RecordsWriteMessage } from '@tbd54566975/dwn-sdk-js';
 
-import { DateSort } from '@tbd54566975/dwn-sdk-js';
 import { Readable } from '@web5/common';
 import { utils as didUtils } from '@web5/dids';
 import { ReadableWebToNodeStream } from 'readable-web-to-node-stream';
-import { DwnInterfaceName, DwnMethodName, Message, RecordsWrite } from '@tbd54566975/dwn-sdk-js';
+import { DateSort, DwnInterfaceName, DwnMethodName, Message, Records, RecordsWrite } from '@tbd54566975/dwn-sdk-js';
 
 export function blobToIsomorphicNodeReadable(blob: Blob): Readable {
   return webReadableToIsomorphicNodeReadable(blob.stream() as ReadableStream<any>);
@@ -39,8 +38,8 @@ export async function getDwnServiceEndpointUrls(didUri: string, dereferencer: Di
   return [];
 }
 
-export function getRecordAuthor(record: RecordsWriteMessage): string | undefined {
-  return RecordsWrite.getAuthor(record);
+export function getRecordAuthor(record: RecordsWriteMessage | RecordsDeleteMessage): string | undefined {
+  return Records.getAuthor(record);
 }
 
 export function isRecordsWrite(obj: unknown): obj is RecordsWrite {

--- a/packages/agent/tests/utils.spec.ts
+++ b/packages/agent/tests/utils.spec.ts
@@ -69,12 +69,19 @@ describe('Utils', () => {
 
   describe('getRecordAuthor', () => {
     it('should get the author of a RecordsWriteMessage', async () => {
-      // create a RecordWriteMessage object
-      const { message, author } = await TestDataGenerator.generateRecordsWrite();
+      // create a RecordsWriteMessage object
+      const { message: recordsWriteMessage, author: recordsWriteAuthor } = await TestDataGenerator.generateRecordsWrite();
 
-      const authorFromFunction = getRecordAuthor(message);
-      expect(authorFromFunction).to.not.be.undefined;
-      expect(authorFromFunction!).to.equal(author.did);
+      const writeAuthorFromFunction = getRecordAuthor(recordsWriteMessage);
+      expect(writeAuthorFromFunction).to.not.be.undefined;
+      expect(writeAuthorFromFunction!).to.equal(recordsWriteAuthor.did);
+
+      // create a RecordsDeleteMessage
+      const { message: recordsDeleteMessage, author: recordsDeleteAuthor } = await TestDataGenerator.generateRecordsDelete();
+
+      const deleteAuthorFromFunction = getRecordAuthor(recordsDeleteMessage);
+      expect(deleteAuthorFromFunction).to.not.be.undefined;
+      expect(deleteAuthorFromFunction!).to.equal(recordsDeleteAuthor.did);
     });
   });
 });

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -77,11 +77,11 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
-    "@web5/agent": "0.3.6",
+    "@web5/agent": "0.3.7",
     "@web5/common": "1.0.0",
     "@web5/crypto": "1.0.0",
-    "@web5/dids": "1.0.1",
-    "@web5/user-agent": "0.3.6"
+    "@web5/dids": "1.1.0",
+    "@web5/user-agent": "0.3.7"
   },
   "devDependencies": {
     "@playwright/test": "1.40.1",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -85,7 +85,7 @@
   },
   "devDependencies": {
     "@playwright/test": "1.40.1",
-    "@tbd54566975/dwn-sdk-js": "0.3.2",
+    "@tbd54566975/dwn-sdk-js": "0.3.5",
     "@types/chai": "4.3.6",
     "@types/eslint": "8.56.10",
     "@types/mocha": "10.0.1",

--- a/packages/api/tests/dwn-api.spec.ts
+++ b/packages/api/tests/dwn-api.spec.ts
@@ -594,9 +594,9 @@ describe('DwnApi', () => {
         const { status: protocolStatus, protocol } = await dwnAlice.protocols.configure({
           message: {
             definition: {
-              protocol: 'http://example.com/parent-child',
-              published: true,
-              types: {
+              protocol  : 'http://example.com/parent-child',
+              published : true,
+              types     : {
                 foo: {
                   schema: 'http://example.com/foo',
                 },
@@ -631,11 +631,11 @@ describe('DwnApi', () => {
         const { status: childWriteStatus, record: childRecord } = await dwnAlice.records.write({
           data    : 'Hello, world!',
           message : {
-            protocol     : protocol.definition.protocol,
-            protocolPath : 'foo/bar',
-            schema       : 'http://example.com/bar',
-            dataFormat   : 'text/plain',
-            parentContextId: parentRecord.contextId
+            protocol        : protocol.definition.protocol,
+            protocolPath    : 'foo/bar',
+            schema          : 'http://example.com/bar',
+            dataFormat      : 'text/plain',
+            parentContextId : parentRecord.contextId
           }
         });
         expect(childWriteStatus.code).to.equal(202);

--- a/packages/api/tests/record.spec.ts
+++ b/packages/api/tests/record.spec.ts
@@ -2107,7 +2107,7 @@ describe('Record', () => {
       // fails because record has not been stored in the local dwn yet
       let updateResult = await record!.update({ data: 'bye' });
       expect(updateResult.status.code).to.equal(400);
-      expect(updateResult.status.detail).to.equal('RecordsWriteGetInitialWriteNotFound: initial write is not found');
+      expect(updateResult.status.detail).to.equal('RecordsWriteGetInitialWriteNotFound: Initial write is not found.');
 
       const { status: recordStoreStatus }=  await record.store();
       expect(recordStoreStatus.code).to.equal(202);
@@ -2235,7 +2235,7 @@ describe('Record', () => {
       const [ queriedRecord ] = queryResult.records;
       let updateResult = await queriedRecord!.update({ data: 'bye' });
       expect(updateResult.status.code).to.equal(400);
-      expect(updateResult.status.detail).to.equal('RecordsWriteGetInitialWriteNotFound: initial write is not found');
+      expect(updateResult.status.detail).to.equal('RecordsWriteGetInitialWriteNotFound: Initial write is not found.');
 
       // store the queried record
       const { status: queriedStoreStatus } = await queriedRecord.store();

--- a/packages/dev-env/docker-compose.yaml
+++ b/packages/dev-env/docker-compose.yaml
@@ -3,6 +3,6 @@ version: "3.98"
 services:
   dwn-server:
     container_name: dwn-server
-    image: ghcr.io/tbd54566975/dwn-server:dwn-sdk-0.3.2
+    image: ghcr.io/tbd54566975/dwn-server:dwn-sdk-0.3.5
     ports:
       - "3000:3000"

--- a/packages/identity-agent/package.json
+++ b/packages/identity-agent/package.json
@@ -72,7 +72,7 @@
     "@web5/agent": "0.3.7",
     "@web5/common": "1.0.0",
     "@web5/crypto": "1.0.0",
-    "@web5/dids": "1.0.1"
+    "@web5/dids": "1.1.0"
   },
   "devDependencies": {
     "@playwright/test": "1.40.1",

--- a/packages/proxy-agent/package.json
+++ b/packages/proxy-agent/package.json
@@ -72,7 +72,7 @@
     "@web5/agent": "0.3.7",
     "@web5/common": "1.0.0",
     "@web5/crypto": "1.0.0",
-    "@web5/dids": "1.0.1"
+    "@web5/dids": "1.1.0"
   },
   "devDependencies": {
     "@playwright/test": "1.40.1",

--- a/packages/user-agent/package.json
+++ b/packages/user-agent/package.json
@@ -72,7 +72,7 @@
     "@web5/agent": "0.3.7",
     "@web5/common": "1.0.0",
     "@web5/crypto": "1.0.0",
-    "@web5/dids": "1.0.1"
+    "@web5/dids": "1.1.0"
   },
   "devDependencies": {
     "@playwright/test": "1.40.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -151,8 +151,8 @@ importers:
   packages/api:
     dependencies:
       '@web5/agent':
-        specifier: 0.3.6
-        version: 0.3.6(ws@8.17.0)
+        specifier: 0.3.7
+        version: link:../agent
       '@web5/common':
         specifier: 1.0.0
         version: 1.0.0
@@ -160,11 +160,11 @@ importers:
         specifier: 1.0.0
         version: 1.0.0
       '@web5/dids':
-        specifier: 1.0.1
-        version: 1.0.1
+        specifier: 1.1.0
+        version: link:../dids
       '@web5/user-agent':
-        specifier: 0.3.6
-        version: 0.3.6(ws@8.17.0)
+        specifier: 0.3.7
+        version: link:../user-agent
     devDependencies:
       '@playwright/test':
         specifier: 1.40.1
@@ -1696,6 +1696,7 @@ packages:
       multiformats: 12.1.3
       multihashes: 4.0.3
       uri-js: 4.4.1
+    dev: true
 
   /@decentralized-identity/ion-sdk@1.0.4:
     resolution: {integrity: sha512-pOWrlTH5ChxUKRHOgfG2ZeTioWEFJXADyErCQOJ0BqYNDKfP+CM09Vss+9ei6PNOABQlcDn0mEDFZtpO+DXl8A==}
@@ -2333,6 +2334,7 @@ packages:
 
   /@multiformats/base-x@4.0.1:
     resolution: {integrity: sha512-eMk0b9ReBbV23xXU693TAIrLyeO5iTgBZGSJfpqriG8UkYvr/hC9u9pyMlAakDNHWmbhMZCDs6KQO0jzKD8OTw==}
+    dev: true
 
   /@multiformats/murmur3@2.1.8:
     resolution: {integrity: sha512-6vId1C46ra3R1sbJUOFCZnsUIveR9oF20yhPmAFxPm0JfrX3/ZRCgP3YDrBzlGoEppOXnA9czHeYc0T9mB6hbA==}
@@ -3141,6 +3143,7 @@ packages:
     transitivePeerDependencies:
       - encoding
       - supports-color
+    dev: true
 
   /@tbd54566975/dwn-sdk-js@0.3.5:
     resolution: {integrity: sha512-1OZFxZSSpMpA186wqPOMbvhE7GJAZ5agVjGusC2KF2FQ4HxM26nlW6ZVigYVnfN/ddrrrey3t3hE7BiGQ9m2yg==}
@@ -4255,29 +4258,6 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@web5/agent@0.3.6(ws@8.17.0):
-    resolution: {integrity: sha512-uA78pIKiEjF++fJWviH/BncTdM4o2vL/QcO4X5jItrx5rmXWDh48tmRb318RzA3RSLvs4ab+AvvFTyWnatIU3A==}
-    engines: {node: '>=18.0.0'}
-    dependencies:
-      '@noble/ciphers': 0.4.1
-      '@scure/bip39': 1.2.2
-      '@tbd54566975/dwn-sdk-js': 0.3.2
-      '@web5/common': 1.0.0
-      '@web5/crypto': 1.0.0
-      '@web5/dids': 1.0.1
-      abstract-level: 1.0.4
-      ed25519-keygen: 0.4.11
-      isomorphic-ws: 5.0.0(ws@8.17.0)
-      level: 8.0.0
-      ms: 2.1.3
-      readable-web-to-node-stream: 3.0.2
-      ulidx: 2.1.0
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
-      - ws
-    dev: false
-
   /@web5/common@1.0.0:
     resolution: {integrity: sha512-3JHF6X5o0h+3oAVQeBC4XpMoZeEYZYdEmQdgpOfKv/rnSru2yHQSAM+0wbIvEFcSCmelBT3u7rUAcpJjelLB0w==}
     engines: {node: '>=18.0.0'}
@@ -4309,6 +4289,7 @@ packages:
       buffer: 6.0.3
       level: 8.0.0
       ms: 2.1.3
+    dev: true
 
   /@web5/dids@1.0.3:
     resolution: {integrity: sha512-XRqONYJg/uZmMpYMX2hNvdYWrlNgy8/wiKApzTRGausgiefXfkDSpBpYzGKThADBeim5Q6RTnS0VnSza4QeGEg==}
@@ -4370,20 +4351,6 @@ packages:
       - supports-color
       - utf-8-validate
     dev: true
-
-  /@web5/user-agent@0.3.6(ws@8.17.0):
-    resolution: {integrity: sha512-dBWp5c6jseFZ7p1T4h2+N6nKb9dWcJTWx12M9+fYnxBJWOOjSzvkqMsdxTD1C903+QO2rVAfRto6GO/4avfd8A==}
-    engines: {node: '>=18.0.0'}
-    dependencies:
-      '@web5/agent': 0.3.6(ws@8.17.0)
-      '@web5/common': 1.0.0
-      '@web5/crypto': 1.0.0
-      '@web5/dids': 1.0.1
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
-      - ws
-    dev: false
 
   /@webassemblyjs/ast@1.11.6:
     resolution: {integrity: sha512-IN1xI7PwOvLPgjcf180gC1bqn3q/QaOCwYUahIOhbYUu8KA/3tw2RT/T0Gidi1l7Hhj5D/INhJxiICObqpMu4Q==}
@@ -8239,6 +8206,7 @@ packages:
     deprecated: This module has been superseded by the multiformats module
     dependencies:
       '@multiformats/base-x': 4.0.1
+    dev: true
 
   /multiformats@11.0.2:
     resolution: {integrity: sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==}
@@ -8258,6 +8226,7 @@ packages:
 
   /multiformats@9.9.0:
     resolution: {integrity: sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==}
+    dev: true
 
   /multihashes@4.0.3:
     resolution: {integrity: sha512-0AhMH7Iu95XjDLxIeuCOOE4t9+vQZsACyKZ9Fxw2pcsRmlX4iCn1mby0hS0bb+nQOVpdQYWPpnyusw4da5RPhA==}
@@ -8266,6 +8235,7 @@ packages:
       multibase: 4.0.6
       uint8arrays: 3.1.1
       varint: 5.0.2
+    dev: true
 
   /murmurhash3js-revisited@3.0.0:
     resolution: {integrity: sha512-/sF3ee6zvScXMb1XFJ8gDsSnY+X8PbOyjIuBhtgis10W2Jx4ZjIhikUCIF9c4gpJxVnQIsPAFrSwTCuAjicP6g==}
@@ -10422,6 +10392,7 @@ packages:
     resolution: {integrity: sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==}
     dependencies:
       multiformats: 9.9.0
+    dev: true
 
   /uint8arrays@4.0.10:
     resolution: {integrity: sha512-AnJNUGGDJAgFw/eWu/Xb9zrVKEGlwJJCaeInlf3BkecE/zcTobk5YXYIPNQJO1q5Hh1QZrQQHf0JvcHqz2hqoA==}
@@ -10560,6 +10531,7 @@ packages:
 
   /varint@5.0.2:
     resolution: {integrity: sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow==}
+    dev: true
 
   /varint@6.0.0:
     resolution: {integrity: sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: 7.9.0
         version: 7.9.0(@typescript-eslint/parser@7.10.0)(eslint@8.57.0)(typescript@5.4.5)
       '@web5/dwn-server':
-        specifier: 0.2.2
-        version: 0.2.2
+        specifier: 0.2.3
+        version: 0.2.3
       eslint-plugin-mocha:
         specifier: 10.4.3
         version: 10.4.3(eslint@8.57.0)
@@ -42,8 +42,8 @@ importers:
         specifier: 1.2.2
         version: 1.2.2
       '@tbd54566975/dwn-sdk-js':
-        specifier: 0.3.2
-        version: 0.3.2
+        specifier: 0.3.5
+        version: 0.3.5
       '@web5/common':
         specifier: 1.0.0
         version: 1.0.0
@@ -51,8 +51,8 @@ importers:
         specifier: 1.0.0
         version: 1.0.0
       '@web5/dids':
-        specifier: 1.0.1
-        version: 1.0.1
+        specifier: 1.1.0
+        version: link:../dids
       abstract-level:
         specifier: 1.0.4
         version: 1.0.4
@@ -706,8 +706,8 @@ importers:
         specifier: 1.0.0
         version: 1.0.0
       '@web5/dids':
-        specifier: 1.0.1
-        version: 1.0.1
+        specifier: 1.1.0
+        version: link:../dids
     devDependencies:
       '@playwright/test':
         specifier: 1.40.1
@@ -794,8 +794,8 @@ importers:
         specifier: 1.0.0
         version: 1.0.0
       '@web5/dids':
-        specifier: 1.0.1
-        version: 1.0.1
+        specifier: 1.1.0
+        version: link:../dids
     devDependencies:
       '@playwright/test':
         specifier: 1.40.1
@@ -879,8 +879,8 @@ importers:
         specifier: 1.0.0
         version: 1.0.0
       '@web5/dids':
-        specifier: 1.0.1
-        version: 1.0.1
+        specifier: 1.1.0
+        version: link:../dids
     devDependencies:
       '@playwright/test':
         specifier: 1.40.1
@@ -1705,7 +1705,6 @@ packages:
       canonicalize: 2.0.0
       multiformats: 12.1.3
       uri-js: 4.4.1
-    dev: false
 
   /@dnsquery/dns-packet@6.1.1:
     resolution: {integrity: sha512-WXTuFvL3G+74SchFAtz3FgIYVOe196ycvGsMgvSH/8Goptb1qpIQtIuM4SOK9G9lhMWYpHxnXyy544ZhluFOew==}
@@ -2347,6 +2346,9 @@ packages:
 
   /@noble/ciphers@0.4.1:
     resolution: {integrity: sha512-QCOA9cgf3Rc33owG0AYBB9wszz+Ul2kramWN8tXG44Gyciud/tbkEqvxRF/IpqQaBpRBNi9f4jdNxqB2CQCIXg==}
+
+  /@noble/ciphers@0.5.3:
+    resolution: {integrity: sha512-B0+6IIHiqEs3BPMT0hcRmHvEj2QHOLu+uwt+tqDDeVd0oyVzh7BPrDcPjRnV1PV/5LaknXJJQvOuRGR0zQJz+w==}
 
   /@noble/curves@1.3.0:
     resolution: {integrity: sha512-t01iSXPuN+Eqzb4eBX0S5oubSqXbK/xXa1Ne18Hj8f9pStxztHCE2gfboSp/dZRLSqfuLpRK2nDXDK+W9puocA==}
@@ -3140,12 +3142,45 @@ packages:
       - encoding
       - supports-color
 
-  /@tbd54566975/dwn-sql-store@0.4.2:
-    resolution: {integrity: sha512-KdLk5PUaAuONr/xLOQN6LSVwVV/JQ3kn7ozlj74f9MRoBjL2iIiowCocCe6sAhzKCYmrT+xSdYP+M3e9moJ6Yw==}
+  /@tbd54566975/dwn-sdk-js@0.3.5:
+    resolution: {integrity: sha512-1OZFxZSSpMpA186wqPOMbvhE7GJAZ5agVjGusC2KF2FQ4HxM26nlW6ZVigYVnfN/ddrrrey3t3hE7BiGQ9m2yg==}
+    engines: {node: '>= 18'}
+    dependencies:
+      '@ipld/dag-cbor': 9.0.3
+      '@js-temporal/polyfill': 0.4.4
+      '@noble/ciphers': 0.5.3
+      '@noble/ed25519': 2.0.0
+      '@noble/secp256k1': 2.0.0
+      '@web5/dids': 1.1.0
+      abstract-level: 1.0.3
+      ajv: 8.12.0
+      blockstore-core: 4.2.0
+      cross-fetch: 4.0.0
+      eciesjs: 0.4.5
+      interface-blockstore: 5.2.3
+      interface-store: 5.1.2
+      ipfs-unixfs-exporter: 13.1.5
+      ipfs-unixfs-importer: 15.1.5
+      level: 8.0.0
+      lodash: 4.17.21
+      lru-cache: 9.1.2
+      ms: 2.1.3
+      multiformats: 11.0.2
+      randombytes: 2.1.0
+      readable-stream: 4.5.2
+      ulidx: 2.1.0
+      uuid: 8.3.2
+      varint: 6.0.0
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  /@tbd54566975/dwn-sql-store@0.4.5:
+    resolution: {integrity: sha512-e0m6zs5JRXzz5maRqrP6XxkdWSIqCd8F4OHZZ9liWUms6fkQA04Tfb9pwVDW/CzvbV5ld91goHtNHwJc6gSRFQ==}
     engines: {node: '>=18'}
     dependencies:
       '@ipld/dag-cbor': 9.2.0
-      '@tbd54566975/dwn-sdk-js': 0.3.2
+      '@tbd54566975/dwn-sdk-js': 0.3.5
       kysely: 0.26.3
       multiformats: 12.0.1
       readable-stream: 4.4.2
@@ -4290,12 +4325,26 @@ packages:
       ms: 2.1.3
     dev: false
 
-  /@web5/dwn-server@0.2.2:
-    resolution: {integrity: sha512-jUd02x1aWvDFVzOdi1KFfB816fMmOJSM9lPY1hi4uFww8r7sx3YU00LH5q+/odJXM3FDwHTX8yDncL8GS9xQEg==}
+  /@web5/dids@1.1.0:
+    resolution: {integrity: sha512-d9pKf/DW+ziUiV5g3McC71utyAhQyT1tYGPbQSYWt2ji6FHGNC6tffHMfLXXK/W+vbwV3eNTn06JqTXRaYhxBA==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@decentralized-identity/ion-sdk': 1.0.4
+      '@dnsquery/dns-packet': 6.1.1
+      '@web5/common': 1.0.0
+      '@web5/crypto': 1.0.0
+      abstract-level: 1.0.4
+      bencode: 4.0.0
+      buffer: 6.0.3
+      level: 8.0.1
+      ms: 2.1.3
+
+  /@web5/dwn-server@0.2.3:
+    resolution: {integrity: sha512-aVcWdegkbdijvwi9HbteuqtUsIA4qYgrR635lTWHjFN306u2MvsvFIR69miwOMALolw5PFHx6nRHnGlStQWZBg==}
     hasBin: true
     dependencies:
-      '@tbd54566975/dwn-sdk-js': 0.3.2
-      '@tbd54566975/dwn-sql-store': 0.4.2
+      '@tbd54566975/dwn-sdk-js': 0.3.5
+      '@tbd54566975/dwn-sql-store': 0.4.5
       better-sqlite3: 8.7.0
       body-parser: 1.20.2
       bytes: 3.1.2
@@ -7695,7 +7744,6 @@ packages:
       abstract-level: 1.0.4
       browser-level: 1.0.1
       classic-level: 1.4.1
-    dev: false
 
   /levn@0.3.0:
     resolution: {integrity: sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -170,8 +170,8 @@ importers:
         specifier: 1.40.1
         version: 1.40.1
       '@tbd54566975/dwn-sdk-js':
-        specifier: 0.3.2
-        version: 0.3.2
+        specifier: 0.3.5
+        version: 0.3.5
       '@types/chai':
         specifier: 4.3.6
         version: 4.3.6
@@ -1687,17 +1687,6 @@ packages:
       prettier: 2.8.8
     dev: true
 
-  /@decentralized-identity/ion-sdk@1.0.1:
-    resolution: {integrity: sha512-+P+DXcRSFjsEsI5KIqUmVjpzgUT28B2lWpTO+IxiBcfibAN/1Sg20NebGTO/+serz2CnSZf95N2a1OZ6eXypGQ==}
-    dependencies:
-      '@noble/ed25519': 2.0.0
-      '@noble/secp256k1': 2.0.0
-      canonicalize: 2.0.0
-      multiformats: 12.1.3
-      multihashes: 4.0.3
-      uri-js: 4.4.1
-    dev: true
-
   /@decentralized-identity/ion-sdk@1.0.4:
     resolution: {integrity: sha512-pOWrlTH5ChxUKRHOgfG2ZeTioWEFJXADyErCQOJ0BqYNDKfP+CM09Vss+9ei6PNOABQlcDn0mEDFZtpO+DXl8A==}
     dependencies:
@@ -2330,10 +2319,6 @@ packages:
       fs-extra: 8.1.0
       globby: 11.1.0
       read-yaml-file: 1.1.0
-    dev: true
-
-  /@multiformats/base-x@4.0.1:
-    resolution: {integrity: sha512-eMk0b9ReBbV23xXU693TAIrLyeO5iTgBZGSJfpqriG8UkYvr/hC9u9pyMlAakDNHWmbhMZCDs6KQO0jzKD8OTw==}
     dev: true
 
   /@multiformats/murmur3@2.1.8:
@@ -3110,39 +3095,6 @@ packages:
     dependencies:
       '@sd-jwt/decode': 0.6.1
       jwt-decode: 3.1.2
-    dev: true
-
-  /@tbd54566975/dwn-sdk-js@0.3.2:
-    resolution: {integrity: sha512-MMBau0Snkfnw4pCyBAzOneniUPVOBD1+m/Wj5rVgkDJNPIRkbFMcJ7auEmc4Pm0w+7pgm/ToPXDaSix+2Qob1w==}
-    engines: {node: '>= 18'}
-    dependencies:
-      '@ipld/dag-cbor': 9.0.3
-      '@js-temporal/polyfill': 0.4.4
-      '@noble/ed25519': 2.0.0
-      '@noble/secp256k1': 2.0.0
-      '@web5/dids': 1.0.1
-      abstract-level: 1.0.3
-      ajv: 8.12.0
-      blockstore-core: 4.2.0
-      cross-fetch: 4.0.0
-      eciesjs: 0.4.5
-      interface-blockstore: 5.2.3
-      interface-store: 5.1.2
-      ipfs-unixfs-exporter: 13.1.5
-      ipfs-unixfs-importer: 15.1.5
-      level: 8.0.0
-      lodash: 4.17.21
-      lru-cache: 9.1.2
-      ms: 2.1.3
-      multiformats: 11.0.2
-      randombytes: 2.1.0
-      readable-stream: 4.5.2
-      ulidx: 2.1.0
-      uuid: 8.3.2
-      varint: 6.0.0
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
     dev: true
 
   /@tbd54566975/dwn-sdk-js@0.3.5:
@@ -4275,21 +4227,6 @@ packages:
       '@noble/curves': 1.3.0
       '@noble/hashes': 1.3.3
       '@web5/common': 1.0.0
-
-  /@web5/dids@1.0.1:
-    resolution: {integrity: sha512-bAc+zwTDPvtFtd8T25XD0oUmSOBmeTpYSZyBz9w/EqZPKtZOFSc5oFS5qLtrh4YDkkcBqTG5ENQlE9fXs56zIQ==}
-    engines: {node: '>=18.0.0'}
-    dependencies:
-      '@decentralized-identity/ion-sdk': 1.0.1
-      '@dnsquery/dns-packet': 6.1.1
-      '@web5/common': 1.0.0
-      '@web5/crypto': 1.0.0
-      abstract-level: 1.0.4
-      bencode: 4.0.0
-      buffer: 6.0.3
-      level: 8.0.0
-      ms: 2.1.3
-    dev: true
 
   /@web5/dids@1.0.3:
     resolution: {integrity: sha512-XRqONYJg/uZmMpYMX2hNvdYWrlNgy8/wiKApzTRGausgiefXfkDSpBpYzGKThADBeim5Q6RTnS0VnSza4QeGEg==}
@@ -8200,14 +8137,6 @@ packages:
   /ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  /multibase@4.0.6:
-    resolution: {integrity: sha512-x23pDe5+svdLz/k5JPGCVdfn7Q5mZVMBETiC+ORfO+sor9Sgs0smJzAjfTbM5tckeCqnaUuMYoz+k3RXMmJClQ==}
-    engines: {node: '>=12.0.0', npm: '>=6.0.0'}
-    deprecated: This module has been superseded by the multiformats module
-    dependencies:
-      '@multiformats/base-x': 4.0.1
-    dev: true
-
   /multiformats@11.0.2:
     resolution: {integrity: sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==}
     engines: {node: '>=16.0.0', npm: '>=7.0.0'}
@@ -8223,19 +8152,6 @@ packages:
 
   /multiformats@13.1.0:
     resolution: {integrity: sha512-HzdtdBwxsIkzpeXzhQ5mAhhuxcHbjEHH+JQoxt7hG/2HGFjjwyolLo7hbaexcnhoEuV4e0TNJ8kkpMjiEYY4VQ==}
-
-  /multiformats@9.9.0:
-    resolution: {integrity: sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==}
-    dev: true
-
-  /multihashes@4.0.3:
-    resolution: {integrity: sha512-0AhMH7Iu95XjDLxIeuCOOE4t9+vQZsACyKZ9Fxw2pcsRmlX4iCn1mby0hS0bb+nQOVpdQYWPpnyusw4da5RPhA==}
-    engines: {node: '>=12.0.0', npm: '>=6.0.0'}
-    dependencies:
-      multibase: 4.0.6
-      uint8arrays: 3.1.1
-      varint: 5.0.2
-    dev: true
 
   /murmurhash3js-revisited@3.0.0:
     resolution: {integrity: sha512-/sF3ee6zvScXMb1XFJ8gDsSnY+X8PbOyjIuBhtgis10W2Jx4ZjIhikUCIF9c4gpJxVnQIsPAFrSwTCuAjicP6g==}
@@ -10388,12 +10304,6 @@ packages:
     dependencies:
       uint8arrays: 5.0.2
 
-  /uint8arrays@3.1.1:
-    resolution: {integrity: sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==}
-    dependencies:
-      multiformats: 9.9.0
-    dev: true
-
   /uint8arrays@4.0.10:
     resolution: {integrity: sha512-AnJNUGGDJAgFw/eWu/Xb9zrVKEGlwJJCaeInlf3BkecE/zcTobk5YXYIPNQJO1q5Hh1QZrQQHf0JvcHqz2hqoA==}
     dependencies:
@@ -10527,10 +10437,6 @@ packages:
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
     dependencies:
       builtins: 5.0.1
-    dev: true
-
-  /varint@5.0.2:
-    resolution: {integrity: sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow==}
     dev: true
 
   /varint@6.0.0:


### PR DESCRIPTION
- Updates `@web5/agent` to consume `dwn-sdk-js` `v0.3.5`
  - Includes `@web5/dids` `v1.1.0`
- Updates `@web5/api` to use the latest `@web5/agent`
  - Includes ability to `prune` children messages when deleting a parent.