### PR TITLE
Add requestPermissionsForProtocol helper method to connect module

### DIFF
--- a/.changeset/fresh-olives-dance.md
+++ b/.changeset/fresh-olives-dance.md
@@ -1,0 +1,5 @@
+---
+"@web5/agent": patch
+---
+
+Add requestPermissionsForProtocol helper method to connect module

--- a/examples/wallet-connect.html
+++ b/examples/wallet-connect.html
@@ -128,35 +128,16 @@
       },
     };
 
-    const scopes = [
-      {
-        interface: "Records",
-        method: "Write",
-        protocol: "http://profile-protocol.xyz",
-      },
-      {
-        interface: "Records",
-        method: "Query",
-        protocol: "http://profile-protocol.xyz",
-      },
-      {
-        interface: "Records",
-        method: "Read",
-        protocol: "http://profile-protocol.xyz",
-      },
-    ];
+    const permissionRequests = Web5.requestPermissions([{
+      definition: profileProtocol,
+    }]);
 
     try {
       const { delegateDid } = await Web5.connect({
         walletConnectOptions: {
           walletUri: "web5://connect",
           connectServerUrl: "http://localhost:3000/connect",
-          permissionRequests: [
-            {
-              protocolDefinition: profileProtocol,
-              permissionScopes: scopes,
-            },
-          ],
+          permissionRequests: permissionRequests,
           onWalletUriReady: generateQRCode,
           validatePin: async () => {
             goToPinScreen();

--- a/examples/wallet-connect.html
+++ b/examples/wallet-connect.html
@@ -128,16 +128,12 @@
       },
     };
 
-    const permissionRequests = Web5.requestPermissions([{
-      definition: profileProtocol,
-    }]);
-
     try {
       const { delegateDid } = await Web5.connect({
         walletConnectOptions: {
           walletUri: "web5://connect",
           connectServerUrl: "http://localhost:3000/connect",
-          permissionRequests: permissionRequests,
+          permissionRequests: [{ protocolDefinition: profileProtocol }],
           onWalletUriReady: generateQRCode,
           validatePin: async () => {
             goToPinScreen();

--- a/packages/agent/src/connect.ts
+++ b/packages/agent/src/connect.ts
@@ -1,13 +1,15 @@
-import { CryptoUtils } from '@web5/crypto';
-import { DwnPermissionScope, DwnProtocolDefinition, DwnRecordsPermissionScope } from './index.js';
+
+import type { PushedAuthResponse } from './oidc.js';
+import type { DwnPermissionScope, DwnProtocolDefinition, Web5ConnectAuthResponse } from './index.js';
+
 import {
-  Web5ConnectAuthResponse,
   Oidc,
-  type PushedAuthResponse,
 } from './oidc.js';
 import { pollWithTtl } from './utils.js';
-import { DidJwk } from '@web5/dids';
+
 import { Convert } from '@web5/common';
+import { CryptoUtils } from '@web5/crypto';
+import { DidJwk } from '@web5/dids';
 import { DwnInterfaceName, DwnMethodName } from '@tbd54566975/dwn-sdk-js';
 
 /**
@@ -183,9 +185,9 @@ export type ConnectPermissionRequest = {
   permissionScopes: DwnPermissionScope[];
 };
 
-export type PermissionRequest = 'write' | 'read' | 'delete' | 'query' | 'subscribe';
+export type Permission = 'write' | 'read' | 'delete' | 'query' | 'subscribe';
 
-function requestPermissionsForProtocol(definition: DwnProtocolDefinition, permissions: PermissionRequest[]): ConnectPermissionRequest {
+function requestPermissionsForProtocol(definition: DwnProtocolDefinition, permissions: Permission[]): ConnectPermissionRequest {
   const requests: DwnPermissionScope[] = [];
 
   // In order to enable sync, we must request permissions for `MessagesQuery`, `MessagesRead` and `MessagesSubscribe`

--- a/packages/agent/src/connect.ts
+++ b/packages/agent/src/connect.ts
@@ -187,7 +187,7 @@ export type ConnectPermissionRequest = {
 
 export type Permission = 'write' | 'read' | 'delete' | 'query' | 'subscribe';
 
-function requestPermissionsForProtocol(definition: DwnProtocolDefinition, permissions: Permission[]): ConnectPermissionRequest {
+function createPermissionRequestForProtocol(definition: DwnProtocolDefinition, permissions: Permission[]): ConnectPermissionRequest {
   const requests: DwnPermissionScope[] = [];
 
   // In order to enable sync, we must request permissions for `MessagesQuery`, `MessagesRead` and `MessagesSubscribe`
@@ -252,4 +252,4 @@ function requestPermissionsForProtocol(definition: DwnProtocolDefinition, permis
   };
 }
 
-export const WalletConnect = { initClient, requestPermissionsForProtocol };
+export const WalletConnect = { initClient, createPermissionRequestForProtocol };

--- a/packages/agent/src/sync-api.ts
+++ b/packages/agent/src/sync-api.ts
@@ -41,7 +41,7 @@ export class AgentSyncApi implements SyncEngine {
     this._syncEngine.agent = agent;
   }
 
-  public async registerIdentity(params: { did: string; options: SyncIdentityOptions }): Promise<void> {
+  public async registerIdentity(params: { did: string; options?: SyncIdentityOptions }): Promise<void> {
     await this._syncEngine.registerIdentity(params);
   }
 

--- a/packages/agent/src/sync-engine-level.ts
+++ b/packages/agent/src/sync-engine-level.ts
@@ -255,7 +255,7 @@ export class SyncEngineLevel implements SyncEngine {
     const registeredIdentities = this._db.sublevel('registeredIdentities');
 
     // if no options are provided, we default to no delegateDid and all protocols (empty array)
-    options ??= { delegateDid: undefined, protocols: [] };
+    options ??= { protocols: [] };
 
     // Add (or overwrite, if present) the Identity's DID as a registered identity.
     await registeredIdentities.put(did, JSON.stringify(options));

--- a/packages/agent/src/sync-engine-level.ts
+++ b/packages/agent/src/sync-engine-level.ts
@@ -250,9 +250,12 @@ export class SyncEngineLevel implements SyncEngine {
     await pushQueue.batch(deleteOperations as any);
   }
 
-  public async registerIdentity({ did, options }: { did: string; options: SyncIdentityOptions }): Promise<void> {
+  public async registerIdentity({ did, options }: { did: string; options?: SyncIdentityOptions }): Promise<void> {
     // Get a reference to the `registeredIdentities` sublevel.
     const registeredIdentities = this._db.sublevel('registeredIdentities');
+
+    // if no options are provided, we default to no delegateDid and all protocols (empty array)
+    options ??= { delegateDid: undefined, protocols: [] };
 
     // Add (or overwrite, if present) the Identity's DID as a registered identity.
     await registeredIdentities.put(did, JSON.stringify(options));

--- a/packages/agent/src/types/sync.ts
+++ b/packages/agent/src/types/sync.ts
@@ -6,7 +6,7 @@ export type SyncIdentityOptions = {
 }
 export interface SyncEngine {
   agent: Web5PlatformAgent;
-  registerIdentity(params: { did: string, options: SyncIdentityOptions }): Promise<void>;
+  registerIdentity(params: { did: string, options?: SyncIdentityOptions }): Promise<void>;
   sync(direction?: 'push' | 'pull'): Promise<void>;
   startSync(params: { interval: string }): Promise<void>;
   stopSync(): void;

--- a/packages/agent/tests/connect.spec.ts
+++ b/packages/agent/tests/connect.spec.ts
@@ -291,8 +291,8 @@ describe('web5 connect', function () {
         testHarness.agent,
         permissionScopes
       );
-      const scopesRequestedPlusTwoDefaultScopes = permissionScopes.length;
-      expect(results).to.have.lengthOf(scopesRequestedPlusTwoDefaultScopes);
+      const scopesRequested = permissionScopes.length;
+      expect(results).to.have.lengthOf(scopesRequested);
       expect(results[0]).to.be.a('object');
     });
 

--- a/packages/agent/tests/connect.spec.ts
+++ b/packages/agent/tests/connect.spec.ts
@@ -288,7 +288,7 @@ describe('web5 connect', function () {
       const results = await Oidc.createPermissionGrants(
         providerIdentity.did.uri,
         delegateBearerDid,
-        testHarness.agent.dwn,
+        testHarness.agent,
         permissionScopes
       );
       const scopesRequestedPlusTwoDefaultScopes = permissionScopes.length;
@@ -390,7 +390,7 @@ describe('web5 connect', function () {
         selectedDid,
         authRequest,
         randomPin,
-        testHarness.agent.dwn
+        testHarness.agent
       );
       expect(fetchSpy.calledOnce).to.be.true;
     });

--- a/packages/agent/tests/connect.spec.ts
+++ b/packages/agent/tests/connect.spec.ts
@@ -197,6 +197,7 @@ describe('web5 connect', function () {
   });
 
   after(async () => {
+    sinon.restore();
     await testHarness.clearStorage();
     await testHarness.closeStorage();
   });
@@ -488,7 +489,7 @@ describe('web5 connect', function () {
     });
   });
 
-  describe('requestPermissionsForProtocol', () => {
+  describe('createPermissionRequestForProtocol', () => {
     it('should add sync permissions to all requests', async () => {
       const protocol:DwnProtocolDefinition = {
         published : true,
@@ -504,7 +505,7 @@ describe('web5 connect', function () {
         }
       };
 
-      const permissionRequests = WalletConnect.requestPermissionsForProtocol(protocol, []);
+      const permissionRequests = WalletConnect.createPermissionRequestForProtocol(protocol, []);
 
       expect(permissionRequests.protocolDefinition).to.deep.equal(protocol);
       expect(permissionRequests.permissionScopes.length).to.equal(3); // only includes the sync permissions
@@ -528,7 +529,7 @@ describe('web5 connect', function () {
         }
       };
 
-      const permissionRequests = WalletConnect.requestPermissionsForProtocol(protocol, ['write', 'read']);
+      const permissionRequests = WalletConnect.createPermissionRequestForProtocol(protocol, ['write', 'read']);
 
       expect(permissionRequests.protocolDefinition).to.deep.equal(protocol);
 
@@ -553,7 +554,7 @@ describe('web5 connect', function () {
         }
       };
 
-      const permissionRequests = WalletConnect.requestPermissionsForProtocol(protocol, ['write', 'read', 'delete', 'query', 'subscribe']);
+      const permissionRequests = WalletConnect.createPermissionRequestForProtocol(protocol, ['write', 'read', 'delete', 'query', 'subscribe']);
 
       expect(permissionRequests.protocolDefinition).to.deep.equal(protocol);
 

--- a/packages/agent/tests/connect.spec.ts
+++ b/packages/agent/tests/connect.spec.ts
@@ -289,11 +289,9 @@ describe('web5 connect', function () {
         providerIdentity.did.uri,
         delegateBearerDid,
         testHarness.agent.dwn,
-        testHarness.agent.permissions,
-        permissionScopes,
-        protocolDefinition.protocol
+        permissionScopes
       );
-      const scopesRequestedPlusTwoDefaultScopes = permissionScopes.length + 2;
+      const scopesRequestedPlusTwoDefaultScopes = permissionScopes.length;
       expect(results).to.have.lengthOf(scopesRequestedPlusTwoDefaultScopes);
       expect(results[0]).to.be.a('object');
     });
@@ -392,8 +390,7 @@ describe('web5 connect', function () {
         selectedDid,
         authRequest,
         randomPin,
-        testHarness.agent.dwn,
-        testHarness.agent.permissions
+        testHarness.agent.dwn
       );
       expect(fetchSpy.calledOnce).to.be.true;
     });

--- a/packages/agent/tests/rpc-client.spec.ts
+++ b/packages/agent/tests/rpc-client.spec.ts
@@ -69,6 +69,10 @@ describe('RPC Clients', () => {
       alice = await TestDataGenerator.generateDidKeyPersona();
     });
 
+    after(() => {
+      sinon.restore();
+    });
+
     it('returns available transports', async () => {
       const httpOnlyClient = new Web5RpcClient();
 
@@ -262,6 +266,10 @@ describe('RPC Clients', () => {
     let alice: Persona;
     let client: HttpWeb5RpcClient;
 
+    after(() => {
+      sinon.restore();
+    });
+
     beforeEach(async () => {
       sinon.restore();
 
@@ -352,6 +360,10 @@ describe('RPC Clients', () => {
     const dwnUrl = new URL(testDwnUrl);
     dwnUrl.protocol = dwnUrl.protocol === 'http:' ? 'ws:' : 'wss:';
     const socketDwnUrl = dwnUrl.toString();
+
+    after(() => {
+      sinon.restore();
+    });
 
     beforeEach(async () => {
       sinon.restore();

--- a/packages/agent/tests/sync-engine-level.spec.ts
+++ b/packages/agent/tests/sync-engine-level.spec.ts
@@ -12,6 +12,7 @@ import { testDwnUrl } from './utils/test-config.js';
 import { SyncEngineLevel } from '../src/sync-engine-level.js';
 import { PlatformAgentTestHarness } from '../src/test-harness.js';
 import { Convert } from '@web5/common';
+import { AbstractLevel } from 'abstract-level';
 
 let testDwnUrls: string[] = [testDwnUrl];
 
@@ -353,10 +354,7 @@ describe('SyncEngineLevel', () => {
 
       // Register Alice's DID to be synchronized.
       await testHarness.agent.sync.registerIdentity({
-        did     : alice.did.uri,
-        options : {
-          protocols: []
-        }
+        did: alice.did.uri,
       });
 
       // Execute Sync to pull all records from Alice's remote DWN to Alice's local DWN.
@@ -431,10 +429,7 @@ describe('SyncEngineLevel', () => {
 
         // Register Alice's DID to be synchronized.
         await testHarness.agent.sync.registerIdentity({
-          did     : alice.did.uri,
-          options : {
-            protocols: []
-          }
+          did: alice.did.uri,
         });
 
         // Execute Sync to push and pull all records from Alice's remote DWN to Alice's local DWN.
@@ -471,10 +466,7 @@ describe('SyncEngineLevel', () => {
       it('throws if sync is attempted while an interval sync is running', async () => {
         // Register Alice's DID to be synchronized.
         await testHarness.agent.sync.registerIdentity({
-          did     : alice.did.uri,
-          options : {
-            protocols: []
-          }
+          did: alice.did.uri,
         });
 
         // start the sync engine with an interval of 10 seconds
@@ -1057,6 +1049,21 @@ describe('SyncEngineLevel', () => {
         expect(localBarRecords.reply.status.code).to.equal(200);
         expect(localBarRecords.reply.entries).to.have.length(0);
       });
+
+      it('defaults to all protocols and undefined delegate if no options are provided', async () => {
+        // spy on AbstractLevel put
+        const abstractLevelPut = sinon.spy(AbstractLevel.prototype, 'put');
+
+        // register identity without any options
+        await testHarness.agent.sync.registerIdentity({
+          did: alice.did.uri
+        });
+
+        const registerIdentitiesPutCall = abstractLevelPut.args[0];
+        const options = JSON.parse(registerIdentitiesPutCall[1] as string);
+        // confirm that without options the options are set to an empty protocol array
+        expect(options).to.deep.equal({ protocols: [] });
+      });
     });
 
     describe('pull()', () => {
@@ -1112,10 +1119,7 @@ describe('SyncEngineLevel', () => {
 
         // Register Alice's DID to be synchronized.
         await testHarness.agent.sync.registerIdentity({
-          did     : alice.did.uri,
-          options : {
-            protocols: []
-          }
+          did: alice.did.uri,
         });
 
         // Execute Sync to pull all records from Alice's remote DWN to Alice's local DWN.
@@ -1208,10 +1212,7 @@ describe('SyncEngineLevel', () => {
 
         // Register Alice's DID to be synchronized.
         await testHarness.agent.sync.registerIdentity({
-          did     : alice.did.uri,
-          options : {
-            protocols: []
-          }
+          did: alice.did.uri,
         });
 
         // Execute Sync to pull all records from Alice's remote DWNs
@@ -1337,10 +1338,7 @@ describe('SyncEngineLevel', () => {
 
         // Register Alice's DID to be synchronized.
         await testHarness.agent.sync.registerIdentity({
-          did     : alice.did.uri,
-          options : {
-            protocols: []
-          }
+          did: alice.did.uri,
         });
 
         // spy on sendDwnRequest to the remote DWN
@@ -1561,10 +1559,7 @@ describe('SyncEngineLevel', () => {
 
         // Register Alice's DID to be synchronized.
         await testHarness.agent.sync.registerIdentity({
-          did     : alice.did.uri,
-          options : {
-            protocols: []
-          }
+          did: alice.did.uri,
         });
 
         // Execute Sync to pull all records from Alice's remote DWN to Alice's local DWN.
@@ -1626,10 +1621,7 @@ describe('SyncEngineLevel', () => {
 
         // register alice
         await testHarness.agent.sync.registerIdentity({
-          did     : alice.did.uri,
-          options : {
-            protocols: []
-          }
+          did: alice.did.uri,
         });
 
         // create a remote record
@@ -1720,18 +1712,12 @@ describe('SyncEngineLevel', () => {
 
         // Register Alice's DID to be synchronized.
         await testHarness.agent.sync.registerIdentity({
-          did     : alice.did.uri,
-          options : {
-            protocols: []
-          }
+          did: alice.did.uri,
         });
 
         // Register Bob's DID to be synchronized.
         await testHarness.agent.sync.registerIdentity({
-          did     : bob.did.uri,
-          options : {
-            protocols: []
-          }
+          did: bob.did.uri,
         });
 
         // Execute Sync to pull all records from Alice's and Bob's remove DWNs to their local DWNs.
@@ -1814,10 +1800,7 @@ describe('SyncEngineLevel', () => {
 
         // Register Alice's DID to be synchronized.
         await testHarness.agent.sync.registerIdentity({
-          did     : alice.did.uri,
-          options : {
-            protocols: []
-          }
+          did: alice.did.uri,
         });
 
         // Execute Sync to pull all records from Alice's remote DWN to Alice's local DWN.
@@ -1917,10 +1900,7 @@ describe('SyncEngineLevel', () => {
 
         // Register Alice's DID to be synchronized.
         await testHarness.agent.sync.registerIdentity({
-          did     : alice.did.uri,
-          options : {
-            protocols: []
-          }
+          did: alice.did.uri,
         });
 
         // Execute Sync to pull all records from Alice's remote DWNs
@@ -1956,10 +1936,7 @@ describe('SyncEngineLevel', () => {
 
         // Register Alice's DID to be synchronized.
         await testHarness.agent.sync.registerIdentity({
-          did     : alice.did.uri,
-          options : {
-            protocols: []
-          }
+          did: alice.did.uri,
         });
 
         // scenario: The messageCids returned from the local eventLog contains a Cid that already exists in the remote DWN.
@@ -2251,10 +2228,7 @@ describe('SyncEngineLevel', () => {
 
         // Register Alice's DID to be synchronized.
         await testHarness.agent.sync.registerIdentity({
-          did     : alice.did.uri,
-          options : {
-            protocols: []
-          }
+          did: alice.did.uri,
         });
 
         // Execute Sync to push all records from Alice's local DWN to Alice's remote DWN.
@@ -2315,10 +2289,7 @@ describe('SyncEngineLevel', () => {
 
         //register alice
         await testHarness.agent.sync.registerIdentity({
-          did     : alice.did.uri,
-          options : {
-            protocols: []
-          }
+          did: alice.did.uri,
         });
 
         // create a local record
@@ -2407,18 +2378,12 @@ describe('SyncEngineLevel', () => {
 
         // Register Alice's DID to be synchronized.
         await testHarness.agent.sync.registerIdentity({
-          did     : alice.did.uri,
-          options : {
-            protocols: []
-          }
+          did: alice.did.uri,
         });
 
         // Register Bob's DID to be synchronized.
         await testHarness.agent.sync.registerIdentity({
-          did     : bob.did.uri,
-          options : {
-            protocols: []
-          }
+          did: bob.did.uri,
         });
 
         // Execute Sync to push all records from Alice's and Bob's local DWNs to their remote DWNs.
@@ -2451,10 +2416,7 @@ describe('SyncEngineLevel', () => {
     describe('startSync()', () => {
       it('calls sync() in each interval', async () => {
         await testHarness.agent.sync.registerIdentity({
-          did     : alice.did.uri,
-          options : {
-            protocols: []
-          }
+          did: alice.did.uri,
         });
 
         const syncSpy = sinon.stub(SyncEngineLevel.prototype, 'sync');
@@ -2473,10 +2435,7 @@ describe('SyncEngineLevel', () => {
 
       it('does not call sync() again until a sync round finishes', async () => {
         await testHarness.agent.sync.registerIdentity({
-          did     : alice.did.uri,
-          options : {
-            protocols: []
-          }
+          did: alice.did.uri,
         });
 
         const clock = sinon.useFakeTimers();

--- a/packages/agent/tests/sync-engine-level.spec.ts
+++ b/packages/agent/tests/sync-engine-level.spec.ts
@@ -163,6 +163,7 @@ describe('SyncEngineLevel', () => {
     });
 
     after(async () => {
+      sinon.restore();
       await testHarness.clearStorage();
       await testHarness.closeStorage();
     });

--- a/packages/api/src/web5.ts
+++ b/packages/api/src/web5.ts
@@ -6,11 +6,14 @@
 
 import type {
   BearerIdentity,
+  ConnectPermissionRequest,
   DelegateGrant,
   DwnDataEncodedRecordsWriteMessage,
   DwnMessagesPermissionScope,
+  DwnProtocolDefinition,
   DwnRecordsPermissionScope,
   HdIdentityVault,
+  Permission,
   WalletConnectOptions,
   Web5Agent,
 } from '@web5/agent';
@@ -479,5 +482,15 @@ export class Web5 {
     // currently we return a de-duped set of protocols represented by these grants, this is used to register protocols for sync
     // we expect that any connected protocols will include MessagesQuery and MessagesRead grants that will allow it to sync
     return [...connectedProtocols];
+  }
+
+  /**
+   * Creates a connect permissions request for specific protocols.
+   * If no permissions are explicitly provided, the default is all permissions ('read', 'write', 'delete', 'query', 'subscribe').
+   */
+  static requestPermissions(requests: { definition: DwnProtocolDefinition, permissions?: Permission[] }[]): ConnectPermissionRequest[] {
+    return requests.map(({ definition, permissions }) => WalletConnect.requestPermissionsForProtocol(definition, permissions ?? [
+      'read', 'write', 'delete', 'query', 'subscribe'
+    ]));
   }
 }

--- a/packages/api/tests/web5.spec.ts
+++ b/packages/api/tests/web5.spec.ts
@@ -793,6 +793,145 @@ describe('web5 api', () => {
 
         expect(startSyncSpy.args[0][0].interval).to.equal('1m');
       });
+
+
+
+      it('should request all permissions for a protocol if no specific permissions are provided', async () => {
+
+        sinon.stub(Web5UserAgent, 'create').resolves(testHarness.agent as Web5UserAgent);
+
+        // spy on the WalletConnect createPermissionRequestForProtocol method
+        const requestPermissionsSpy = sinon.spy(WalletConnect, 'createPermissionRequestForProtocol');
+
+        // We throw and spy on the initClient method to avoid the actual WalletConnect initialization
+        // but to still be able to spy on the passed parameters
+        sinon.stub(WalletConnect, 'initClient').throws('Error');
+
+        // stub the cleanUpIdentity method to avoid actual cleanup
+        sinon.stub(Web5 as any, 'cleanUpIdentity').resolves();
+
+        const protocolDefinition: DwnProtocolDefinition = {
+          protocol  : 'https://example.com/test-protocol',
+          published : true,
+          types     : {
+            foo : {},
+            bar : {}
+          },
+          structure: {
+            foo: {
+              bar: {}
+            }
+          }
+        };
+
+        try {
+
+          await Web5.connect({
+            walletConnectOptions: {
+              connectServerUrl   : 'https://connect.example.com',
+              walletUri          : 'https://wallet.example.com',
+              validatePin        : async () => { return '1234'; },
+              onWalletUriReady   : (_walletUri: string) => {},
+              permissionRequests : [{ protocolDefinition }]
+            }
+          });
+
+          expect.fail('Should have thrown an error');
+        } catch(error: any) {
+          // we expect an error because we stubbed the initClient method to throw it
+          expect(error.message).to.include('Sinon-provided Error');
+
+          // The `createPermissionRequestForProtocol` method should have been called once for the provided protocol
+          expect(requestPermissionsSpy.callCount).to.equal(1);
+          const call = requestPermissionsSpy.getCall(0);
+
+          // since no explicit permissions were provided, all permissions should be requested
+          expect(call.args[1]).to.have.members([
+            'read', 'write', 'delete', 'query', 'subscribe'
+          ]);
+        }
+      });
+
+      it('should only request the specified permissions for a protocol', async () => {
+
+        sinon.stub(Web5UserAgent, 'create').resolves(testHarness.agent as Web5UserAgent);
+
+        // spy on the WalletConnect createPermissionRequestForProtocol method
+        const requestPermissionsSpy = sinon.spy(WalletConnect, 'createPermissionRequestForProtocol');
+
+        // We throw and spy on the initClient method to avoid the actual WalletConnect initialization
+        // but to still be able to spy on the passed parameters
+        sinon.stub(WalletConnect, 'initClient').throws('Error');
+
+        // stub the cleanUpIdentity method to avoid actual cleanup
+        sinon.stub(Web5 as any, 'cleanUpIdentity').resolves();
+
+        const protocol1Definition: DwnProtocolDefinition = {
+          protocol  : 'https://example.com/test-protocol-1',
+          published : true,
+          types     : {
+            foo : {},
+            bar : {}
+          },
+          structure: {
+            foo: {
+              bar: {}
+            }
+          }
+        };
+
+        const protocol2Definition: DwnProtocolDefinition = {
+          protocol  : 'https://example.com/test-protocol-2',
+          published : true,
+          types     : {
+            foo : {},
+            bar : {}
+          },
+          structure: {
+            foo: {
+              bar: {}
+            }
+          }
+        };
+
+
+        try {
+
+          await Web5.connect({
+            walletConnectOptions: {
+              connectServerUrl   : 'https://connect.example.com',
+              walletUri          : 'https://wallet.example.com',
+              validatePin        : async () => { return '1234'; },
+              onWalletUriReady   : (_walletUri: string) => {},
+              permissionRequests : [
+                { protocolDefinition: protocol1Definition }, // no permissions provided, expect all permissions to be requested
+                { protocolDefinition: protocol2Definition, permissions: ['read', 'write'] } // only read and write permissions provided
+              ]
+            }
+          });
+
+          expect.fail('Should have thrown an error');
+        } catch(error: any) {
+          // we expect an error because we stubbed the initClient method to throw it
+          expect(error.message).to.include('Sinon-provided Error');
+
+          // The `createPermissionRequestForProtocol` method should have been called once for each provided request
+          expect(requestPermissionsSpy.callCount).to.equal(2);
+          const call1 = requestPermissionsSpy.getCall(0);
+
+          // since no explicit permissions were provided for the first protocol, all permissions should be requested
+          expect(call1.args[1]).to.have.members([
+            'read', 'write', 'delete', 'query', 'subscribe'
+          ]);
+
+          const call2 = requestPermissionsSpy.getCall(1);
+
+          // only the provided permissions should be requested for the second protocol
+          expect(call2.args[1]).to.have.members([
+            'read', 'write'
+          ]);
+        }
+      });
     });
 
     describe('registration', () => {
@@ -980,73 +1119,6 @@ describe('web5 api', () => {
         expect(serverInfoStub.calledOnce, 'getServerInfo called').to.be.true; // Should only be called once for `techPreview` endpoint
         expect(registerStub.callCount, 'registerTenant called').to.equal(2); // called twice, once for Agent DID once for Identity DID
       });
-    });
-  });
-
-  describe('requestPermissions()', () => {
-    beforeEach(() => {
-      sinon.restore();
-    });
-
-    after(() => {
-      sinon.restore();
-    });
-
-    it('should request all permissions for a protocol if no specific permissions are provided', async () => {
-      // spy on the WalletConnect requestPermissionsForProtocol method
-      const requestPermissionsSpy = sinon.spy(WalletConnect, 'requestPermissionsForProtocol');
-
-      const permissionRequests = Web5.requestPermissions([{
-        definition: {
-          protocol  : 'https://example.com/test-protocol',
-          published : true,
-          types     : {
-            foo : {},
-            bar : {}
-          },
-          structure: {
-            foo: {
-              bar: {}
-            }
-          }
-        }
-      }]);
-
-      expect(permissionRequests.length).to.equal(1);
-      expect(requestPermissionsSpy.callCount).to.equal(1);
-      const call = requestPermissionsSpy.getCall(0);
-      expect(call.args[1]).to.have.members([
-        'read', 'write', 'delete', 'query', 'subscribe'
-      ]);
-    });
-
-    it('should only request the specified permissions for a protocol', async () => {
-      // spy on the WalletConnect requestPermissionsForProtocol method
-      const requestPermissionsSpy = sinon.spy(WalletConnect, 'requestPermissionsForProtocol');
-
-      const permissionRequests = Web5.requestPermissions([{
-        definition: {
-          protocol  : 'https://example.com/test-protocol',
-          published : true,
-          types     : {
-            foo : {},
-            bar : {}
-          },
-          structure: {
-            foo: {
-              bar: {}
-            }
-          }
-        },
-        permissions: ['read', 'write']
-      }]);
-
-      expect(permissionRequests.length).to.equal(1);
-      expect(requestPermissionsSpy.callCount).to.equal(1);
-      const call = requestPermissionsSpy.getCall(0);
-      expect(call.args[1]).to.have.members([
-        'read', 'write'
-      ]);
     });
   });
 });

--- a/packages/api/tests/web5.spec.ts
+++ b/packages/api/tests/web5.spec.ts
@@ -982,4 +982,71 @@ describe('web5 api', () => {
       });
     });
   });
