### PR TITLE
Use empty filters for sync `EventsQuery`

### DIFF
--- a/packages/agent/src/dwn-api.ts
+++ b/packages/agent/src/dwn-api.ts
@@ -4,7 +4,7 @@ import type { DwnConfig, GenericMessage, UnionMessageReply } from '@tbd54566975/
 import { Convert, NodeStream } from '@web5/common';
 import { utils as cryptoUtils } from '@web5/crypto';
 import { DidDht, DidJwk, DidResolverCacheLevel, UniversalResolver } from '@web5/dids';
-import { Cid, DataStoreLevel, Dwn, DwnMethodName, EventLogLevel, Message, MessageStoreLevel } from '@tbd54566975/dwn-sdk-js';
+import { Cid, DataStoreLevel, Dwn, DwnMethodName, EventLogLevel, Message, MessageStoreLevel, ResumableTaskStoreLevel } from '@tbd54566975/dwn-sdk-js';
 
 import type { Web5PlatformAgent } from './types/agent.js';
 import type { DwnMessage, DwnMessageInstance, DwnMessageParams, DwnMessageReply, DwnMessageWithData, DwnResponse, DwnSigner, MessageHandler, ProcessDwnRequest, SendDwnRequest } from './types/dwn.js';
@@ -95,7 +95,7 @@ export class AgentDwnApi {
   }
 
   public static async createDwn({
-    dataPath, dataStore, didResolver, eventLog, eventStream, messageStore, tenantGate
+    dataPath, dataStore, didResolver, eventLog, eventStream, messageStore, tenantGate, resumableTaskStore
   }: DwnApiCreateDwnParams): Promise<Dwn> {
     dataStore ??= new DataStoreLevel({ blockstoreLocation: `${dataPath}/DWN_DATASTORE` });
 
@@ -111,7 +111,9 @@ export class AgentDwnApi {
       indexLocation      : `${dataPath}/DWN_MESSAGEINDEX`
     }));
 
