### PR TITLE
Remove Duplicate Methods used in sync

### DIFF
--- a/.changeset/tidy-wasps-smell.md
+++ b/.changeset/tidy-wasps-smell.md
@@ -1,0 +1,8 @@
+---
+"@web5/agent": patch
+"@web5/identity-agent": patch
+"@web5/proxy-agent": patch
+"@web5/user-agent": patch
+---
+
+Remove Duplicate Methods used in sync & Fix sync bug where only RecordsWrite were being pulled from the remote

--- a/packages/agent/src/dwn-api.ts
+++ b/packages/agent/src/dwn-api.ts
@@ -1,5 +1,5 @@
 import type { Readable } from '@web5/common';
-import type { DwnConfig, GenericMessage, UnionMessageReply } from '@tbd54566975/dwn-sdk-js';
+import type { DwnConfig, GenericMessage } from '@tbd54566975/dwn-sdk-js';
 
 import { NodeStream } from '@web5/common';
 import { utils as cryptoUtils } from '@web5/crypto';
@@ -7,7 +7,7 @@ import { DidDht, DidJwk, DidResolverCacheLevel, UniversalResolver } from '@web5/
 import { Cid, DataStoreLevel, Dwn, DwnMethodName, EventLogLevel, Message, MessageStoreLevel, ResumableTaskStoreLevel } from '@tbd54566975/dwn-sdk-js';
 
 import type { Web5PlatformAgent } from './types/agent.js';
-import type { DwnMessage, DwnMessageInstance, DwnMessageParams, DwnMessageReply, DwnMessageWithData, DwnResponse, DwnSigner, MessageHandler, ProcessDwnRequest, SendDwnRequest } from './types/dwn.js';
+import type { DwnMessage, DwnMessageReply, DwnMessageWithData, DwnResponse, DwnSigner, MessageHandler, ProcessDwnRequest, SendDwnRequest } from './types/dwn.js';
 
 import { DwnInterface, dwnMessageConstructors } from './types/dwn.js';
 import { blobToIsomorphicNodeReadable, getDwnServiceEndpointUrls, isRecordsWrite, webReadableToIsomorphicNodeReadable } from './utils.js';
@@ -381,38 +381,5 @@ export class AgentDwnApi {
     }
 
     return dwnMessageWithBlob;
-  }
-
-  /**
-   * TODO: Refactor this to consolidate logic in AgentDwnApi and SyncEngineLevel.
-   * ADDED TO GET SYNC WORKING
-   * - createMessage()
-   * - processMessage()
-   */
-
-  public async createMessage<T extends DwnInterface>({ author, messageParams, messageType }: {
-    author: string;
-    messageType: T;
-    messageParams?: DwnMessageParams[T];
-  }): Promise<DwnMessageInstance[T]> {
-    // Determine the signer for the message.
-    const signer = await this.getSigner(author);
-
-    const dwnMessageConstructor = dwnMessageConstructors[messageType];
-    const dwnMessage = await dwnMessageConstructor.create({
-      // TODO: Explore whether 'messageParams' should be required in the ProcessDwnRequest type.
-      ...messageParams!,
-      signer
-    });
-
-    return dwnMessage;
-  }
-
-  public async processMessage({ dataStream, message, targetDid }: {
-    targetDid: string;
-    message: GenericMessage;
-    dataStream?: Readable;
-  }): Promise<UnionMessageReply> {
-    return await this._dwn.processMessage(targetDid, message, { dataStream });
   }
 }

--- a/packages/agent/tests/dwn-api.spec.ts
+++ b/packages/agent/tests/dwn-api.spec.ts
@@ -604,11 +604,12 @@ describe('AgentDwnApi', () => {
 
     it('returns a 202 Accepted status when the request is not stored', async () => {
       // spy on dwn.processMessage
-      const processMessageSpy = sinon.spy(testHarness.agent.dwn, 'processMessage');
+      const processMessageSpy = sinon.spy(testHarness.agent.dwn.node, 'processMessage');
 
       // Attempt to process the RecordsWrite
       const dataBytes = Convert.string('Hello, world!').toUint8Array();
       let writeResponse = await testHarness.agent.dwn.processRequest({
+        store         : false,
         author        : alice.did.uri,
         target        : alice.did.uri,
         messageType   : DwnInterface.RecordsWrite,


### PR DESCRIPTION
- remove duplicate methods used in sync.
- fix bug where only RecordsWrite messages were being synced & add coverage