### PR TITLE
Modify `stopSync` to block if sync is currently active

### DIFF
--- a/.changeset/afraid-geese-knock.md
+++ b/.changeset/afraid-geese-knock.md
@@ -1,0 +1,8 @@
+---
+"@web5/agent": patch
+"@web5/identity-agent": patch
+"@web5/proxy-agent": patch
+"@web5/user-agent": patch
+---
+
+Fix sync race condition issue

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@changesets/cli": "^2.27.5",
     "@npmcli/package-json": "5.0.0",
     "@typescript-eslint/eslint-plugin": "7.9.0",
-    "@web5/dwn-server": "0.4.8",
+    "@web5/dwn-server": "0.4.9",
     "audit-ci": "^7.0.1",
     "eslint-plugin-mocha": "10.4.3",
     "globals": "^13.24.0",

--- a/packages/agent/src/sync-api.ts
+++ b/packages/agent/src/sync-api.ts
@@ -53,7 +53,7 @@ export class AgentSyncApi implements SyncEngine {
     return this._syncEngine.startSync(params);
   }
 
-  public stopSync(): void {
-    this._syncEngine.stopSync();
+  public stopSync(): Promise<void> {
+    return this._syncEngine.stopSync();
   }
 }

--- a/packages/agent/src/sync-api.ts
+++ b/packages/agent/src/sync-api.ts
@@ -53,7 +53,7 @@ export class AgentSyncApi implements SyncEngine {
     return this._syncEngine.startSync(params);
   }
 
-  public stopSync(): Promise<void> {
-    return this._syncEngine.stopSync();
+  public stopSync(timeout?: number): Promise<void> {
+    return this._syncEngine.stopSync(timeout);
   }
 }