+
+  describe('requestPermissions()', () => {
+    beforeEach(() => {
+      sinon.restore();
+    });
+
+    after(() => {
+      sinon.restore();
+    });
+
+    it('should request all permissions for a protocol if no specific permissions are provided', async () => {
+      // spy on the WalletConnect requestPermissionsForProtocol method
+      const requestPermissionsSpy = sinon.spy(WalletConnect, 'requestPermissionsForProtocol');
+
+      const permissionRequests = Web5.requestPermissions([{
+        definition: {
+          protocol  : 'https://example.com/test-protocol',
+          published : true,
+          types     : {
+            foo : {},
+            bar : {}
+          },
+          structure: {
+            foo: {
+              bar: {}
+            }
+          }
+        }
+      }]);
+
+      expect(permissionRequests.length).to.equal(1);
+      expect(requestPermissionsSpy.callCount).to.equal(1);
+      const call = requestPermissionsSpy.getCall(0);
+      expect(call.args[1]).to.have.members([
+        'read', 'write', 'delete', 'query', 'subscribe'
+      ]);
+    });
+
+    it('should only request the specified permissions for a protocol', async () => {
+      // spy on the WalletConnect requestPermissionsForProtocol method
+      const requestPermissionsSpy = sinon.spy(WalletConnect, 'requestPermissionsForProtocol');
+
+      const permissionRequests = Web5.requestPermissions([{
+        definition: {
+          protocol  : 'https://example.com/test-protocol',
+          published : true,
+          types     : {
+            foo : {},
+            bar : {}
+          },
+          structure: {
+            foo: {
+              bar: {}
+            }
+          }
+        },
+        permissions: ['read', 'write']
+      }]);
+
+      expect(permissionRequests.length).to.equal(1);
+      expect(requestPermissionsSpy.callCount).to.equal(1);
+      const call = requestPermissionsSpy.getCall(0);
+      expect(call.args[1]).to.have.members([
+        'read', 'write'
+      ]);
+    });
+  });
 });


