### PR TITLE
[WIP] SyncEngine for specific protocols + delegate sync.

### DIFF
--- a/.changeset/blue-roses-cough.md
+++ b/.changeset/blue-roses-cough.md
@@ -1,0 +1,8 @@
+---
+"@web5/agent": minor
+"@web5/identity-agent": minor
+"@web5/proxy-agent": minor
+"@web5/user-agent": minor
+---
+
+Add ability to Sync a subset of protocols as a delegate

--- a/.changeset/green-dolls-provide.md
+++ b/.changeset/green-dolls-provide.md
@@ -1,0 +1,5 @@
+---
+"@web5/api": minor
+---
+
+Finalize ability to WalletConnect with sync involved

--- a/audit-ci.json
+++ b/audit-ci.json
@@ -5,6 +5,7 @@
     "ip",
     "mysql2",
     "braces",
-    "GHSA-rv95-896h-c2vc"
+    "GHSA-rv95-896h-c2vc",
+    "GHSA-952p-6rrq-rcjv"
   ]
 }

--- a/packages/agent/src/cached-permissions.ts
+++ b/packages/agent/src/cached-permissions.ts
@@ -53,7 +53,7 @@ export class CachedPermissions {
     );
 
     if (!grant) {
-      throw new Error(`AgentDwnApi: No permissions found for ${messageType}: ${protocol}`);
+      throw new Error(`CachedPermissions: No permissions found for ${messageType}: ${protocol}`);
     }
 
     this.cachedPermissions.set(cacheKey, grant);

--- a/packages/agent/src/cached-permissions.ts
+++ b/packages/agent/src/cached-permissions.ts
@@ -1,0 +1,66 @@
+import { TtlCache } from '@web5/common';
+import { AgentPermissionsApi } from './permissions-api.js';
+import { Web5Agent } from './types/agent.js';
+import { PermissionGrantEntry } from './types/permissions.js';
+import { DwnInterface } from './types/dwn.js';
+
+export class CachedPermissions {
+
+  /** the default value for whether a fetch is cached or not */
+  private cachedDefault: boolean;
+
+  /** Holds the instance of {@link AgentPermissionsApi} that helps when dealing with permissions protocol records */
+  private permissionsApi: AgentPermissionsApi;
+
+  /** cache for fetching a permission {@link PermissionGrant}, keyed by a specific MessageType and protocol */
+  private cachedPermissions: TtlCache<string, PermissionGrantEntry> = new TtlCache({ ttl: 60 * 1000 });
+
+  constructor({ agent, cachedDefault }:{ agent: Web5Agent, cachedDefault?: boolean }) {
+    this.permissionsApi = new AgentPermissionsApi({ agent });
+    this.cachedDefault = cachedDefault ?? false;
+  }
+
+  public async getPermission<T extends DwnInterface>({ connectedDid, delegateDid, delegate, messageType, protocol, cached = this.cachedDefault }: {
+    connectedDid: string;
+    delegateDid: string;
+    messageType: T;
+    protocol?: string;
+    cached?: boolean;
+    delegate?: boolean;
+  }): Promise<PermissionGrantEntry> {
+    // Currently we only support finding grants based on protocols
+    // A different approach may be necessary when we introduce `protocolPath` and `contextId` specific impersonation
+    const cacheKey = [ connectedDid, delegateDid, messageType, protocol ].join('~');
+    const cachedGrant = cached ? this.cachedPermissions.get(cacheKey) : undefined;
+    if (cachedGrant) {
+      return cachedGrant;
+    }
+
+    const permissionGrants = await this.permissionsApi.fetchGrants({
+      author  : delegateDid,
+      target  : delegateDid,
+      grantor : connectedDid,
+      grantee : delegateDid,
+    });
+
+    // get the delegate grants that match the messageParams and are associated with the connectedDid as the grantor
+    const grant = await AgentPermissionsApi.matchGrantFromArray(
+      connectedDid,
+      delegateDid,
+      { messageType, protocol },
+      permissionGrants,
+      delegate
+    );
+
+    if (!grant) {
+      throw new Error(`AgentDwnApi: No permissions found for ${messageType}: ${protocol}`);
+    }
+
+    this.cachedPermissions.set(cacheKey, grant);
+    return grant;
+  }
+
+  public async clear(): Promise<void> {
+    this.cachedPermissions.clear();
+  }
+}