--- a/packages/agent/src/sync-engine-level.ts
+++ b/packages/agent/src/sync-engine-level.ts
@@ -319,16 +319,16 @@ export class SyncEngineLevel implements SyncEngine {
    * stopSync currently awaits the completion of the current sync operation before stopping the sync interval.
    * TODO: implement a signal to gracefully stop sync immediately https://github.com/TBD54566975/web5-js/issues/890
    */
-  public async stopSync(): Promise<void> {
+  public async stopSync(timeout: number = 2000): Promise<void> {
     let elapsedTimeout = 0;
 
     while(this._syncLock) {
-      if (elapsedTimeout > 2000) {
-        throw new Error('SyncEngineLevel: Existing sync operation did not complete within 5 seconds.');
+      if (elapsedTimeout >= timeout) {
+        throw new Error(`SyncEngineLevel: Existing sync operation did not complete within ${timeout} milliseconds.`);
       }
 
       elapsedTimeout += 100;
-      await new Promise((resolve) => setTimeout(resolve, 100));
+      await new Promise((resolve) => setTimeout(resolve, timeout < 100 ? timeout : 100));
     }
 
     if (this._syncIntervalId) {

--- a/packages/agent/src/sync-engine-level.ts
+++ b/packages/agent/src/sync-engine-level.ts
@@ -315,7 +315,22 @@ export class SyncEngineLevel implements SyncEngine {
     }
   }
 
-  public stopSync(): void {
+  /**
+   * stopSync currently awaits the completion of the current sync operation before stopping the sync interval.
+   * TODO: implement a signal to gracefully stop sync immediately https://github.com/TBD54566975/web5-js/issues/890
+   */
+  public async stopSync(): Promise<void> {
+    let elapsedTimeout = 0;
+
+    while(this._syncLock) {
+      if (elapsedTimeout > 2000) {
+        throw new Error('SyncEngineLevel: Existing sync operation did not complete within 5 seconds.');
+      }
+
+      elapsedTimeout += 100;
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+
     if (this._syncIntervalId) {
       clearInterval(this._syncIntervalId);
       this._syncIntervalId = undefined;

--- a/packages/agent/src/test-harness.ts
+++ b/packages/agent/src/test-harness.ts
@@ -85,6 +85,9 @@ export class PlatformAgentTestHarness {
   }
 
   public async clearStorage(): Promise<void> {
+    // first stop any ongoing sync operations
+    await this.agent.sync.stopSync();
+
     // @ts-expect-error since normally this property shouldn't be set to undefined.
     this.agent.agentDid = undefined;
     await this.didResolverCache.clear();

--- a/packages/agent/src/types/sync.ts
+++ b/packages/agent/src/types/sync.ts
@@ -39,5 +39,5 @@ export interface SyncEngine {
   /**
    * Stops the periodic sync operation, will complete the current sync operation if one is already in progress.
    */
-  stopSync(): void;
+  stopSync(): Promise<void>;
 }

--- a/packages/agent/src/types/sync.ts
+++ b/packages/agent/src/types/sync.ts
@@ -38,6 +38,9 @@ export interface SyncEngine {
   startSync(params: { interval: string }): Promise<void>;
   /**
    * Stops the periodic sync operation, will complete the current sync operation if one is already in progress.
+   *
+   * @param timeout the maximum amount of time, in milliseconds, to wait for the current sync operation to complete. Default is 2000 (2 seconds).
+   * @throws {Error} if the sync operation fails to stop before the timeout.
    */
-  stopSync(): Promise<void>;
+  stopSync(timeout?: number): Promise<void>;
 }

--- a/packages/agent/tests/sync-engine-level.spec.ts
+++ b/packages/agent/tests/sync-engine-level.spec.ts
@@ -152,7 +152,6 @@ describe('SyncEngineLevel', () => {
 
       sinon.restore();
 
-      syncEngine.stopSync();
       await syncEngine.clear();
       await testHarness.syncStore.clear();
       await testHarness.dwnDataStore.clear();

--- a/packages/api/tests/web5.spec.ts
+++ b/packages/api/tests/web5.spec.ts
@@ -171,7 +171,6 @@ describe('web5 api', () => {
 
     beforeEach(async () => {
       sinon.restore();
-      testHarness.agent.sync.stopSync();
       await testHarness.clearStorage();
       await testHarness.createAgentDid();
     });
@@ -793,8 +792,6 @@ describe('web5 api', () => {
 
         expect(startSyncSpy.args[0][0].interval).to.equal('1m');
       });
-
-
 
       it('should request all permissions for a protocol if no specific permissions are provided', async () => {
 

--- a/packages/dev-env/docker-compose.yaml
+++ b/packages/dev-env/docker-compose.yaml
@@ -3,6 +3,6 @@ version: "3.98"
 services:
   dwn-server:
     container_name: dwn-server
-    image: ghcr.io/tbd54566975/dwn-server:0.4.8
+    image: ghcr.io/tbd54566975/dwn-server:0.4.9
     ports:
       - "3000:3000"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,8 +33,8 @@ importers:
         specifier: 7.9.0
         version: 7.9.0(@typescript-eslint/parser@7.14.1(eslint@9.7.0)(typescript@5.5.4))(eslint@9.7.0)(typescript@5.5.4)
       '@web5/dwn-server':
-        specifier: 0.4.8
-        version: 0.4.8
+        specifier: 0.4.9
+        version: 0.4.9
       audit-ci:
         specifier: ^7.0.1
         version: 7.1.0
@@ -2504,8 +2504,8 @@ packages:
     resolution: {integrity: sha512-M9EfsEYcOtYuEvUQjow4vpxXbD0Sz5H8EuDXMtwuvP4UdYL0ATl+60F8+8HDmwPFeUy6M2wxuoixrLDwSRFwZA==}
     engines: {node: '>=18.0.0'}
 
-  '@web5/dwn-server@0.4.8':
-    resolution: {integrity: sha512-Mr+Oq8XTZN133gnQYjhN07sbjVkfdlhsigQhDqThX9ghf2Kk3kiakb+5tlwYgsFCyj8O6sW+UM07443xZS3qLA==}
+  '@web5/dwn-server@0.4.9':
+    resolution: {integrity: sha512-LCBu7gcmfWcT8i571LPK5bHsBqtF2b0gC1VjAqZTo7ESCjGPrL6byvntiGiYWfSfzl9zgxpb/dIdVu/Ia8xvFA==}
     hasBin: true
 
   '@webassemblyjs/ast@1.12.1':
@@ -8343,7 +8343,7 @@ snapshots:
       level: 8.0.1
       ms: 2.1.3
 
-  '@web5/dwn-server@0.4.8':
+  '@web5/dwn-server@0.4.9':
     dependencies:
       '@tbd54566975/dwn-sdk-js': 0.4.6
       '@tbd54566975/dwn-sql-store': 0.6.6


### PR DESCRIPTION
- Add a missing changset for https://github.com/TBD54566975/web5-js/pull/887:

`stopSync` now blocks if a current sync is in progress before clearing the interval. An optional timeout can be defined, the default is 2 seconds. After this timeout it will throw.

TestHarness has been updated to stop sync before clearing storage, previously this caused an issue where an ongoing sync would attempt to sign messages for DID that no longer had keys after clearing storage.

https://github.com/TBD54566975/web5-js/issues/890 has been created to better address this by creating a signal to gracefully stop sync immediately.