### PR TITLE
Ability to update SyncOptions for an identity

### DIFF
--- a/.changeset/lovely-eyes-tell.md
+++ b/.changeset/lovely-eyes-tell.md
@@ -1,0 +1,8 @@
+---
+"@web5/agent": patch
+"@web5/identity-agent": patch
+"@web5/proxy-agent": patch
+"@web5/user-agent": patch
+---
+
+Add additionaly Sync Identity Management capabilities

--- a/packages/agent/src/sync-api.ts
+++ b/packages/agent/src/sync-api.ts
@@ -45,6 +45,18 @@ export class AgentSyncApi implements SyncEngine {
     await this._syncEngine.registerIdentity(params);
   }
 
+  public async unregisterIdentity(did: string): Promise<void> {
+    await this._syncEngine.unregisterIdentity(did);
+  }
+
+  public async getIdentityOptions(did: string): Promise<SyncIdentityOptions | undefined> {
+    return await this._syncEngine.getIdentityOptions(did);
+  }
+
+  public async updateIdentityOptions(did: string, options: SyncIdentityOptions): Promise<void> {
+    await this._syncEngine.updateIdentityOptions(did, options);
+  }
+
   public sync(direction?: 'push' | 'pull'): Promise<void> {
     return this._syncEngine.sync(direction);
   }

--- a/packages/agent/src/sync-api.ts
+++ b/packages/agent/src/sync-api.ts
@@ -53,8 +53,8 @@ export class AgentSyncApi implements SyncEngine {
     return await this._syncEngine.getIdentityOptions(did);
   }
 
-  public async updateIdentityOptions(did: string, options: SyncIdentityOptions): Promise<void> {
-    await this._syncEngine.updateIdentityOptions(did, options);
+  public async updateIdentityOptions(params: { did: string, options: SyncIdentityOptions }): Promise<void> {
+    await this._syncEngine.updateIdentityOptions(params);
   }
 
   public sync(direction?: 'push' | 'pull'): Promise<void> {

--- a/packages/agent/src/sync-engine-level.ts
+++ b/packages/agent/src/sync-engine-level.ts
@@ -171,7 +171,6 @@ export class SyncEngineLevel implements SyncEngine {
           message   : messagesRead.message,
         }) as MessagesReadReply;
       } catch(e) {
-        console.log('SyncEngineLevel: pull - Error fetching message from remote DWN', e);
         errored.add(dwnUrl);
         continue;
       }

--- a/packages/agent/src/sync-engine-level.ts
+++ b/packages/agent/src/sync-engine-level.ts
@@ -260,7 +260,7 @@ export class SyncEngineLevel implements SyncEngine {
 
     const existing = await this.getIdentityOptions(did);
     if (existing) {
-      throw new Error(`SyncEngineLevel: Identity with DID ${did} is already registered`);
+      throw new Error(`SyncEngineLevel: Identity with DID ${did} is already registered.`);
     }
 
     // if no options are provided, we default to no delegateDid and all protocols (empty array)
@@ -274,7 +274,7 @@ export class SyncEngineLevel implements SyncEngine {
     const registeredIdentities = this._db.sublevel('registeredIdentities');
     const existing = await this.getIdentityOptions(did);
     if (!existing) {
-      throw new Error(`SyncEngineLevel: Identity with DID ${did} is not registered`);
+      throw new Error(`SyncEngineLevel: Identity with DID ${did} is not registered.`);
     }
 
     await registeredIdentities.del(did);
@@ -298,11 +298,11 @@ export class SyncEngineLevel implements SyncEngine {
     }
   }
 
-  public async updateIdentityOptions(did: string, options: SyncIdentityOptions): Promise<void> {
+  public async updateIdentityOptions({ did, options }: { did: string, options: SyncIdentityOptions }): Promise<void> {
     const registeredIdentities = this._db.sublevel('registeredIdentities');
     const existingOptions = await this.getIdentityOptions(did);
     if (!existingOptions) {
-      throw new Error(`SyncEngineLevel: Identity with DID ${did} is not registered`);
+      throw new Error(`SyncEngineLevel: Identity with DID ${did} is not registered.`);
     }
 
     await registeredIdentities.put(did, JSON.stringify(options));

--- a/packages/agent/src/sync-engine-level.ts
+++ b/packages/agent/src/sync-engine-level.ts
@@ -1,5 +1,5 @@
 import type { ULIDFactory } from 'ulidx';
-import { AbstractBatchOperation, AbstractLevel } from 'abstract-level';
+import type { AbstractBatchOperation, AbstractLevel } from 'abstract-level';
 import type {
   GenericMessage,
   MessagesQueryReply,

--- a/packages/agent/src/types/sync.ts
+++ b/packages/agent/src/types/sync.ts
@@ -34,7 +34,7 @@ export interface SyncEngine {
   /**
    * Update the Sync Options for a specific identity, replaces the existing options.
    */
-  updateIdentityOptions(did: string, options: SyncIdentityOptions): Promise<void>;
+  updateIdentityOptions(params: { did: string, options: SyncIdentityOptions }): Promise<void>;
   /**
    * Preforms a one-shot sync operation. If no direction is provided, it will perform both push and pull.
    * @param direction which direction you'd like to perform the sync operation.

--- a/packages/agent/src/types/sync.ts
+++ b/packages/agent/src/types/sync.ts
@@ -24,6 +24,18 @@ export interface SyncEngine {
    */
   registerIdentity(params: { did: string, options?: SyncIdentityOptions }): Promise<void>;
   /**
+   * Unregister an identity from the SyncEngine, this will stop syncing messages for this identity.
+   */
+  unregisterIdentity(did: string): Promise<void>;
+  /**
+   * Get the Sync Options for a specific identity.
+   */
+  getIdentityOptions(did: string): Promise<SyncIdentityOptions | undefined>;
+  /**
+   * Update the Sync Options for a specific identity, replaces the existing options.
+   */
+  updateIdentityOptions(did: string, options: SyncIdentityOptions): Promise<void>;
+  /**
    * Preforms a one-shot sync operation. If no direction is provided, it will perform both push and pull.
    * @param direction which direction you'd like to perform the sync operation.
    *


### PR DESCRIPTION
Added the ability to get/update the sync options for a given identity.

Additionally calling `registerIdentity` will fail if an identity is already registered instead of over-writing the options.
Ability to `unregister` an identity, which will stop it from syncing further the next interval.