--- a/packages/agent/src/dwn-api.ts
+++ b/packages/agent/src/dwn-api.ts
@@ -5,6 +5,7 @@ import {
   DataStoreLevel,
   Dwn,
   DwnConfig,
+  DwnInterfaceName,
   DwnMethodName,
   EventLogLevel,
   GenericMessage,
@@ -23,8 +24,11 @@ import type {
   DwnMessageInstance,
   DwnMessageParams,
   DwnMessageReply,
+  DwnMessagesPermissionScope,
   DwnMessageWithData,
+  DwnPermissionScope,
   DwnRecordsInterfaces,
+  DwnRecordsPermissionScope,
   DwnResponse,
   DwnSigner,
   MessageHandler,
@@ -68,6 +72,14 @@ export function isRecordsType(messageType: DwnInterface): messageType is DwnReco
     messageType === DwnInterface.RecordsRead ||
     messageType === DwnInterface.RecordsSubscribe ||
     messageType === DwnInterface.RecordsWrite;
+}
+
+export function isRecordPermissionScope(scope: DwnPermissionScope): scope is DwnRecordsPermissionScope {
+  return scope.interface === DwnInterfaceName.Records;
+}
+
+export function isMessagesPermissionScope(scope: DwnPermissionScope): scope is DwnMessagesPermissionScope {
+  return scope.interface === DwnInterfaceName.Messages;
 }
 
 export class AgentDwnApi {

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -8,6 +8,7 @@ export type * from './types/sync.js';
 export type * from './types/vc.js';
 
 export * from './bearer-identity.js';
+export * from './cached-permissions.js';
 export * from './crypto-api.js';
 export * from './did-api.js';
 export * from './dwn-api.js';

--- a/packages/agent/src/store-data.ts
+++ b/packages/agent/src/store-data.ts
@@ -165,7 +165,7 @@ export class DwnDataStore<TStoreObject extends Record<string, any> = Jwk> implem
 
     // If the write fails, throw an error.
     if (!(message && status.code === 202)) {
-      throw new Error(`${this.name}: Failed to write data to store for: ${id}`);
+      throw new Error(`${this.name}: Failed to write data to store for ${id}: ${status.detail}`);
     }
 
     // Add the ID of the newly created record to the index.

--- a/packages/agent/src/sync-api.ts
+++ b/packages/agent/src/sync-api.ts
@@ -1,4 +1,4 @@
-import type { SyncEngine } from './types/sync.js';
+import type { SyncEngine, SyncIdentityOptions } from './types/sync.js';
 import type { Web5PlatformAgent } from './types/agent.js';
 
 export type SyncApiParams = {
@@ -41,8 +41,12 @@ export class AgentSyncApi implements SyncEngine {
     this._syncEngine.agent = agent;
   }
 
-  public async registerIdentity(params: { did: string; }): Promise<void> {
+  public async registerIdentity(params: { did: string; options: SyncIdentityOptions }): Promise<void> {
     await this._syncEngine.registerIdentity(params);
+  }
+
+  public sync(direction?: 'push' | 'pull'): Promise<void> {
+    return this._syncEngine.sync(direction);
   }
 
   public startSync(params: { interval: string; }): Promise<void> {

--- a/packages/agent/src/sync-engine-level.ts
+++ b/packages/agent/src/sync-engine-level.ts
@@ -411,7 +411,7 @@ export class SyncEngineLevel implements SyncEngine {
         granteeDid = delegateDid;
       } catch(error:any) {
         console.log('SyncEngineLevel: Error fetching permission grant for delegate DID', error);
-        return;
+        return [];
       }
     }
 

--- a/packages/agent/src/sync-engine-level.ts
+++ b/packages/agent/src/sync-engine-level.ts
@@ -394,14 +394,14 @@ export class SyncEngineLevel implements SyncEngine {
     let granteeDid: string | undefined;
     if (delegateDid) {
       // fetch the grants for the delegate DID
-      const messagesReadGrant = await this._cachedPermissionsApi.getPermission({
+      const messagesQueryGrant = await this._cachedPermissionsApi.getPermission({
         connectedDid : did,
-        messageType  : DwnInterface.MessagesRead,
+        messageType  : DwnInterface.MessagesQuery,
         delegateDid,
         protocol,
       });
 
-      permissionGrantId = messagesReadGrant?.grant.id;
+      permissionGrantId = messagesQueryGrant?.grant.id;
       granteeDid = delegateDid;
     }
 

--- a/packages/agent/src/sync-engine-level.ts
+++ b/packages/agent/src/sync-engine-level.ts
@@ -139,7 +139,7 @@ export class SyncEngineLevel implements SyncEngine {
           protocol,
         });
 
-        permissionGrantId = messagesReadGrant?.grant.id;
+        permissionGrantId = messagesReadGrant.grant.id;
         granteeDid = delegateDid;
       }
 
@@ -401,7 +401,7 @@ export class SyncEngineLevel implements SyncEngine {
         protocol,
       });
 
-      permissionGrantId = messagesQueryGrant?.grant.id;
+      permissionGrantId = messagesQueryGrant.grant.id;
       granteeDid = delegateDid;
     }
 
@@ -467,7 +467,7 @@ export class SyncEngineLevel implements SyncEngine {
         protocol,
       });
 
-      permissionGrantId = messagesReadGrant?.grant.id;
+      permissionGrantId = messagesReadGrant.grant.id;
       granteeDid = delegateDid;
     }
 

--- a/packages/agent/src/sync-engine-level.ts
+++ b/packages/agent/src/sync-engine-level.ts
@@ -132,15 +132,20 @@ export class SyncEngineLevel implements SyncEngine {
       let permissionGrantId: string | undefined;
       let granteeDid: string | undefined;
       if (delegateDid) {
-        const messagesReadGrant = await this._cachedPermissionsApi.getPermission({
-          connectedDid : did,
-          messageType  : DwnInterface.MessagesRead,
-          delegateDid,
-          protocol,
-        });
+        try {
+          const messagesReadGrant = await this._cachedPermissionsApi.getPermission({
+            connectedDid : did,
+            messageType  : DwnInterface.MessagesRead,
+            delegateDid,
+            protocol,
+          });
 
-        permissionGrantId = messagesReadGrant.grant.id;
-        granteeDid = delegateDid;
+          permissionGrantId = messagesReadGrant.grant.id;
+          granteeDid = delegateDid;
+        } catch(error:any) {
+          console.log('SyncEngineLevel: Error fetching permission grant for delegate DID', error);
+          continue;
+        }
       }
 
       const messagesRead = await this.agent.processDwnRequest({
@@ -394,15 +399,20 @@ export class SyncEngineLevel implements SyncEngine {
     let granteeDid: string | undefined;
     if (delegateDid) {
       // fetch the grants for the delegate DID
-      const messagesQueryGrant = await this._cachedPermissionsApi.getPermission({
-        connectedDid : did,
-        messageType  : DwnInterface.MessagesQuery,
-        delegateDid,
-        protocol,
-      });
+      try {
+        const messagesReadGrant = await this._cachedPermissionsApi.getPermission({
+          connectedDid : did,
+          messageType  : DwnInterface.MessagesQuery,
+          delegateDid,
+          protocol,
+        });
 
-      permissionGrantId = messagesQueryGrant.grant.id;
-      granteeDid = delegateDid;
+        permissionGrantId = messagesReadGrant.grant.id;
+        granteeDid = delegateDid;
+      } catch(error:any) {
+        console.log('SyncEngineLevel: Error fetching permission grant for delegate DID', error);
+        return;
+      }
     }
 
     if (syncDirection === 'pull') {
@@ -460,15 +470,20 @@ export class SyncEngineLevel implements SyncEngine {
     let granteeDid: string | undefined;
 
     if (delegateDid) {
-      const messagesReadGrant = await this._cachedPermissionsApi.getPermission({
-        connectedDid : author,
-        messageType  : DwnInterface.MessagesRead,
-        delegateDid,
-        protocol,
-      });
+      try {
+        const messagesReadGrant = await this._cachedPermissionsApi.getPermission({
+          connectedDid : author,
+          messageType  : DwnInterface.MessagesRead,
+          delegateDid,
+          protocol,
+        });
 
-      permissionGrantId = messagesReadGrant.grant.id;
-      granteeDid = delegateDid;
+        permissionGrantId = messagesReadGrant.grant.id;
+        granteeDid = delegateDid;
+      } catch(error:any) {
+        console.log('SyncEngineLevel: Error fetching permission grant for delegate DID', error);
+        return;
+      }
     }
 
     let { reply } = await this.agent.dwn.processRequest({

--- a/packages/agent/src/types/sync.ts
+++ b/packages/agent/src/types/sync.ts
@@ -1,8 +1,13 @@
 import type { Web5PlatformAgent } from './agent.js';
 
+export type SyncIdentityOptions = {
+  delegateDid?: string;
+  protocols: string[]
+}
 export interface SyncEngine {
   agent: Web5PlatformAgent;
-  registerIdentity(params: { did: string }): Promise<void>;
+  registerIdentity(params: { did: string, options: SyncIdentityOptions }): Promise<void>;
+  sync(direction?: 'push' | 'pull'): Promise<void>;
   startSync(params: { interval: string }): Promise<void>;
   stopSync(): void;
 }

--- a/packages/agent/tests/cached-permissions.spec.ts
+++ b/packages/agent/tests/cached-permissions.spec.ts
@@ -1,0 +1,240 @@
+import sinon from 'sinon';
+import { expect } from 'chai';
+import { AgentPermissionsApi } from '../src/permissions-api.js';
+import { PlatformAgentTestHarness } from '../src/test-harness.js';
+import { TestAgent } from './utils/test-agent.js';
+import { BearerDid } from '@web5/dids';
+
+import { testDwnUrl } from './utils/test-config.js';
+import { DwnInterfaceName, DwnMethodName, Time } from '@tbd54566975/dwn-sdk-js';
+import { CachedPermissions, DwnInterface } from '../src/index.js';
+import { Convert } from '@web5/common';
+
+let testDwnUrls: string[] = [testDwnUrl];
+
+describe('CachedPermissions', () => {
+  let permissions: AgentPermissionsApi;
+  let testHarness: PlatformAgentTestHarness;
+  let aliceDid: BearerDid;
+  let bobDid: BearerDid;
+
+  before(async () => {
+    testHarness = await PlatformAgentTestHarness.setup({
+      agentClass  : TestAgent,
+      agentStores : 'dwn'
+    });
+  });
+
+  after(async () => {
+    sinon.restore();
+    await testHarness.clearStorage();
+    await testHarness.closeStorage();
+  });
+
+  beforeEach(async () => {
+    sinon.restore();
+    await testHarness.clearStorage();
+    await testHarness.createAgentDid();
+
+    // Create an "alice" Identity to author the DWN messages.
+    const alice = await testHarness.createIdentity({ name: 'Alice', testDwnUrls });
+    await testHarness.agent.identity.manage({ portableIdentity: await alice.export() });
+    aliceDid = alice.did;
+
+    const bob = await testHarness.createIdentity({ name: 'Bob', testDwnUrls });
+    await testHarness.agent.identity.manage({ portableIdentity: await bob.export() });
+    bobDid = bob.did;
+
+    permissions = new AgentPermissionsApi({ agent: testHarness.agent });
+  });
+
+  describe('cachedDefault', () => {
+    it('caches permissions by default if defaultCache is set to true', async () => {
+      // create a permission grant to fetch
+      const messagesQueryGrant = await permissions.createGrant({
+        store       : true,
+        author      : aliceDid.uri,
+        grantedTo   : bobDid.uri,
+        dateExpires : Time.createOffsetTimestamp({ seconds: 60 }),
+        scope       : {
+          interface : DwnInterfaceName.Messages,
+          method    : DwnMethodName.Query,
+        }
+      });
+
+      // store the grant as owner from bob so that it can be fetched
+      const { encodedData, ...messagesQueryGrantMessage } = messagesQueryGrant.message;
+      const grantReply = await testHarness.agent.processDwnRequest({
+        target      : bobDid.uri,
+        author      : bobDid.uri,
+        signAsOwner : true,
+        messageType : DwnInterface.RecordsWrite,
+        rawMessage  : messagesQueryGrantMessage,
+        dataStream  : new Blob([ Convert.base64Url(encodedData).toUint8Array() ])
+      });
+      expect(grantReply.reply.status.code).to.equal(202);
+
+      const permissionGrantsApiSpy = sinon.spy(AgentPermissionsApi.prototype, 'fetchGrants');
+
+      // with defaultCache set to true
+      const cachedPermissions = new CachedPermissions({ agent: testHarness.agent, cachedDefault: true });
+
+      // fetch the grant
+      let fetchedMessagesQueryGrant = await cachedPermissions.getPermission({
+        connectedDid : aliceDid.uri,
+        delegateDid  : bobDid.uri,
+        messageType  : DwnInterface.MessagesQuery,
+      });
+      expect(fetchedMessagesQueryGrant).to.not.be.undefined;
+      expect(fetchedMessagesQueryGrant.message.recordId).to.equal(messagesQueryGrant.message.recordId);
+
+      // confirm that the permission was fetched from the API
+      expect(permissionGrantsApiSpy.calledOnce).to.be.true;
+      permissionGrantsApiSpy.resetHistory();
+
+      // fetch the grant again to confirm that it was cached
+      fetchedMessagesQueryGrant = await cachedPermissions.getPermission({
+        connectedDid : aliceDid.uri,
+        delegateDid  : bobDid.uri,
+        messageType  : DwnInterface.MessagesQuery,
+      });
+      expect(fetchedMessagesQueryGrant).to.not.be.undefined;
+      expect(fetchedMessagesQueryGrant.message.recordId).to.equal(messagesQueryGrant.message.recordId);
+
+      // confirm that the permission was not fetched again from the API
+      expect(permissionGrantsApiSpy.called).to.be.false;
+
+      // confirm that the permissions is fetched from teh api if cache is set to false on a single call
+      fetchedMessagesQueryGrant = await cachedPermissions.getPermission({
+        connectedDid : aliceDid.uri,
+        delegateDid  : bobDid.uri,
+        messageType  : DwnInterface.MessagesQuery,
+        cached       : false,
+      });
+      expect(fetchedMessagesQueryGrant).to.not.be.undefined;
+      expect(fetchedMessagesQueryGrant.message.recordId).to.equal(messagesQueryGrant.message.recordId);
+
+      // confirm that the permission was fetched from the API
+      expect(permissionGrantsApiSpy.calledOnce).to.be.true;
+    });
+
+    it('does not cache permission by default defaultCache is set to false', async () => {
+      // create a permission grant to fetch
+      const messagesQueryGrant = await permissions.createGrant({
+        store       : true,
+        author      : aliceDid.uri,
+        grantedTo   : bobDid.uri,
+        dateExpires : Time.createOffsetTimestamp({ seconds: 60 }),
+        scope       : {
+          interface : DwnInterfaceName.Messages,
+          method    : DwnMethodName.Query,
+        }
+      });
+
+      // store the grant as owner from bob so that it can be fetched
+      const { encodedData, ...messagesQueryGrantMessage } = messagesQueryGrant.message;
+      const grantReply = await testHarness.agent.processDwnRequest({
+        target      : bobDid.uri,
+        author      : bobDid.uri,
+        signAsOwner : true,
+        messageType : DwnInterface.RecordsWrite,
+        rawMessage  : messagesQueryGrantMessage,
+        dataStream  : new Blob([ Convert.base64Url(encodedData).toUint8Array() ])
+      });
+      expect(grantReply.reply.status.code).to.equal(202);
+
+      const permissionGrantsApiSpy = sinon.spy(AgentPermissionsApi.prototype, 'fetchGrants');
+
+      // with defaultCache set to false by default
+      const cachedPermissions = new CachedPermissions({ agent: testHarness.agent });
+
+      // fetch the grant
+      let fetchedMessagesQueryGrant = await cachedPermissions.getPermission({
+        connectedDid : aliceDid.uri,
+        delegateDid  : bobDid.uri,
+        messageType  : DwnInterface.MessagesQuery,
+      });
+      expect(fetchedMessagesQueryGrant).to.not.be.undefined;
+      expect(fetchedMessagesQueryGrant.message.recordId).to.equal(messagesQueryGrant.message.recordId);
+
+      // confirm that the permission was fetched from the API
+      expect(permissionGrantsApiSpy.calledOnce).to.be.true;
+      permissionGrantsApiSpy.resetHistory();
+
+      // fetch the grant again to confirm that it was cached
+      fetchedMessagesQueryGrant = await cachedPermissions.getPermission({
+        connectedDid : aliceDid.uri,
+        delegateDid  : bobDid.uri,
+        messageType  : DwnInterface.MessagesQuery,
+      });
+      expect(fetchedMessagesQueryGrant).to.not.be.undefined;
+      expect(fetchedMessagesQueryGrant.message.recordId).to.equal(messagesQueryGrant.message.recordId);
+
+      // confirm that the permission was fetched a second time from the API
+      expect(permissionGrantsApiSpy.called).to.be.true;
+      permissionGrantsApiSpy.resetHistory();
+
+      // confirm that the permissions is not fetched from the api if cache is set to true on a single call
+      fetchedMessagesQueryGrant = await cachedPermissions.getPermission({
+        connectedDid : aliceDid.uri,
+        delegateDid  : bobDid.uri,
+        messageType  : DwnInterface.MessagesQuery,
+        cached       : true,
+      });
+      expect(fetchedMessagesQueryGrant).to.not.be.undefined;
+      expect(fetchedMessagesQueryGrant.message.recordId).to.equal(messagesQueryGrant.message.recordId);
+
+      // confirm that the permission was fetched from the API
+      expect(permissionGrantsApiSpy.calledOnce).to.be.false;
+    });
+  });
+
+  describe('getPermission', () => {
+    it('throws an error if no permissions are found', async () => {
+      const cachedPermissions = new CachedPermissions({ agent: testHarness.agent });
+
+      try {
+        await cachedPermissions.getPermission({
+          connectedDid : aliceDid.uri,
+          delegateDid  : bobDid.uri,
+          messageType  : DwnInterface.MessagesQuery,
+        });
+        expect.fail('Expected an error to be thrown');
+      } catch(error: any) {
+        expect(error.message).to.equal('CachedPermissions: No permissions found for MessagesQuery: undefined');
+      }
+
+      // create a permission grant to fetch
+      const messagesQueryGrant = await permissions.createGrant({
+        store       : true,
+        author      : aliceDid.uri,
+        grantedTo   : bobDid.uri,
+        dateExpires : Time.createOffsetTimestamp({ seconds: 60 }),
+        scope       : {
+          interface : DwnInterfaceName.Messages,
+          method    : DwnMethodName.Query,
+        }
+      });
+
+      // store the grant as owner from bob so that it can be fetched
+      const { encodedData, ...messagesQueryGrantMessage } = messagesQueryGrant.message;
+      const grantReply = await testHarness.agent.processDwnRequest({
+        target      : bobDid.uri,
+        author      : bobDid.uri,
+        signAsOwner : true,
+        messageType : DwnInterface.RecordsWrite,
+        rawMessage  : messagesQueryGrantMessage,
+        dataStream  : new Blob([ Convert.base64Url(encodedData).toUint8Array() ])
+      });
+      expect(grantReply.reply.status.code).to.equal(202);
+
+      // fetch the grant
+      const fetchedMessagesQueryGrant = await cachedPermissions.getPermission({
+        connectedDid : aliceDid.uri,
+        delegateDid  : bobDid.uri,
+        messageType  : DwnInterface.MessagesQuery,
+      });
+      expect(fetchedMessagesQueryGrant.message.recordId).to.equal(messagesQueryGrant.message.recordId);
+    });
+  });
+});

--- a/packages/agent/tests/dwn-api.spec.ts
+++ b/packages/agent/tests/dwn-api.spec.ts
@@ -11,13 +11,13 @@ import { expect } from 'chai';
 
 import type { PortableIdentity } from '../src/types/identity.js';
 
-import { DwnInterface } from '../src/types/dwn.js';
+import { DwnInterface, DwnPermissionScope } from '../src/types/dwn.js';
 import { BearerIdentity } from '../src/bearer-identity.js';
 import emailProtocolDefinition from './fixtures/protocol-definitions/email.json' assert { type: 'json' };
 import { PlatformAgentTestHarness } from '../src/test-harness.js';
 import { TestAgent } from './utils/test-agent.js';
 import { testDwnUrl } from './utils/test-config.js';
-import { AgentDwnApi, isDwnMessage } from '../src/dwn-api.js';
+import { AgentDwnApi, isDwnMessage, isMessagesPermissionScope, isRecordPermissionScope } from '../src/dwn-api.js';
 
 // NOTE: @noble/secp256k1 requires globalThis.crypto polyfill for node.js <=18: https://github.com/paulmillr/noble-secp256k1/blob/main/README.md#usage
 // Remove when we move off of node.js v18 to v20, earliest possible time would be Oct 2023: https://github.com/nodejs/release#release-schedule
@@ -1934,5 +1934,49 @@ describe('isDwnMessage', () => {
     // negative tests
     expect(isDwnMessage(DwnInterface.RecordsQuery, recordsWriteMessage)).to.be.false;
     expect(isDwnMessage(DwnInterface.RecordsWrite, recordsQueryMessage)).to.be.false;
+  });
+});
+
+describe('isRecordPermissionScope', () => {
+  it('asserts the type of RecordPermissionScope', async () => {
+    // messages read scope to test negative case
+    const messagesReadScope:DwnPermissionScope = {
+      interface : DwnInterfaceName.Messages,
+      method    : DwnMethodName.Read
+    };
+
+    expect(isRecordPermissionScope(messagesReadScope)).to.be.false;
+
+    // records read scope to test positive case
+    const recordsReadScope:DwnPermissionScope = {
+      interface : DwnInterfaceName.Records,
+      method    : DwnMethodName.Read,
+      protocol  : 'https://schemas.xyz/example'
+    };
+
+    expect(isRecordPermissionScope(recordsReadScope)).to.be.true;
+  });
+});
+
+describe('isMessagesPermissionScope', () => {
+  it('asserts the type of RecordPermissionScope', async () => {
+
+    // records read scope to test negative case
+    const recordsReadScope:DwnPermissionScope = {
+      interface : DwnInterfaceName.Records,
+      method    : DwnMethodName.Read,
+      protocol  : 'https://schemas.xyz/example'
+    };
+
+    expect(isMessagesPermissionScope(recordsReadScope)).to.be.false;
+
+    // messages read scope to test positive case
+    const messagesReadScope:DwnPermissionScope = {
+      interface : DwnInterfaceName.Messages,
+      method    : DwnMethodName.Read
+    };
+
+    expect(isMessagesPermissionScope(messagesReadScope)).to.be.true;
+
   });
 });

--- a/packages/agent/tests/store-data.spec.ts
+++ b/packages/agent/tests/store-data.spec.ts
@@ -605,7 +605,7 @@ describe('AgentDataStore', () => {
             expect.fail('Expected an error to be thrown');
 
           } catch (error: any) {
-            expect(error.message).to.include(`Failed to write data to store for: test-1`);
+            expect(error.message).to.include(`Failed to write data to store for test-1`);
           } finally {
             dwnApiStub.restore();
           }

--- a/packages/agent/tests/sync-engine-level.spec.ts
+++ b/packages/agent/tests/sync-engine-level.spec.ts
@@ -280,8 +280,7 @@ describe('SyncEngineLevel', () => {
       });
 
       // Execute Sync to pull all records from Alice's remote DWN to Alice's local DWN.
-      await syncEngine.push();
-      await syncEngine.pull();
+      await syncEngine.sync();
 
       // query local to see all protocols
       localProtocolsQueryResponse = await testHarness.agent.dwn.processRequest({
@@ -347,8 +346,8 @@ describe('SyncEngineLevel', () => {
     describe('sync()', () => {
       it('syncs only specified direction, or if non specified syncs both directions', async () => {
         // spy on push and pull and stub their response
-        const pushSpy = sinon.stub(syncEngine, 'push').resolves();
-        const pullSpy = sinon.stub(syncEngine, 'pull').resolves();
+        const pushSpy = sinon.stub(syncEngine as any, 'push').resolves();
+        const pullSpy = sinon.stub(syncEngine as any, 'pull').resolves();
 
         // Register Alice's DID to be synchronized.
         await testHarness.agent.sync.registerIdentity({
@@ -993,7 +992,7 @@ describe('SyncEngineLevel', () => {
         });
 
         // Execute Sync to pull all records from Alice's remote DWN to Alice's local DWN.
-        await syncEngine.pull();
+        await syncEngine.sync('pull');
 
         // Confirm the record now DOES exist on Alice's local DWN.
         queryResponse = await testHarness.agent.dwn.processRequest({
@@ -1007,7 +1006,7 @@ describe('SyncEngineLevel', () => {
         expect(localDwnQueryReply.entries).to.have.length(1); // Record does exist on local DWN.
 
         // remove `initialWrite` from the response to generate an accurate messageCid
-        const { initialWrite, ...rawMessage } = localDwnQueryReply.entries![0]
+        const { initialWrite, ...rawMessage } = localDwnQueryReply.entries![0];
         const queriedMessageCid = await Message.getCid(rawMessage);
         expect(queriedMessageCid).to.equal(updateMessageCid);
       });
@@ -1089,7 +1088,7 @@ describe('SyncEngineLevel', () => {
         });
 
         // Execute Sync to pull all records from Alice's remote DWNs
-        await syncEngine.pull();
+        await syncEngine.sync('pull');
 
         // Verify sendDwnRequest was called once for each record, including the invalid record
         //
@@ -1222,7 +1221,7 @@ describe('SyncEngineLevel', () => {
         const processMessageSpy = sinon.spy(testHarness.agent.dwn.node, 'processMessage');
 
         // Execute Sync to push records to Alice's remote node
-        await syncEngine.pull();
+        await syncEngine.sync('pull');
 
         // Verify sendDwnRequest is called for all 4 messages
         expect(sendDwnRequestSpy.callCount).to.equal(4, 'sendDwnRequestSpy');
@@ -1261,7 +1260,7 @@ describe('SyncEngineLevel', () => {
         const didResolveSpy = sinon.spy(testHarness.agent.did, 'resolve');
         const sendDwnRequestSpy = sinon.spy(testHarness.agent.rpc, 'sendDwnRequest');
 
-        await syncEngine.pull();
+        await syncEngine.sync('pull');
 
         // Verify DID resolution and DWN requests did not occur.
         expect(didResolveSpy.notCalled).to.be.true;
@@ -1312,7 +1311,7 @@ describe('SyncEngineLevel', () => {
         });
 
         // Execute Sync to pull all records from Alice's remote DWN to Alice's local DWN.
-        await syncEngine.pull();
+        await syncEngine.sync('pull');
 
         // Confirm the record now DOES exist on Alice's local DWN.
         queryResponse = await testHarness.agent.dwn.processRequest({
@@ -1350,7 +1349,7 @@ describe('SyncEngineLevel', () => {
         expect(localDwnQueryReply.status.code).to.equal(200); // Query was successfully executed.
         expect(localDwnQueryReply.entries).to.have.length(0); // New Record doesn't exist on local DWN.
 
-        await syncEngine.pull();
+        await syncEngine.sync('pull');
 
         // Confirm the new record DOES exist on Alice's local DWN.
         queryResponse = await testHarness.agent.dwn.processRequest({
@@ -1400,7 +1399,7 @@ describe('SyncEngineLevel', () => {
         expect(localReply.entries?.length).to.equal(0);
 
         // initiate sync
-        await syncEngine.pull();
+        await syncEngine.sync('pull');
 
         // query that the local record exists
         const { reply: localReply2 } = await testHarness.agent.dwn.processRequest({
@@ -1479,7 +1478,7 @@ describe('SyncEngineLevel', () => {
         });
 
         // Execute Sync to pull all records from Alice's and Bob's remove DWNs to their local DWNs.
-        await syncEngine.pull();
+        await syncEngine.sync('pull');
 
         // Confirm the Alice test record exist on Alice's local DWN.
         let queryResponse = await testHarness.agent.dwn.processRequest({
@@ -1565,7 +1564,7 @@ describe('SyncEngineLevel', () => {
         });
 
         // Execute Sync to pull all records from Alice's remote DWN to Alice's local DWN.
-        await syncEngine.push();
+        await syncEngine.sync('push');
 
         // Confirm the record now DOES exist on Alice's local DWN.
         queryResponse = await testHarness.agent.dwn.sendRequest({
@@ -1579,7 +1578,7 @@ describe('SyncEngineLevel', () => {
         expect(remoteDwnQueryReply.entries).to.have.length(1); // Record does exist on local DWN.
 
         // remove `initialWrite` from the response to generate an accurate messageCid
-        const { initialWrite, ...rawMessage } = remoteDwnQueryReply.entries![0]
+        const { initialWrite, ...rawMessage } = remoteDwnQueryReply.entries![0];
         const queriedMessageCid = await Message.getCid(rawMessage);
         expect(queriedMessageCid).to.equal(updateMessageCid);
       });
@@ -1668,7 +1667,7 @@ describe('SyncEngineLevel', () => {
         });
 
         // Execute Sync to pull all records from Alice's remote DWNs
-        await syncEngine.push();
+        await syncEngine.sync('push');
 
         // verify that sendDwnRequest was called once only for each valid record
         // and getDwnMessage was called for each record, including the invalid record
@@ -1800,7 +1799,7 @@ describe('SyncEngineLevel', () => {
         const sendDwnRequestSpy = sinon.spy(testHarness.agent.rpc, 'sendDwnRequest');
 
         // Execute Sync to push records to Alice's remote node
-        await syncEngine.push();
+        await syncEngine.sync('push');
 
         // Verify sendDwnRequest was called once for each record including the ones that already exist remotely
         expect(sendDwnRequestSpy.callCount).to.equal(4);
@@ -1837,7 +1836,7 @@ describe('SyncEngineLevel', () => {
         const didResolveSpy = sinon.spy(testHarness.agent.did, 'resolve');
         const processRequestSpy = sinon.spy(testHarness.agent.dwn, 'processRequest');
 
-        await syncEngine.push();
+        await syncEngine.sync('push');
 
         // Verify DID resolution and DWN requests did not occur.
         expect(didResolveSpy.notCalled).to.be.true;
@@ -1882,7 +1881,7 @@ describe('SyncEngineLevel', () => {
         });
 
         // Execute Sync to push all records from Alice's local DWN to Alice's remote DWN.
-        await syncEngine.push();
+        await syncEngine.sync('push');
 
         // Confirm the record now DOES exist on Alice's remote DWN.
         queryResponse = await testHarness.agent.dwn.sendRequest({
@@ -1919,7 +1918,7 @@ describe('SyncEngineLevel', () => {
         expect(remoteDwnQueryReply.status.code).to.equal(200); // Query was successfully executed.
         expect(remoteDwnQueryReply.entries).to.have.length(0); // New Record doesn't exist on local DWN.
 
-        await syncEngine.push();
+        await syncEngine.sync('push');
 
         // Confirm the new record DOES exist on Alice's local DWN.
         queryResponse = await testHarness.agent.dwn.sendRequest({
@@ -1968,7 +1967,7 @@ describe('SyncEngineLevel', () => {
         expect(remoteReply.entries?.length).to.equal(0);
 
         // initiate sync
-        await syncEngine.push();
+        await syncEngine.sync('push');
 
         // query for remote REcords
         const { reply: remoteReply2 } = await testHarness.agent.dwn.sendRequest({
@@ -2046,7 +2045,7 @@ describe('SyncEngineLevel', () => {
         });
 
         // Execute Sync to push all records from Alice's and Bob's local DWNs to their remote DWNs.
-        await syncEngine.push();
+        await syncEngine.sync('push');
 
         // Confirm the Alice test record exist on Alice's remote DWN.
         let queryResponse = await testHarness.agent.dwn.sendRequest({

--- a/packages/api/src/dwn-api.ts
+++ b/packages/api/src/dwn-api.ts
@@ -5,7 +5,6 @@
 /// <reference types="@tbd54566975/dwn-sdk-js" />
 
 import type {
-  CachedPermissions,
   CreateGrantParams,
   CreateRequestParams,
   FetchPermissionRequestParams,
@@ -18,6 +17,7 @@ import {
   DwnResponse,
   DwnMessageParams,
   DwnResponseStatus,
+  CachedPermissions,
   ProcessDwnRequest,
   DwnPaginationCursor,
   DwnDataEncodedRecordsWriteMessage,
@@ -279,6 +279,7 @@ export class DwnApi {
     this.connectedDid = options.connectedDid;
     this.delegateDid = options.delegateDid;
     this.permissionsApi = new AgentPermissionsApi({ agent: this.agent });
+    this.cachedPermissionsApi = new CachedPermissions({ agent: this.agent, cachedDefault: true });
   }
 
   /**
@@ -306,13 +307,13 @@ export class DwnApi {
         }
 
         const delegateGrant = await this.cachedPermissionsApi.getPermission({
-          connectedDid: this.connectedDid,
-          delegateDid: this.delegateDid,
-          messageType: messageParams.messageType,
-          protocol: messageParams.protocol,
-          delegate: true,
+          connectedDid : this.connectedDid,
+          delegateDid  : this.delegateDid,
+          messageType  : messageParams.messageType,
+          protocol     : messageParams.protocol,
+          delegate     : true,
           cached,
-        })
+        });
 
         if (!delegateGrant) {
           throw new Error(`AgentDwnApi: No permissions found for ${messageParams.messageType}: ${messageParams.protocol}`);

--- a/packages/api/src/dwn-api.ts
+++ b/packages/api/src/dwn-api.ts
@@ -315,10 +315,6 @@ export class DwnApi {
           cached,
         });
 
-        if (!delegateGrant) {
-          throw new Error(`AgentDwnApi: No permissions found for ${messageParams.messageType}: ${messageParams.protocol}`);
-        }
-
         const grant = await PermissionGrant.parse({ connectedDid: this.delegateDid, agent: this.agent, message: delegateGrant.message });
         return grant;
       }

--- a/packages/api/src/dwn-api.ts
+++ b/packages/api/src/dwn-api.ts
@@ -24,7 +24,7 @@ import {
   AgentPermissionsApi
 } from '@web5/agent';
 
-import { isEmptyObject, TtlCache } from '@web5/common';
+import { isEmptyObject } from '@web5/common';
 import { DwnInterface, getRecordAuthor } from '@web5/agent';
 
 import { Record } from './record.js';
@@ -32,6 +32,8 @@ import { dataToBlob } from './utils.js';
 import { Protocol } from './protocol.js';
 import { PermissionGrant } from './permission-grant.js';
 import { PermissionRequest } from './permission-request.js';
+import { DwnMessagesPermissionScope } from '@web5/agent';
+import { DwnRecordsPermissionScope } from '@web5/agent';
 
 /**
  * Represents the request payload for fetching permission requests from a Decentralized Web Node (DWN).
@@ -797,26 +799,5 @@ export class DwnApi {
         return { record, status };
       },
     };
-  }
-
-  /**
-   * A static method to process connected grants for a delegate DID.
-   *
-   * This will store the grants as the DWN owner to be used later when impersonating the connected DID.
-   */
-  static async processConnectedGrants({ grants, agent, delegateDid }: {
-    grants: DwnDataEncodedRecordsWriteMessage[],
-    agent: Web5Agent,
-    delegateDid: string,
-  }): Promise<void> {
-    for (const grantMessage of grants) {
-      // use the delegateDid as the connectedDid of the grant as they do not yet support impersonation/delegation
-      const grant = await PermissionGrant.parse({ connectedDid: delegateDid, agent, message: grantMessage });
-      // store the grant as the owner of the DWN, this will allow the delegateDid to use the grant when impersonating the connectedDid
-      const { status } = await grant.store(true);
-      if (status.code !== 202) {
-        throw new Error(`AgentDwnApi: Failed to process connected grant: ${status.detail}`);
-      }
-    }
   }
 }

--- a/packages/api/src/web5.ts
+++ b/packages/api/src/web5.ts
@@ -370,7 +370,7 @@ export class Web5 {
       // Enable sync, unless explicitly disabled.
       if (sync !== 'off') {
         // First, register the user identity for sync.
-        await userAgent.sync.registerIdentity({ did: connectedDid, options: {
+        await userAgent.sync.registerIdentity({ did     : connectedDid, options : {
           protocols: [] // TODO: Add protocols to sync
         } });
 

--- a/packages/api/src/web5.ts
+++ b/packages/api/src/web5.ts
@@ -370,7 +370,9 @@ export class Web5 {
       // Enable sync, unless explicitly disabled.
       if (sync !== 'off') {
         // First, register the user identity for sync.
-        await userAgent.sync.registerIdentity({ did: connectedDid });
+        await userAgent.sync.registerIdentity({ did: connectedDid, options: {
+          protocols: [] // TODO: Add protocols to sync
+        } });
 
         // Enable sync using the specified interval or default.
         sync ??= '2m';

--- a/packages/api/tests/dwn-api.spec.ts
+++ b/packages/api/tests/dwn-api.spec.ts
@@ -46,6 +46,10 @@ describe('DwnApi', () => {
     // Instantiate DwnApi for both test identities.
     dwnAlice = new DwnApi({ agent: testHarness.agent, connectedDid: aliceDid.uri });
     dwnBob = new DwnApi({ agent: testHarness.agent, connectedDid: bobDid.uri });
+
+    // clear cached permissions between test runs
+    dwnAlice['cachedPermissions'].clear();
+    dwnBob['cachedPermissions'].clear();
   });
 
   after(async () => {

--- a/packages/api/tests/dwn-api.spec.ts
+++ b/packages/api/tests/dwn-api.spec.ts
@@ -1449,7 +1449,7 @@ describe('DwnApi', () => {
         });
         expect.fail('Should have thrown an error');
       } catch(error:any) {
-        expect(error.message).to.equal('AgentDwnApi: No permissions found for RecordsRead: http://example.com/protocol');
+        expect(error.message).to.equal('CachedPermissions: No permissions found for RecordsRead: http://example.com/protocol');
       }
       expect(fetchGrantsSpy.callCount).to.equal(1);
 
@@ -1463,7 +1463,7 @@ describe('DwnApi', () => {
         });
         expect.fail('Should have thrown an error');
       } catch(error:any) {
-        expect(error.message).to.equal('AgentDwnApi: No permissions found for RecordsRead: http://example.com/protocol');
+        expect(error.message).to.equal('CachedPermissions: No permissions found for RecordsRead: http://example.com/protocol');
       }
 
       expect(fetchGrantsSpy.callCount).to.equal(2); // should have been called again

--- a/packages/api/tests/dwn-api.spec.ts
+++ b/packages/api/tests/dwn-api.spec.ts
@@ -11,6 +11,7 @@ import emailProtocolDefinition from './fixtures/protocol-definitions/email.json'
 import photosProtocolDefinition from './fixtures/protocol-definitions/photos.json' assert { type: 'json' };
 import { DwnInterfaceName, DwnMethodName, PermissionsProtocol, Time } from '@tbd54566975/dwn-sdk-js';
 import { PermissionGrant } from '../src/permission-grant.js';
+import { Web5 } from '../src/web5.js';
 
 let testDwnUrls: string[] = [testDwnUrl];
 
@@ -1389,7 +1390,7 @@ describe('DwnApi', () => {
       // simulate a connect where bobDid can impersonate aliceDid
       dwnBob['connectedDid'] = aliceDid.uri;
       dwnBob['delegateDid'] = bobDid.uri;
-      await DwnApi.processConnectedGrants({
+      await Web5.processConnectedGrants({
         agent       : testHarness.agent,
         delegateDid : bobDid.uri,
         grants      : [ deviceXGrant.rawMessage ]

--- a/packages/api/tests/dwn-api.spec.ts
+++ b/packages/api/tests/dwn-api.spec.ts
@@ -46,10 +46,6 @@ describe('DwnApi', () => {
     // Instantiate DwnApi for both test identities.
     dwnAlice = new DwnApi({ agent: testHarness.agent, connectedDid: aliceDid.uri });
     dwnBob = new DwnApi({ agent: testHarness.agent, connectedDid: bobDid.uri });
-
-    // clear cached permissions between test runs
-    dwnAlice['cachedPermissions'].clear();
-    dwnBob['cachedPermissions'].clear();
   });
 
   after(async () => {

--- a/packages/api/tests/dwn-api.spec.ts
+++ b/packages/api/tests/dwn-api.spec.ts
@@ -48,8 +48,8 @@ describe('DwnApi', () => {
     dwnBob = new DwnApi({ agent: testHarness.agent, connectedDid: bobDid.uri });
 
     // clear cached permissions between test runs
-    dwnAlice['cachedPermissions'].clear();
-    dwnBob['cachedPermissions'].clear();
+    dwnAlice['cachedPermissionsApi'].clear();
+    dwnBob['cachedPermissionsApi'].clear();
   });
 
   after(async () => {

--- a/packages/api/tests/web5.spec.ts
+++ b/packages/api/tests/web5.spec.ts
@@ -16,9 +16,21 @@ import { Web5 } from '../src/web5.js';
 import { DwnInterfaceName, DwnMethodName, Jws, Time } from '@tbd54566975/dwn-sdk-js';
 import { testDwnUrl } from './utils/test-config.js';
 import { DidJwk } from '@web5/dids';
-import { DwnApi } from '../src/dwn-api.js';
 
 describe('web5 api', () => {
+  let consoleWarn;
+
+  before(() => {
+    // Suppress console.warn output due to default password warnings
+    consoleWarn = console.warn;
+    console.warn = () => {};
+  });
+
+  after(() => {
+    // Restore console.warn output
+    console.warn = consoleWarn;
+  });
+
   describe('using Test Harness', () => {
     let testHarness: PlatformAgentTestHarness;
 
@@ -246,7 +258,7 @@ describe('web5 api', () => {
 
         // write the grants to app as owner
         // this also clears the grants cache
-        await DwnApi.processConnectedGrants({
+        await Web5.processConnectedGrants({
           grants      : [ queryGrant.message, deleteGrant.message ],
           agent       : appTestHarness.agent,
           delegateDid : app.uri,
@@ -602,7 +614,7 @@ describe('web5 api', () => {
 
         // write the grants to app as owner
         // this also clears the grants cache
-        await DwnApi.processConnectedGrants({
+        await Web5.processConnectedGrants({
           grants : [ queryGrant.message, deleteGrant.message ],
           agent  : appTestHarness.agent,
           delegateDid,

--- a/packages/api/tests/web5.spec.ts
+++ b/packages/api/tests/web5.spec.ts
@@ -203,7 +203,7 @@ describe('web5 api', () => {
 
           expect.fail('Should have thrown an error');
         } catch(error:any) {
-          expect(error.message).to.include('AgentDwnApi: No permissions found for RecordsQuery');
+          expect(error.message).to.include('CachedPermissions: No permissions found for RecordsQuery');
         }
 
         try {
@@ -216,7 +216,7 @@ describe('web5 api', () => {
 
           expect.fail('Should have thrown an error');
         } catch(error:any) {
-          expect(error.message).to.include('AgentDwnApi: No permissions found for RecordsDelete');
+          expect(error.message).to.include('CachedPermissions: No permissions found for RecordsDelete');
         }
 
         // grant query and delete permissions
@@ -559,7 +559,7 @@ describe('web5 api', () => {
 
           expect.fail('Should have thrown an error');
         } catch(error:any) {
-          expect(error.message).to.include('AgentDwnApi: No permissions found for RecordsQuery');
+          expect(error.message).to.include('CachedPermissions: No permissions found for RecordsQuery');
         }
 
         try {
@@ -572,7 +572,7 @@ describe('web5 api', () => {
 
           expect.fail('Should have thrown an error');
         } catch(error:any) {
-          expect(error.message).to.include('AgentDwnApi: No permissions found for RecordsDelete');
+          expect(error.message).to.include('CachedPermissions: No permissions found for RecordsDelete');
         }
 
         // grant query and delete permissions

--- a/packages/api/tests/web5.spec.ts
+++ b/packages/api/tests/web5.spec.ts
@@ -16,6 +16,7 @@ import { Web5 } from '../src/web5.js';
 import { DwnInterfaceName, DwnMethodName, Jws, Time } from '@tbd54566975/dwn-sdk-js';
 import { testDwnUrl } from './utils/test-config.js';
 import { DidJwk } from '@web5/dids';
+import { Convert } from '@web5/common';
 
 describe('web5 api', () => {
   let consoleWarn;
@@ -53,24 +54,252 @@ describe('web5 api', () => {
       await testHarness.closeStorage();
     });
 
-    describe('connect()', () => {
-      it('accepts an externally created DID with an external agent', async () => {
-        const testIdentity = await testHarness.createIdentity({
-          name        : 'Test',
-          testDwnUrls : ['https://dwn.example.com']
+    describe('constructor', () => {
+      it('instantiates Web5 API with provided Web5Agent and connectedDid', async () => {
+        // Create a new Identity.
+        const socialIdentity = await testHarness.agent.identity.create({
+          metadata  : { name: 'Social' },
+          didMethod : 'jwk',
         });
 
-        // Call connect() with the custom agent.
-        const { web5, did } = await Web5.connect({
+        // Instantiates Web5 instance with test agent and new Identity's DID.
+        const web5 = new Web5({
           agent        : testHarness.agent,
-          connectedDid : testIdentity.did.uri
+          connectedDid : socialIdentity.did.uri,
         });
-
-        expect(did).to.exist;
         expect(web5).to.exist;
-        expect(did).to.equal(testIdentity.did.uri);
+        expect(web5).to.have.property('did');
+        expect(web5).to.have.property('dwn');
+        expect(web5).to.have.property('vc');
       });
 
+      it('supports a single agent with multiple Web5 instances and different DIDs', async () => {
+        // Create two identities, each of which is stored in a new tenant.
+        const careerIdentity = await testHarness.agent.identity.create({
+          metadata  : { name: 'Social' },
+          didMethod : 'jwk',
+        });
+        const socialIdentity = await testHarness.agent.identity.create({
+          metadata  : { name: 'Social' },
+          didMethod : 'jwk',
+        });
+
+        // Instantiate a Web5 instance with the "Career" Identity, write a record, and verify the result.
+        const web5Career = new Web5({
+          agent        : testHarness.agent,
+          connectedDid : careerIdentity.did.uri,
+        });
+        expect(web5Career).to.exist;
+
+        // Instantiate a Web5 instance with the "Social" Identity, write a record, and verify the result.
+        const web5Social = new Web5({
+          agent        : testHarness.agent,
+          connectedDid : socialIdentity.did.uri,
+        });
+        expect(web5Social).to.exist;
+      });
+    });
+
+    describe('scenarios', () => {
+      it('writes records with multiple identities under management', async () => {
+        // First launch and initialization.
+        await testHarness.agent.initialize({ password: 'test' });
+
+        // Start the Agent, which will decrypt and load the Agent's DID from the vault.
+        await testHarness.agent.start({ password: 'test' });
+
+        // Create two identities, each of which is stored in a new tenant.
+        const careerIdentity = await testHarness.agent.identity.create({
+          metadata  : { name: 'Social' },
+          didMethod : 'jwk',
+        });
+        const socialIdentity = await testHarness.agent.identity.create({
+          metadata  : { name: 'Social' },
+          didMethod : 'jwk',
+        });
+
+        // Instantiate a Web5 instance with the "Career" Identity, write a record, and verify the result.
+        const web5Career = new Web5({
+          agent        : testHarness.agent,
+          connectedDid : careerIdentity.did.uri,
+        });
+        const careerResult = await web5Career.dwn.records.write({
+          data    : 'Hello, world!',
+          message : {
+            schema     : 'foo/bar',
+            dataFormat : 'text/plain',
+          },
+        });
+        expect(careerResult.status.code).to.equal(202);
+        expect(careerResult.record).to.exist;
+        expect(careerResult.record?.author).to.equal(careerIdentity.did.uri);
+        expect(await careerResult.record?.data.text()).to.equal(
+          'Hello, world!'
+        );
+
+        // Instantiate a Web5 instance with the "Social" Identity, write a record, and verify the result.
+        const web5Social = new Web5({
+          agent        : testHarness.agent,
+          connectedDid : socialIdentity.did.uri,
+        });
+        const socialResult = await web5Social.dwn.records.write({
+          data    : 'Hello, everyone!',
+          message : {
+            schema     : 'foo/bar',
+            dataFormat : 'text/plain',
+          },
+        });
+        expect(socialResult.status.code).to.equal(202);
+        expect(socialResult.record).to.exist;
+        expect(socialResult.record?.author).to.equal(socialIdentity.did.uri);
+        expect(await socialResult.record?.data.text()).to.equal(
+          'Hello, everyone!'
+        );
+      });
+    });
+  });
+
+  describe('connect()', () => {
+    let testHarness: PlatformAgentTestHarness;
+
+    before(async () => {
+      testHarness = await PlatformAgentTestHarness.setup({
+        agentClass  : Web5UserAgent,
+        agentStores : 'memory',
+      });
+    });
+
+    beforeEach(async () => {
+      sinon.restore();
+      testHarness.agent.sync.stopSync();
+      await testHarness.clearStorage();
+      await testHarness.createAgentDid();
+    });
+
+    after(async () => {
+      sinon.restore();
+      await testHarness.clearStorage();
+      await testHarness.closeStorage();
+    });
+
+    it('uses Web5UserAgent, by default', async () => {
+      // stub the create method of the Web5UserAgent to use the test harness agent
+      // this avoids DB locks when the agent is created twice
+      sinon.stub(Web5UserAgent, 'create').resolves(testHarness.agent as Web5UserAgent);
+
+      const { web5, recoveryPhrase, did } = await Web5.connect();
+      expect(web5).to.exist;
+      expect(web5.agent).to.be.instanceOf(Web5UserAgent);
+      // Verify recovery phrase is a 12-word string.
+      expect(recoveryPhrase).to.be.a('string');
+      expect(recoveryPhrase.split(' ')).to.have.lengthOf(12);
+
+      // if called again, the same DID is returned, and the recovery phrase is not regenerated
+      const { recoveryPhrase: recoveryPhraseConnect2, did: didConnect2 } = await Web5.connect();
+      expect(recoveryPhraseConnect2).to.be.undefined;
+      expect(didConnect2).to.equal(did);
+    });
+
+    it('accepts an externally created DID', async () => {
+      const walletConnectSpy = sinon.spy(WalletConnect, 'initClient');
+
+      const testIdentity = await testHarness.createIdentity({
+        name        : 'Test',
+        testDwnUrls : ['https://dwn.example.com'],
+      });
+
+      // Call connect() with the custom agent.
+      const { web5, did } = await Web5.connect({
+        agent        : testHarness.agent,
+        connectedDid : testIdentity.did.uri,
+      });
+
+      expect(did).to.exist;
+      expect(web5).to.exist;
+      expect(walletConnectSpy.called).to.be.false;
+    });
+
+    it('creates an identity using the provided techPreview dwnEndpoints', async () => {
+      sinon
+        .stub(Web5UserAgent, 'create')
+        .resolves(testHarness.agent as Web5UserAgent);
+      const walletConnectSpy = sinon.spy(WalletConnect, 'initClient');
+      const identityApiSpy = sinon.spy(AgentIdentityApi.prototype, 'create');
+      const { web5, did } = await Web5.connect({
+        techPreview: { dwnEndpoints: ['https://dwn.example.com/preview'] },
+      });
+      expect(web5).to.exist;
+      expect(did).to.exist;
+
+      expect(identityApiSpy.calledOnce, 'identityApiSpy called').to.be.true;
+      const serviceEndpoints = (
+        identityApiSpy.firstCall.args[0].didOptions as any
+      ).services[0].serviceEndpoint;
+      expect(serviceEndpoints).to.deep.equal([
+        'https://dwn.example.com/preview',
+      ]);
+      expect(walletConnectSpy.called).to.be.false;
+    });
+
+    it('creates an identity using the provided didCreateOptions dwnEndpoints', async () => {
+      sinon
+        .stub(Web5UserAgent, 'create')
+        .resolves(testHarness.agent as Web5UserAgent);
+      const identityApiSpy = sinon.spy(AgentIdentityApi.prototype, 'create');
+      const walletConnectSpy = sinon.spy(WalletConnect, 'initClient');
+      const { web5, did } = await Web5.connect({
+        didCreateOptions: { dwnEndpoints: ['https://dwn.example.com'] },
+      });
+      expect(web5).to.exist;
+      expect(did).to.exist;
+
+      expect(identityApiSpy.calledOnce, 'identityApiSpy called').to.be.true;
+      const serviceEndpoints = (
+        identityApiSpy.firstCall.args[0].didOptions as any
+      ).services[0].serviceEndpoint;
+      expect(serviceEndpoints).to.deep.equal(['https://dwn.example.com']);
+      expect(walletConnectSpy.called).to.be.false;
+    });
+
+    it('defaults to the first identity if multiple identities exist', async () => {
+      // scenario: For some reason more than one identity exists when attempting to re-connect to `Web5`
+      // the first identity in the array should be the one selected
+      // TODO: this has happened due to a race condition somewhere. Dig into this issue and implement a better way to select/manage DIDs when using `Web5.connect()`
+
+      // create an identity by connecting
+      sinon.stub(Web5UserAgent, 'create').resolves(testHarness.agent as Web5UserAgent);
+      const { web5, did } = await Web5.connect({ techPreview: { dwnEndpoints: [ testDwnUrl ] }});
+      expect(web5).to.exist;
+      expect(did).to.exist;
+
+      // create a second identity
+      await testHarness.agent.identity.create({
+        didMethod : 'jwk',
+        metadata  : { name: 'Second' }
+      });
+
+      // connect again
+      const { did: did2 } = await Web5.connect();
+      expect(did2).to.equal(did);
+    });
+
+    it('defaults to `https://dwn.tbddev.org/beta` as the single DWN Service endpoint if non is provided', async () => {
+      sinon
+        .stub(Web5UserAgent, 'create')
+        .resolves(testHarness.agent as Web5UserAgent);
+      const identityApiSpy = sinon.spy(AgentIdentityApi.prototype, 'create');
+      const { web5, did } = await Web5.connect();
+      expect(web5).to.exist;
+      expect(did).to.exist;
+
+      expect(identityApiSpy.calledOnce, 'identityApiSpy called').to.be.true;
+      const serviceEndpoints = (
+        identityApiSpy.firstCall.args[0].didOptions as any
+      ).services[0].serviceEndpoint;
+      expect(serviceEndpoints).to.deep.equal(['https://dwn.tbddev.org/beta']);
+    });
+
+    describe('walletConnectOptions', () => {
       it('uses walletConnectOptions to connect to a DID and import the grants', async () => {
         // Create a new Identity.
         const alice = await testHarness.createIdentity({
@@ -102,6 +331,16 @@ describe('web5 api', () => {
           },
         });
         expect(protocolConfigReply.status.code).to.equal(202);
+
+        // send the protocol to alice's remote DWN
+        const { reply: protocolSendReply } = await testHarness.agent.dwn.sendRequest({
+          author      : alice.did.uri,
+          target      : alice.did.uri,
+          messageType : DwnInterface.ProtocolsConfigure,
+          rawMessage  : protocolConfigureMessage,
+        });
+        expect(protocolSendReply.status.code).to.equal(202);
+
         // create an identity for the app to use
         const app = await testHarness.agent.did.create({
           store  : false,
@@ -121,6 +360,16 @@ describe('web5 api', () => {
           }
         });
 
+        const { encodedData: writeGrantEncodedData, ...writeGrantMessage } = writeGrant.message;
+        const writeGrantSend = await testHarness.agent.sendDwnRequest({
+          author      : alice.did.uri,
+          target      : alice.did.uri,
+          messageType : DwnInterface.RecordsWrite,
+          rawMessage  : writeGrantMessage,
+          dataStream  : new Blob([ Convert.base64Url(writeGrantEncodedData).toUint8Array() ])
+        });
+        expect(writeGrantSend.reply.status.code).to.equal(202);
+
         const readGrant = await testHarness.agent.permissions.createGrant({
           delegated   : true,
           author      : alice.did.uri,
@@ -133,9 +382,62 @@ describe('web5 api', () => {
           }
         });
 
-        // stub the walletInit method of the Connect placeholder class
+        const { encodedData: readGrantEncodedData, ...readGrantMessage } = readGrant.message;
+        const readGrantSend = await testHarness.agent.sendDwnRequest({
+          author      : alice.did.uri,
+          target      : alice.did.uri,
+          messageType : DwnInterface.RecordsWrite,
+          rawMessage  : readGrantMessage,
+          dataStream  : new Blob([ Convert.base64Url(readGrantEncodedData).toUint8Array() ])
+        });
+        expect(readGrantSend.reply.status.code).to.equal(202);
+
+        // create MessagesQuery and MessagesRead grants so that sync does not fail
+        const messagesQueryGrant = await testHarness.agent.permissions.createGrant({
+          store       : true,
+          author      : alice.did.uri,
+          grantedTo   : app.uri,
+          dateExpires : Time.createOffsetTimestamp({ seconds: 60 }),
+          scope       : {
+            interface : DwnInterfaceName.Messages,
+            method    : DwnMethodName.Query,
+          }
+        });
+
+        const { encodedData: messagesQueryGrantEncodedData, ...messagesQueryGrantMessage} = messagesQueryGrant.message;
+        const messagesQueryGrantSend = await testHarness.agent.sendDwnRequest({
+          author      : alice.did.uri,
+          target      : alice.did.uri,
+          messageType : DwnInterface.RecordsWrite,
+          rawMessage  : messagesQueryGrantMessage,
+          dataStream  : new Blob([ Convert.base64Url(messagesQueryGrantEncodedData).toUint8Array() ])
+        });
+        expect(messagesQueryGrantSend.reply.status.code).to.equal(202);
+
+        const messagesReadGrant = await testHarness.agent.permissions.createGrant({
+          store       : true,
+          author      : alice.did.uri,
+          grantedTo   : app.uri,
+          dateExpires : Time.createOffsetTimestamp({ seconds: 60 }),
+          scope       : {
+            interface : DwnInterfaceName.Messages,
+            method    : DwnMethodName.Read,
+          }
+        });
+
+        const { encodedData: messagesReadEncodedData, ...messagesReadGrantMessage  } = messagesReadGrant.message;
+        const messagesReadGrantSend = await testHarness.agent.sendDwnRequest({
+          author      : alice.did.uri,
+          target      : alice.did.uri,
+          messageType : DwnInterface.RecordsWrite,
+          rawMessage  : messagesReadGrantMessage,
+          dataStream  : new Blob([ Convert.base64Url(messagesReadEncodedData).toUint8Array() ])
+        });
+        expect(messagesReadGrantSend.reply.status.code).to.equal(202);
+
+        // stub the walletInit method
         sinon.stub(WalletConnect, 'initClient').resolves({
-          delegateGrants : [ writeGrant.message, readGrant.message ],
+          delegateGrants : [ writeGrant.message, readGrant.message, messagesQueryGrant.message, messagesReadGrant.message ],
           delegateDid    : await app.export(),
           connectedDid   : alice.did.uri
         });
@@ -166,371 +468,6 @@ describe('web5 api', () => {
         expect(delegateDid).to.exist;
         expect(did).to.equal(alice.did.uri);
         expect(delegateDid).to.equal(app.uri);
-
-        // in lieu of sync, we will process the grants and protocol definition on the local connected agent
-        const { reply: localProtocolReply } = await web5.agent.processDwnRequest({
-          author      : alice.did.uri,
-          target      : alice.did.uri,
-          messageType : DwnInterface.ProtocolsConfigure,
-          rawMessage  : protocolConfigureMessage,
-        });
-        expect(localProtocolReply.status.code).to.equal(202);
-
-        // use the grant to write a record
-        const writeResult = await web5.dwn.records.write({
-          data    : 'Hello, world!',
-          message : {
-            protocol     : protocol.protocol,
-            protocolPath : 'foo',
-          }
-        });
-        expect(writeResult.status.code).to.equal(202);
-        expect(writeResult.record).to.exist;
-        // test that the logical author is the connected DID and the signer is the impersonator DID
-        expect(writeResult.record.author).to.equal(did);
-        const writeSigner = Jws.getSignerDid(writeResult.record.authorization.signature.signatures[0]);
-        expect(writeSigner).to.equal(delegateDid);
-
-        const readResult = await web5.dwn.records.read({
-          protocol : protocol.protocol,
-          message  : {
-            filter: { recordId: writeResult.record.id }
-          }
-        });
-        expect(readResult.status.code).to.equal(200);
-        expect(readResult.record).to.exist;
-        // test that the logical author is the connected DID and the signer is the impersonator DID
-        expect(readResult.record.author).to.equal(did);
-        const readSigner = Jws.getSignerDid(readResult.record.authorization.signature.signatures[0]);
-        expect(readSigner).to.equal(delegateDid);
-
-        // attempt to query or delete, should fail because we did not grant query permissions
-        try {
-          await web5.dwn.records.query({
-            protocol : protocol.protocol,
-            message  : {
-              filter: { protocol: protocol.protocol }
-            }
-          });
-
-          expect.fail('Should have thrown an error');
-        } catch(error:any) {
-          expect(error.message).to.include('CachedPermissions: No permissions found for RecordsQuery');
-        }
-
-        try {
-          await web5.dwn.records.delete({
-            protocol : protocol.protocol,
-            message  : {
-              recordId: writeResult.record.id
-            }
-          });
-
-          expect.fail('Should have thrown an error');
-        } catch(error:any) {
-          expect(error.message).to.include('CachedPermissions: No permissions found for RecordsDelete');
-        }
-
-        // grant query and delete permissions
-        const queryGrant = await testHarness.agent.permissions.createGrant({
-          author      : alice.did.uri,
-          delegated   : true,
-          grantedTo   : app.uri,
-          dateExpires : Time.createOffsetTimestamp({ seconds: 60 }),
-          scope       : {
-            interface : DwnInterfaceName.Records,
-            method    : DwnMethodName.Query,
-            protocol  : protocol.protocol,
-          }
-        });
-
-        const deleteGrant = await testHarness.agent.permissions.createGrant({
-          author      : alice.did.uri,
-          delegated   : true,
-          grantedTo   : app.uri,
-          dateExpires : Time.createOffsetTimestamp({ seconds: 60 }),
-          scope       : {
-            interface : DwnInterfaceName.Records,
-            method    : DwnMethodName.Delete,
-            protocol  : protocol.protocol,
-          }
-        });
-
-        // write the grants to app as owner
-        // this also clears the grants cache
-        await Web5.processConnectedGrants({
-          grants      : [ queryGrant.message, deleteGrant.message ],
-          agent       : appTestHarness.agent,
-          delegateDid : app.uri,
-        });
-
-        // attempt to delete using the grant
-        const deleteResult = await web5.dwn.records.delete({
-          protocol : protocol.protocol,
-          message  : {
-            recordId: writeResult.record.id
-          }
-        });
-        expect(deleteResult.status.code).to.equal(202);
-
-        // attempt to query using the grant
-        const queryResult = await web5.dwn.records.query({
-          protocol : protocol.protocol,
-          message  : {
-            filter: { protocol: protocol.protocol }
-          }
-        });
-        expect(queryResult.status.code).to.equal(200);
-        expect(queryResult.records).to.have.lengthOf(0); // record has been deleted
-
-        // connecting a 2nd time will return the same connectedDID and delegatedDID
-        const { did: did2, delegateDid: delegateDid2 } = await Web5.connect();
-        expect(did2).to.equal(did);
-        expect(delegateDid2).to.equal(delegateDid);
-
-        // Close the app test harness storage.
-        await appTestHarness.clearStorage();
-        await appTestHarness.closeStorage();
-      });
-
-      it('cleans up imported Identity from walletConnectOptions flow if grants cannot be processed', async () => {
-        const alice = await testHarness.createIdentity({
-          name        : 'Alice',
-          testDwnUrls : [testDwnUrl]
-        });
-
-        // alice installs a protocol definition
-        const protocol: DwnProtocolDefinition = {
-          protocol  : 'https://example.com/test-protocol',
-          published : true,
-          types     : {
-            foo : {},
-            bar : {}
-          },
-          structure: {
-            foo: {
-              bar: {}
-            }
-          }
-        };
-
-        const { reply: protocolConfigReply } = await testHarness.agent.dwn.processRequest({
-          author        : alice.did.uri,
-          target        : alice.did.uri,
-          messageType   : DwnInterface.ProtocolsConfigure,
-          messageParams : {
-            definition: protocol,
-          },
-        });
-        expect(protocolConfigReply.status.code).to.equal(202);
-        // create an identity for the app to use
-        const app = await testHarness.agent.did.create({
-          store  : false,
-          method : 'jwk',
-        });
-
-        // create grants for the app to use
-        const writeGrant = await testHarness.agent.permissions.createGrant({
-          delegated   : true,
-          author      : alice.did.uri,
-          grantedTo   : app.uri,
-          dateExpires : Time.createOffsetTimestamp({ seconds: 60 }),
-          scope       : {
-            interface : DwnInterfaceName.Records,
-            method    : DwnMethodName.Write,
-            protocol  : protocol.protocol,
-          }
-        });
-
-        const readGrant = await testHarness.agent.permissions.createGrant({
-          delegated   : true,
-          author      : alice.did.uri,
-          grantedTo   : app.uri,
-          dateExpires : Time.createOffsetTimestamp({ seconds: 60 }),
-          scope       : {
-            interface : DwnInterfaceName.Records,
-            method    : DwnMethodName.Read,
-            protocol  : protocol.protocol,
-          }
-        });
-
-        // stub the walletInit method of the Connect placeholder class
-        sinon.stub(WalletConnect, 'initClient').resolves({
-          delegateGrants : [ writeGrant.message, readGrant.message ],
-          delegateDid    : await app.export(),
-          connectedDid   : alice.did.uri
-        });
-
-        const appTestHarness = await PlatformAgentTestHarness.setup({
-          agentClass       : Web5UserAgent,
-          agentStores      : 'memory',
-          testDataLocation : '__TESTDATA__/web5-connect-app'
-        });
-        await appTestHarness.clearStorage();
-        await appTestHarness.createAgentDid();
-
-
-        // stub processDwnRequest to return a non 202 error code
-        sinon.stub(appTestHarness.agent, 'processDwnRequest').resolves({
-          messageCid : '',
-          reply      : { status: { code: 400, detail: 'Bad Request' } }
-        });
-
-        // stub the create method of the Web5UserAgent to use the test harness agent
-        sinon.stub(Web5UserAgent, 'create').resolves(appTestHarness.agent as Web5UserAgent);
-
-        try {
-          // connect to the app, the options don't matter because we're stubbing the initClient method
-          await Web5.connect({
-            walletConnectOptions: {
-              connectServerUrl   : 'https://connect.example.com',
-              walletUri          : 'https://wallet.example.com',
-              validatePin        : async () => { return '1234'; },
-              onWalletUriReady   : (_walletUri: string) => {},
-              permissionRequests : []
-            }
-          });
-
-          expect.fail('Should have thrown an error');
-        } catch(error:any) {
-          expect(error.message).to.equal('Failed to connect to wallet: AgentDwnApi: Failed to process connected grant: Bad Request');
-        }
-
-        // check that the Identity was deleted
-        const appDid = await appTestHarness.agent.identity.list();
-        expect(appDid).to.have.lengthOf(0);
-
-        // close the app test harness storage
-        await appTestHarness.clearStorage();
-        await appTestHarness.closeStorage();
-      });
-
-      it('logs an error if there is a failure during cleanup of Identity information, but does not throw', async () => {
-        // create a DID that is not stored in the agent
-        const did = await DidJwk.create();
-        const identity = new BearerIdentity({
-          did,
-          metadata: {
-            name   : 'Test',
-            uri    : did.uri,
-            tenant : did.uri
-          }
-        });
-
-        // stub console.error to avoid logging errors into the test output, use as spy to check if the error message is logged
-        const consoleSpy = sinon.stub(console, 'error').returns();
-
-        // call identityCleanup on a did that does not exist
-        await Web5['cleanUpIdentity']({ userAgent: testHarness.agent as Web5UserAgent, identity });
-
-        expect(consoleSpy.calledTwice, 'console.error called twice').to.be.true;
-      });
-
-      it('uses walletConnectOptions to connect to a DID and import the grants', async () => {
-        // Create a new Identity.
-        const alice = await testHarness.createIdentity({
-          name        : 'Alice',
-          testDwnUrls : [testDwnUrl]
-        });
-
-        // alice installs a protocol definition
-        const protocol: DwnProtocolDefinition = {
-          protocol  : 'https://example.com/test-protocol',
-          published : true,
-          types     : {
-            foo : {},
-            bar : {}
-          },
-          structure: {
-            foo: {
-              bar: {}
-            }
-          }
-        };
-
-        const { reply: protocolConfigReply, message: protocolConfigureMessage } = await testHarness.agent.dwn.processRequest({
-          author        : alice.did.uri,
-          target        : alice.did.uri,
-          messageType   : DwnInterface.ProtocolsConfigure,
-          messageParams : {
-            definition: protocol,
-          },
-        });
-        expect(protocolConfigReply.status.code).to.equal(202);
-
-        // create an identity for the app to use
-        const app = await testHarness.agent.did.create({
-          store  : false,
-          method : 'jwk',
-        });
-
-        // create grants for the app to use
-        const writeGrant = await testHarness.agent.permissions.createGrant({
-          delegated   : true,
-          author      : alice.did.uri,
-          grantedTo   : app.uri,
-          dateExpires : Time.createOffsetTimestamp({ seconds: 60 }),
-          scope       : {
-            interface : DwnInterfaceName.Records,
-            method    : DwnMethodName.Write,
-            protocol  : protocol.protocol,
-          }
-        });
-
-        const readGrant = await testHarness.agent.permissions.createGrant({
-          delegated   : true,
-          author      : alice.did.uri,
-          grantedTo   : app.uri,
-          dateExpires : Time.createOffsetTimestamp({ seconds: 60 }),
-          scope       : {
-            interface : DwnInterfaceName.Records,
-            method    : DwnMethodName.Read,
-            protocol  : protocol.protocol,
-          }
-        });
-
-        // stub the walletInit method
-        sinon.stub(WalletConnect, 'initClient').resolves({
-          delegateGrants : [ writeGrant.message, readGrant.message ],
-          delegateDid    : await app.export(),
-          connectedDid   : alice.did.uri
-        });
-
-        const appTestHarness = await PlatformAgentTestHarness.setup({
-          agentClass       : Web5UserAgent,
-          agentStores      : 'memory',
-          testDataLocation : '__TESTDATA__/web5-connect-app'
-        });
-        await appTestHarness.clearStorage();
-        await appTestHarness.createAgentDid();
-
-        // stub the create method of the Web5UserAgent to use the test harness agent
-        sinon.stub(Web5UserAgent, 'create').resolves(appTestHarness.agent as Web5UserAgent);
-
-        // connect to the app, the options don't matter because we're stubbing the initClient method
-        const { web5, did, delegateDid } = await Web5.connect({
-          walletConnectOptions: {
-            connectServerUrl   : 'https://connect.example.com',
-            walletUri          : 'https://wallet.example.com',
-            validatePin        : async () => { return '1234'; },
-            onWalletUriReady   : (_walletUri: string) => {},
-            permissionRequests : [],
-          }
-        });
-        expect(web5).to.exist;
-        expect(did).to.exist;
-        expect(delegateDid).to.exist;
-        expect(did).to.equal(alice.did.uri);
-        expect(delegateDid).to.equal(app.uri);
-
-        // in lieu of sync, we will process the grants and protocol definition on the local connected agent
-        const { reply: localProtocolReply } = await web5.agent.processDwnRequest({
-          author      : alice.did.uri,
-          target      : alice.did.uri,
-          messageType : DwnInterface.ProtocolsConfigure,
-          rawMessage  : protocolConfigureMessage,
-        });
-        expect(localProtocolReply.status.code).to.equal(202);
 
         // use the grant to write a record
         const writeResult = await web5.dwn.records.write({
@@ -784,272 +721,78 @@ describe('web5 api', () => {
 
         expect(consoleSpy.calledTwice, 'console.error called twice').to.be.true;
       });
-    });
 
-    describe('constructor', () => {
-      it('instantiates Web5 API with provided Web5Agent and connectedDid', async () => {
+      it('throws an error if walletConnectOptions are provided and sync is set to `off`', async () => {
+        // stub the walletInit method
+        sinon.stub(WalletConnect, 'initClient').resolves({
+          delegateGrants : [ ],
+          delegateDid    : {} as any,
+          connectedDid   : ''
+        });
+
+        // stub the create method of the Web5UserAgent to use the test harness agent
+        sinon.stub(Web5UserAgent, 'create').resolves(testHarness.agent as Web5UserAgent);
+
+        try {
+
+          // attempt to connect with sync set to false
+          await Web5.connect({
+            sync                 : 'off',
+            walletConnectOptions : {
+              connectServerUrl   : 'https://connect.example.com',
+              walletUri          : 'https://wallet.example.com',
+              validatePin        : async () => { return '1234'; },
+              onWalletUriReady   : (_walletUri: string) => {},
+              permissionRequests : []
+            }
+          });
+
+          expect.fail('Should have thrown an error');
+        } catch(error: any) {
+          expect(error.message).to.equal('Sync must not be disabled when using WalletConnect');
+        }
+      });
+
+      it('does not throw an error if walletConnectOptions are provided and sync is not the default', async () => {
         // Create a new Identity.
-        const socialIdentity = await testHarness.agent.identity.create({
-          metadata  : { name: 'Social' },
-          didMethod : 'jwk',
+        const alice = await testHarness.createIdentity({
+          name        : 'Alice',
+          testDwnUrls : [testDwnUrl]
         });
 
-        // Instantiates Web5 instance with test agent and new Identity's DID.
-        const web5 = new Web5({
-          agent        : testHarness.agent,
-          connectedDid : socialIdentity.did.uri,
+        // create an identity for the app to use
+        const app = await testHarness.agent.did.create({
+          store  : false,
+          method : 'jwk',
         });
-        expect(web5).to.exist;
-        expect(web5).to.have.property('did');
-        expect(web5).to.have.property('dwn');
-        expect(web5).to.have.property('vc');
+
+        // stub the walletInit method
+        sinon.stub(WalletConnect, 'initClient').resolves({
+          delegateGrants : [ ],
+          delegateDid    : await app.export(),
+          connectedDid   : alice.did.uri
+        });
+
+        // stub the create method of the Web5UserAgent to use the test harness agent
+        sinon.stub(Web5UserAgent, 'create').resolves(testHarness.agent as Web5UserAgent);
+
+        // stub the sync records as we are not actually testing sync
+        sinon.stub(testHarness.agent.sync, 'sync').resolves();
+        const startSyncSpy = sinon.stub(testHarness.agent.sync, 'startSync').resolves();
+        // attempt to connect with sync set to false
+        await Web5.connect({
+          sync                 : '1m',
+          walletConnectOptions : {
+            connectServerUrl   : 'https://connect.example.com',
+            walletUri          : 'https://wallet.example.com',
+            validatePin        : async () => { return '1234'; },
+            onWalletUriReady   : (_walletUri: string) => {},
+            permissionRequests : []
+          }
+        });
+
+        expect(startSyncSpy.args[0][0].interval).to.equal('1m');
       });
-
-      it('supports a single agent with multiple Web5 instances and different DIDs', async () => {
-        // Create two identities, each of which is stored in a new tenant.
-        const careerIdentity = await testHarness.agent.identity.create({
-          metadata  : { name: 'Social' },
-          didMethod : 'jwk',
-        });
-        const socialIdentity = await testHarness.agent.identity.create({
-          metadata  : { name: 'Social' },
-          didMethod : 'jwk',
-        });
-
-        // Instantiate a Web5 instance with the "Career" Identity, write a record, and verify the result.
-        const web5Career = new Web5({
-          agent        : testHarness.agent,
-          connectedDid : careerIdentity.did.uri,
-        });
-        expect(web5Career).to.exist;
-
-        // Instantiate a Web5 instance with the "Social" Identity, write a record, and verify the result.
-        const web5Social = new Web5({
-          agent        : testHarness.agent,
-          connectedDid : socialIdentity.did.uri,
-        });
-        expect(web5Social).to.exist;
-      });
-    });
-
-    describe('scenarios', () => {
-      it('writes records with multiple identities under management', async () => {
-        // First launch and initialization.
-        await testHarness.agent.initialize({ password: 'test' });
-
-        // Start the Agent, which will decrypt and load the Agent's DID from the vault.
-        await testHarness.agent.start({ password: 'test' });
-
-        // Create two identities, each of which is stored in a new tenant.
-        const careerIdentity = await testHarness.agent.identity.create({
-          metadata  : { name: 'Social' },
-          didMethod : 'jwk',
-        });
-        const socialIdentity = await testHarness.agent.identity.create({
-          metadata  : { name: 'Social' },
-          didMethod : 'jwk',
-        });
-
-        // Instantiate a Web5 instance with the "Career" Identity, write a record, and verify the result.
-        const web5Career = new Web5({
-          agent        : testHarness.agent,
-          connectedDid : careerIdentity.did.uri,
-        });
-        const careerResult = await web5Career.dwn.records.write({
-          data    : 'Hello, world!',
-          message : {
-            schema     : 'foo/bar',
-            dataFormat : 'text/plain',
-          },
-        });
-        expect(careerResult.status.code).to.equal(202);
-        expect(careerResult.record).to.exist;
-        expect(careerResult.record?.author).to.equal(careerIdentity.did.uri);
-        expect(await careerResult.record?.data.text()).to.equal(
-          'Hello, world!'
-        );
-
-        // Instantiate a Web5 instance with the "Social" Identity, write a record, and verify the result.
-        const web5Social = new Web5({
-          agent        : testHarness.agent,
-          connectedDid : socialIdentity.did.uri,
-        });
-        const socialResult = await web5Social.dwn.records.write({
-          data    : 'Hello, everyone!',
-          message : {
-            schema     : 'foo/bar',
-            dataFormat : 'text/plain',
-          },
-        });
-        expect(socialResult.status.code).to.equal(202);
-        expect(socialResult.record).to.exist;
-        expect(socialResult.record?.author).to.equal(socialIdentity.did.uri);
-        expect(await socialResult.record?.data.text()).to.equal(
-          'Hello, everyone!'
-        );
-      });
-    });
-  });
-
-  describe('connect()', () => {
-    let testHarness: PlatformAgentTestHarness;
-
-    before(async () => {
-      testHarness = await PlatformAgentTestHarness.setup({
-        agentClass  : Web5UserAgent,
-        agentStores : 'memory',
-      });
-    });
-
-    beforeEach(async () => {
-      sinon.restore();
-      await testHarness.clearStorage();
-      await testHarness.createAgentDid();
-    });
-
-    after(async () => {
-      sinon.restore();
-      await testHarness.clearStorage();
-      await testHarness.closeStorage();
-    });
-
-    it('uses Web5UserAgent, by default', async () => {
-      // stub the create method of the Web5UserAgent to use the test harness agent
-      // this avoids DB locks when the agent is created twice
-      sinon.stub(Web5UserAgent, 'create').resolves(testHarness.agent as Web5UserAgent);
-
-      const { web5, recoveryPhrase, did } = await Web5.connect();
-      expect(web5).to.exist;
-      expect(web5.agent).to.be.instanceOf(Web5UserAgent);
-      // Verify recovery phrase is a 12-word string.
-      expect(recoveryPhrase).to.be.a('string');
-      expect(recoveryPhrase.split(' ')).to.have.lengthOf(12);
-
-      // if called again, the same DID is returned, and the recovery phrase is not regenerated
-      const { recoveryPhrase: recoveryPhraseConnect2, did: didConnect2 } = await Web5.connect();
-      expect(recoveryPhraseConnect2).to.be.undefined;
-      expect(didConnect2).to.equal(did);
-    });
-
-    it('accepts an externally created DID', async () => {
-      const walletConnectSpy = sinon.spy(WalletConnect, 'initClient');
-
-      const testIdentity = await testHarness.createIdentity({
-        name        : 'Test',
-        testDwnUrls : ['https://dwn.example.com'],
-      });
-
-      // Call connect() with the custom agent.
-      const { web5, did } = await Web5.connect({
-        agent        : testHarness.agent,
-        connectedDid : testIdentity.did.uri,
-      });
-
-      expect(did).to.exist;
-      expect(web5).to.exist;
-      expect(walletConnectSpy.called).to.be.false;
-    });
-
-    it('creates an identity using the provided techPreview dwnEndpoints', async () => {
-      sinon
-        .stub(Web5UserAgent, 'create')
-        .resolves(testHarness.agent as Web5UserAgent);
-      const walletConnectSpy = sinon.spy(WalletConnect, 'initClient');
-      const identityApiSpy = sinon.spy(AgentIdentityApi.prototype, 'create');
-      const { web5, did } = await Web5.connect({
-        techPreview: { dwnEndpoints: ['https://dwn.example.com/preview'] },
-      });
-      expect(web5).to.exist;
-      expect(did).to.exist;
-
-      expect(identityApiSpy.calledOnce, 'identityApiSpy called').to.be.true;
-      const serviceEndpoints = (
-        identityApiSpy.firstCall.args[0].didOptions as any
-      ).services[0].serviceEndpoint;
-      expect(serviceEndpoints).to.deep.equal([
-        'https://dwn.example.com/preview',
-      ]);
-      expect(walletConnectSpy.called).to.be.false;
-    });
-
-    it('creates an identity using the provided didCreateOptions dwnEndpoints', async () => {
-      sinon
-        .stub(Web5UserAgent, 'create')
-        .resolves(testHarness.agent as Web5UserAgent);
-      const identityApiSpy = sinon.spy(AgentIdentityApi.prototype, 'create');
-      const walletConnectSpy = sinon.spy(WalletConnect, 'initClient');
-      const { web5, did } = await Web5.connect({
-        didCreateOptions: { dwnEndpoints: ['https://dwn.example.com'] },
-      });
-      expect(web5).to.exist;
-      expect(did).to.exist;
-
-      expect(identityApiSpy.calledOnce, 'identityApiSpy called').to.be.true;
-      const serviceEndpoints = (
-        identityApiSpy.firstCall.args[0].didOptions as any
-      ).services[0].serviceEndpoint;
-      expect(serviceEndpoints).to.deep.equal(['https://dwn.example.com']);
-      expect(walletConnectSpy.called).to.be.false;
-    });
-
-    it('defaults to the first identity if multiple identities exist', async () => {
-      // scenario: For some reason more than one identity exists when attempting to re-connect to `Web5`
-      // the first identity in the array should be the one selected
-      // TODO: this has happened due to a race condition somewhere. Dig into this issue and implement a better way to select/manage DIDs when using `Web5.connect()`
-
-      // create an identity by connecting
-      sinon.stub(Web5UserAgent, 'create').resolves(testHarness.agent as Web5UserAgent);
-      const { web5, did } = await Web5.connect({ techPreview: { dwnEndpoints: [ testDwnUrl ] }});
-      expect(web5).to.exist;
-      expect(did).to.exist;
-
-      // create a second identity
-      await testHarness.agent.identity.create({
-        didMethod : 'jwk',
-        metadata  : { name: 'Second' }
-      });
-
-      // connect again
-      const { did: did2 } = await Web5.connect();
-      expect(did2).to.equal(did);
-    });
-
-    it('defaults to the first identity if multiple identities exist', async () => {
-      // scenario: For some reason more than one identity exists when attempting to re-connect to `Web5`
-      // the first identity in the array should be the one selected
-      // TODO: this has happened due to a race condition somewhere. Dig into this issue and implement a better way to select/manage DIDs when using `Web5.connect()`
-
-      // create an identity by connecting
-      sinon.stub(Web5UserAgent, 'create').resolves(testHarness.agent as Web5UserAgent);
-      const { web5, did } = await Web5.connect({ techPreview: { dwnEndpoints: [ testDwnUrl ] }});
-      expect(web5).to.exist;
-      expect(did).to.exist;
-
-      // create a second identity
-      await testHarness.agent.identity.create({
-        didMethod : 'jwk',
-        metadata  : { name: 'Second' }
-      });
-
-      // connect again
-      const { did: did2 } = await Web5.connect();
-      expect(did2).to.equal(did);
-    });
-
-    it('defaults to `https://dwn.tbddev.org/beta` as the single DWN Service endpoint if non is provided', async () => {
-      sinon
-        .stub(Web5UserAgent, 'create')
-        .resolves(testHarness.agent as Web5UserAgent);
-      const identityApiSpy = sinon.spy(AgentIdentityApi.prototype, 'create');
-      const { web5, did } = await Web5.connect();
-      expect(web5).to.exist;
-      expect(did).to.exist;
-
-      expect(identityApiSpy.calledOnce, 'identityApiSpy called').to.be.true;
-      const serviceEndpoints = (
-        identityApiSpy.firstCall.args[0].didOptions as any
-      ).services[0].serviceEndpoint;
-      expect(serviceEndpoints).to.deep.equal(['https://dwn.tbddev.org/beta']);
     });
 
     describe('registration', () => {


### PR DESCRIPTION
Resolves https://github.com/TBD54566975/web5-js/issues/826

This PR adds the ability to Sync a subset of data by providing specific protocols a user would like to sync. Additionally sync now supports using a grant and delegateDid to perform sync.

Introduced a `CachedPermissions` class to help cache the lookup of permission grants records from the DWN. This is used both in `DwnApi` and `SyncEngineLevel`.