### PR DESCRIPTION
This PR adds a `requestPermissionsForProtocol` helper method to the Connect module.

This helper method takes a protocol definition, as well as simple string representations of the permissions being requested, ie `write`, `read`, `delete`, `query` and `subscribe`.

It will by default include the permissions also needed to sync a protocol's messages `MessagesRead`, `MessagesQuery` and `MessagesSubscribe`.

#### Example:
```typescript
// all permissions for each protocol    
const { delegateDid } = await Web5.connect({
  walletConnectOptions: {
    walletUri: "web5://connect",
    connectServerUrl: "http://localhost:3000/connect",
    permissionRequests: [{ protocolDefinition: profileProtocol }],
    onWalletUriReady: generateQRCode,
    validatePin: async () => {
      goToPinScreen();

      const pin = await waitForPin();
      return pin;
    },
  },
});
```
```typescript
// specific permissions
const { delegateDid } = await Web5.connect({
  walletConnectOptions: {
    walletUri: "web5://connect",
    connectServerUrl: "http://localhost:3000/connect",
    permissionRequests: [{
      definition: protocol1,
      permissions: ['read', 'write'] // creates read+write + sync grants
    },{
      definition: protocol2,
    }],
    onWalletUriReady: generateQRCode,
    validatePin: async () => {
      goToPinScreen();

      const pin = await waitForPin();
      return pin;
    },
  },
});
```
---

This PR also makes `registerIdentity` options optional. If no options are provided all protocols are synced.