### PR TITLE
Already deleted Message returns 404 vs 409 conflict when a 2nd attempt to delete is processed

### DIFF
--- a/.changeset/dirty-days-flash.md
+++ b/.changeset/dirty-days-flash.md
@@ -1,0 +1,8 @@
+---
+"@web5/agent": patch
+"@web5/identity-agent": patch
+"@web5/proxy-agent": patch
+"@web5/user-agent": patch
+---
+
+Sync accounts for 404 from a conflicting RecordsDelete message

--- a/packages/agent/src/sync-engine-level.ts
+++ b/packages/agent/src/sync-engine-level.ts
@@ -148,7 +148,7 @@ export class SyncEngineLevel implements SyncEngine {
         : undefined;
 
       const pullReply = await this.agent.dwn.node.processMessage(did, message, { dataStream });
-      if (SyncEngineLevel.successMessageSyncReply(pullReply)) {
+      if (SyncEngineLevel.syncMessageReplyIsSuccessful(pullReply)) {
         await this.addMessage(did, messageCid);
         deleteOperations.push({ type: 'del', key: key });
       }
@@ -201,7 +201,7 @@ export class SyncEngineLevel implements SyncEngine {
         // - 202: message was successfully written to the remote DWN
         // - 409: message was already present on the remote DWN
         // - RecordsDelete and the status code is 404: the initial write message was not found or the message was already deleted
-        if (SyncEngineLevel.successMessageSyncReply(reply)) {
+        if (SyncEngineLevel.syncMessageReplyIsSuccessful(reply)) {
           await this.addMessage(did, messageCid);
           deleteOperations.push({ type: 'del', key: key });
         }
@@ -258,7 +258,7 @@ export class SyncEngineLevel implements SyncEngine {
     }
   }
 
-  private static successMessageSyncReply(reply: UnionMessageReply): boolean {
+  private static syncMessageReplyIsSuccessful(reply: UnionMessageReply): boolean {
     return reply.status.code === 202 ||
       reply.status.code === 409 ||
       (

--- a/packages/api/tests/record.spec.ts
+++ b/packages/api/tests/record.spec.ts
@@ -2983,7 +2983,7 @@ describe('Record', () => {
       }
     });
 
-    it('duplicate delete with store should return conflict', async () => {
+    it('duplicate delete with store should return not found', async () => {
       // create a record
       const { status: writeStatus, record }  = await dwnAlice.records.write({
         data    : 'Hello, world!',
@@ -3013,7 +3013,7 @@ describe('Record', () => {
 
       // attempt to delete the record again
       const { status: deleteStatus2 } = await record.delete();
-      expect(deleteStatus2.code).to.equal(409);
+      expect(deleteStatus2.code).to.equal(404);
     });
 
     it('a record in a deleted state returns undefined for data related fields', async () => {


### PR DESCRIPTION
After merging https://github.com/TBD54566975/web5-js/pull/635, which was a bit old, one of the new tests failed upon merge to main.

During a `dwn-sdk-js` change the return for a conflicting `RecordsDelete` changed from a `409` to a `404`.
https://github.com/TBD54566975/dwn-sdk-js/pull/749/files#diff-169fe156eb9ea99859416850b92e6836907930a425399f2bcb059c9edf4259b6R57

This PR addresses it within the new `record.delete()` method, as well as for sync, adding additional coverage.