### PR TITLE
make `rawMessage` public on the `Record` class

### DIFF
--- a/.changeset/silly-taxis-pull.md
+++ b/.changeset/silly-taxis-pull.md
@@ -1,0 +1,5 @@
+---
+"@web5/api": patch
+---
+
+make `rawMessage` not private in `Record` class

--- a/packages/api/src/record.ts
+++ b/packages/api/src/record.ts
@@ -312,7 +312,7 @@ export class Record implements RecordModel {
   /**
    * Returns a copy of the raw `RecordsWriteMessage` that was used to create the current `Record` instance.
    */
-  private get rawMessage(): DwnMessage[DwnInterface.RecordsWrite] | DwnMessage[DwnInterface.RecordsDelete] {
+  get rawMessage(): DwnMessage[DwnInterface.RecordsWrite] | DwnMessage[DwnInterface.RecordsDelete] {
     const messageType = this._descriptor.interface + this._descriptor.method;
     let message: DwnMessage[DwnInterface.RecordsWrite] | DwnMessage[DwnInterface.RecordsDelete];
     if (messageType === DwnInterface.RecordsWrite) {

--- a/packages/credentials/tests/verifiable-credential.spec.ts
+++ b/packages/credentials/tests/verifiable-credential.spec.ts
@@ -135,7 +135,9 @@ describe('Verifiable Credential Tests', () => {
       }
     });
 
-    it('create and sign vc with did:ion', async () => {
+    // TBD's `did:ion` resolver has been sunset so skipping tests
+    // TODO: Move `did:ion` functionality to separate repo
+    xit('create and sign vc with did:ion', async () => {
       const did = await DidIon.create();
 
       const vc = await VerifiableCredential.create({


### PR DESCRIPTION
- `rawMessage` property on the `Record` class is not private
- skip `did:ion` test in the `credentials` package