### PR TITLE
remove jwt `typ` requirement

### DIFF
--- a/.changeset/two-worms-float.md
+++ b/.changeset/two-worms-float.md
@@ -1,0 +1,5 @@
+---
+"@web5/credentials": patch
+---
+
+Replaced hardcoded `typ` value in JWT with an optional header override.

--- a/packages/credentials/src/jwt.ts
+++ b/packages/credentials/src/jwt.ts
@@ -68,7 +68,10 @@ export type SignJwtOptions = {
   payload: JwtPayload
 
   /** Overridable header parameters */
-  header?: { typ: string }
+  header?: { 
+    /** Type Header Parameter */
+    typ: string 
+  }
 }
 
 /**

--- a/packages/credentials/src/jwt.ts
+++ b/packages/credentials/src/jwt.ts
@@ -66,6 +66,9 @@ export type SignJwtOptions = {
   signerDid: BearerDid
   /** The payload to sign. */
   payload: JwtPayload
+
+  /** Header parameters */
+  header?: { typ: string }
 }
 
 /**
@@ -108,9 +111,9 @@ export class Jwt {
     }
 
     const header: JwtHeaderParams = {
-      typ : 'JWT',
       alg : signer.algorithm,
       kid : vmId,
+      ...options.header,
     };
 
     const base64UrlEncodedHeader = Convert.object(header).toBase64Url();

--- a/packages/credentials/src/jwt.ts
+++ b/packages/credentials/src/jwt.ts
@@ -210,10 +210,6 @@ export class Jwt {
       throw new Error('Verification failed: Malformed JWT. Invalid base64url encoding for JWT header');
     }
 
-    if (!jwtHeader.typ || jwtHeader.typ !== 'JWT') {
-      throw new Error('Verification failed: Expected JWT header to contain typ property set to JWT');
-    }
-
     if (!jwtHeader.alg || !jwtHeader.kid) { // ensure that JWT header has required properties
       throw new Error('Verification failed: Expected JWT header to contain alg and kid');
     }

--- a/packages/credentials/src/jwt.ts
+++ b/packages/credentials/src/jwt.ts
@@ -67,7 +67,7 @@ export type SignJwtOptions = {
   /** The payload to sign. */
   payload: JwtPayload
 
-  /** Header parameters */
+  /** Overridable header parameters */
   header?: { typ: string }
 }
 

--- a/packages/credentials/src/jwt.ts
+++ b/packages/credentials/src/jwt.ts
@@ -68,9 +68,9 @@ export type SignJwtOptions = {
   payload: JwtPayload
 
   /** Overridable header parameters */
-  header?: { 
+  header?: {
     /** Type Header Parameter */
-    typ: string 
+    typ: string
   }
 }
 

--- a/packages/credentials/tests/jwt.spec.ts
+++ b/packages/credentials/tests/jwt.spec.ts
@@ -261,13 +261,13 @@ describe('Jwt', () => {
       const did = await DidJwk.create();
       const signedJwt = await Jwt.sign({
         signerDid : did,
-        payload: {jti: 'hehe'},
-        header: {typ: 'openid4vci-proof+jwt'}
+        payload   : {jti: 'hehe'},
+        header    : {typ: 'openid4vci-proof+jwt'}
       });
 
       const parsed = Jwt.parse({ jwt: signedJwt });
       expect(parsed.decoded.header.typ).to.equal('openid4vci-proof+jwt');
-    })
+    });
   });
 
   describe('Web5TestVectorsVcJwt', () => {

--- a/packages/credentials/tests/jwt.spec.ts
+++ b/packages/credentials/tests/jwt.spec.ts
@@ -25,24 +25,6 @@ describe('Jwt', () => {
       ).to.throw('Invalid base64url encoding for JWT header');
     });
 
-    it('throws error if JWT header is missing typ property', async () => {
-      const header: JwtHeaderParams = { alg: 'ES256K', kid: 'whateva' };
-      const base64UrlEncodedHeader = Convert.object(header).toBase64Url();
-
-      expect(() =>
-        Jwt.parse({ jwt: `${base64UrlEncodedHeader}.efgh.hijk` })
-      ).to.throw('typ property set to JWT');
-    });
-
-    it('throws error if JWT header typ property is not set to JWT', async () => {
-      const header: JwtHeaderParams = { typ: 'hehe', alg: 'ES256K', kid: 'whateva' };
-      const base64UrlEncodedHeader = Convert.object(header).toBase64Url();
-
-      expect(() =>
-        Jwt.parse({ jwt: `${base64UrlEncodedHeader}.efgh.hijk` })
-      ).to.throw('typ property set to JWT');
-    });
-
     it('throws error if JWT header alg property is missing', async () => {
       // @ts-expect-error because alg is intentionally missing to trigger error.
       const header: JwtHeaderParams = { typ: 'JWT', kid: 'whateva' };
@@ -272,6 +254,20 @@ describe('Jwt', () => {
       expect(verifyResult.header).to.deep.equal(header);
       expect(verifyResult.payload).to.deep.equal(payload);
     });
+  });
+
+  describe('sign()', () => {
+    it('allows typ to be set by caller', async () => {
+      const did = await DidJwk.create();
+      const signedJwt = await Jwt.sign({
+        signerDid : did,
+        payload: {jti: 'hehe'},
+        header: {typ: 'openid4vci-proof+jwt'}
+      });
+
+      const parsed = Jwt.parse({ jwt: signedJwt });
+      expect(parsed.decoded.header.typ).to.equal('openid4vci-proof+jwt');
+    })
   });
 
   describe('Web5TestVectorsVcJwt', () => {


### PR DESCRIPTION
# Summary
This PR removes the `typ` requirement for JWTs.

# Rationale
[section 5.1 of RFC7519](https://datatracker.ietf.org/doc/html/rfc7519#section-5.1) `typ` is not a required parameter in a JWT 

<img width="934" alt="image" src="https://github.com/user-attachments/assets/e1b43fe9-81f2-49fd-8c51-17124471088c">

---

Requiring that it be set and then _further_ requiring that `typ` **MUST** be `JWT` is preventing folks from being able to set it to values that other specs require e.g. [openid4vci-proof+jwt](https://github.com/TBD54566975/known-customer-credential?tab=readme-ov-file#proofjwt-jose-headers)


# Changes
* removes `typ` requirement from `Jwt.parse`
* adds option for caller to provide `typ` when calling `Jwt.sign`