-    return await Dwn.create({ dataStore, didResolver, eventLog, eventStream, messageStore, tenantGate });
+    resumableTaskStore ??= new ResumableTaskStoreLevel({ location: `${dataPath}/DWN_RESUMABLETASKSTORE` });
+
+    return await Dwn.create({ dataStore, didResolver, eventLog, eventStream, messageStore, tenantGate, resumableTaskStore });
   }
 
   public async processRequest<T extends DwnInterface>(

--- a/packages/agent/src/sync-engine-level.ts
+++ b/packages/agent/src/sync-engine-level.ts
@@ -362,8 +362,7 @@ export class SyncEngineLevel implements SyncEngine {
       const eventsGetMessage = await this.agent.dwn.createMessage({
         author        : did,
         messageType   : DwnInterface.EventsQuery,
-        // TODO: Liran help!
-        messageParams : { cursor }
+        messageParams : { filters: [], cursor }
       });
 
       try {
@@ -382,8 +381,7 @@ export class SyncEngineLevel implements SyncEngine {
         author        : did,
         target        : did,
         messageType   : DwnInterface.EventsQuery,
-        // TODO: Liran help!
-        messageParams : { cursor }
+        messageParams : { filters: [], cursor }
       });
       eventsReply = eventsGetDwnResponse.reply as EventsQueryReply;
     }

--- a/packages/agent/src/test-harness.ts
+++ b/packages/agent/src/test-harness.ts
@@ -3,7 +3,7 @@ import type { AbstractLevel } from 'abstract-level';
 
 import { Level } from 'level';
 import { LevelStore, MemoryStore } from '@web5/common';
-import { DataStoreLevel, Dwn, EventEmitterStream, EventLogLevel, MessageStoreLevel } from '@tbd54566975/dwn-sdk-js';
+import { DataStoreLevel, Dwn, EventEmitterStream, EventLogLevel, MessageStoreLevel, ResumableTaskStoreLevel } from '@tbd54566975/dwn-sdk-js';
 import { DidDht, DidJwk, DidResolutionResult, DidResolverCache, DidResolverCacheLevel } from '@web5/dids';
 
 import type { Web5PlatformAgent } from './types/agent.js';
@@ -32,6 +32,7 @@ type PlatformAgentTestHarnessParams = {
   dwnDataStore: DataStoreLevel;
   dwnEventLog: EventLogLevel;
   dwnMessageStore: MessageStoreLevel;
+  dwnResumableTaskStore: ResumableTaskStoreLevel;
   syncStore: AbstractLevel<string | Buffer | Uint8Array>;
   vaultStore: KeyValueStore<string, string>;
 }
@@ -51,6 +52,7 @@ export class PlatformAgentTestHarness {
   public dwnDataStore: DataStoreLevel;
   public dwnEventLog: EventLogLevel;
   public dwnMessageStore: MessageStoreLevel;
+  public dwnResumableTaskStore: ResumableTaskStoreLevel;
   public syncStore: AbstractLevel<string | Buffer | Uint8Array>;
   public vaultStore: KeyValueStore<string, string>;
 
@@ -64,6 +66,7 @@ export class PlatformAgentTestHarness {
     this.dwnMessageStore = params.dwnMessageStore;
     this.syncStore = params.syncStore;
     this.vaultStore = params.vaultStore;
+    this.dwnResumableTaskStore = params.dwnResumableTaskStore;
   }
 
   public async clearStorage(): Promise<void> {
@@ -73,6 +76,7 @@ export class PlatformAgentTestHarness {
     await this.dwnDataStore.clear();
     await this.dwnEventLog.clear();
     await this.dwnMessageStore.clear();
+    await this.dwnResumableTaskStore.clear();
     await this.syncStore.clear();
     await this.vaultStore.clear();
 
@@ -98,6 +102,7 @@ export class PlatformAgentTestHarness {
     await this.dwnDataStore.close();
     await this.dwnEventLog.close();
     await this.dwnMessageStore.close();
+    await this.dwnResumableTaskStore.close();
     await this.syncStore.close();
     await this.vaultStore.close();
   }
@@ -181,6 +186,7 @@ export class PlatformAgentTestHarness {
     const dwnDataStore = new DataStoreLevel({ blockstoreLocation: testDataPath('DWN_DATASTORE') });
     const dwnEventLog = new EventLogLevel({ location: testDataPath('DWN_EVENTLOG') });
     const dwnEventStream = new EventEmitterStream();
+    const dwnResumableTaskStore = new ResumableTaskStoreLevel({ location: testDataPath('DWN_RESUMABLETASKSTORE') });
 
     const dwnMessageStore = new MessageStoreLevel({
       blockstoreLocation : testDataPath('DWN_MESSAGESTORE'),
@@ -189,12 +195,13 @@ export class PlatformAgentTestHarness {
 
     // Instantiate DWN instance using the custom stores.
     const dwn = await AgentDwnApi.createDwn({
-      dataPath     : testDataLocation,
-      dataStore    : dwnDataStore,
-      didResolver  : didApi,
-      eventLog     : dwnEventLog,
-      eventStream  : dwnEventStream,
-      messageStore : dwnMessageStore,
+      dataPath           : testDataLocation,
+      dataStore          : dwnDataStore,
+      didResolver        : didApi,
+      eventLog           : dwnEventLog,
+      eventStream        : dwnEventStream,
+      messageStore       : dwnMessageStore,
+      resumableTaskStore : dwnResumableTaskStore
     });
 
     // Instantiate Agent's DWN API using the custom DWN instance.
@@ -225,6 +232,7 @@ export class PlatformAgentTestHarness {
       dwnDataStore,
       dwnEventLog,
       dwnMessageStore,
+      dwnResumableTaskStore,
       syncStore,
       vaultStore
     });


### PR DESCRIPTION
Hope you don't mind I included the `ResumableTaskStore` in the DWN scaffolding to get the tests to pass, not sure if there is any agent-specific paths to test with it.

The fix you needed was to pass an empty filters array (to get all events) for sync. In future enhancements it will pass filters depending on what it's syncing and the permissions it has.

This is reliant on: https://github.com/TBD54566975/dwn-server/pull/137

Testing against that server version goes all green, so just need to merge that + bump the `dwn-server` dependency on this repo.