### PR TITLE
replace Identity API `list` method with `lisetMetadata`

### DIFF
--- a/.changeset/popular-monkeys-rush.md
+++ b/.changeset/popular-monkeys-rush.md
@@ -1,0 +1,8 @@
+---
+"@web5/identity-agent": minor
+"@web5/agent": minor
+"@web5/proxy-agent": minor
+"@web5/user-agent": minor
+---
+
+Replace `list` of Identities with `listeMetadata` in the identity api to prevent an issue that could occur during sync of an identity agent.

--- a/.changeset/witty-pants-serve.md
+++ b/.changeset/witty-pants-serve.md
@@ -1,0 +1,5 @@
+---
+"@web5/api": minor
+---
+
+Replace use of identity api `list` with `listMetadata`

--- a/packages/agent/tests/identity-api.spec.ts
+++ b/packages/agent/tests/identity-api.spec.ts
@@ -133,18 +133,18 @@ describe('AgentIdentityApi', () => {
           });
 
           // List identities and verify the result.
-          const storedIdentities = await testHarness.agent.identity.list();
+          const storedIdentities = await testHarness.agent.identity.listMetadata();
           expect(storedIdentities).to.have.length(3);
 
           const createdIdentities = [alice.did.uri, bob.did.uri, carol.did.uri];
           for (const storedIdentity of storedIdentities) {
-            expect(createdIdentities).to.include(storedIdentity.did.uri);
+            expect(createdIdentities).to.include(storedIdentity.uri);
           }
         });
 
         it('returns an empty array if the store contains no Identities', async () => {
           // List identities and verify the result is empty.
-          const storedIdentities = await testHarness.agent.identity.list();
+          const storedIdentities = await testHarness.agent.identity.listMetadata();
           expect(storedIdentities).to.be.empty;
         });
       });

--- a/packages/api/tests/web5.spec.ts
+++ b/packages/api/tests/web5.spec.ts
@@ -692,7 +692,7 @@ describe('web5 api', () => {
         }
 
         // check that the Identity was deleted
-        const appIdentities = await appTestHarness.agent.identity.list();
+        const appIdentities = await appTestHarness.agent.identity.listMetadata();
         expect(appIdentities).to.have.lengthOf(0);
 
         // close the app test harness storage
@@ -716,7 +716,7 @@ describe('web5 api', () => {
         const consoleSpy = sinon.stub(console, 'error').returns();
 
         // call identityCleanup on a did that does not exist
-        await Web5['cleanUpIdentity']({ userAgent: testHarness.agent as Web5UserAgent, identity });
+        await Web5['cleanUpIdentity']({ userAgent: testHarness.agent as Web5UserAgent, identity: identity.metadata });
 
         expect(consoleSpy.calledTwice, 'console.error called twice').to.be.true;
       });

--- a/packages/identity-agent/tests/managing-identities.spec.ts
+++ b/packages/identity-agent/tests/managing-identities.spec.ts
@@ -98,7 +98,7 @@ describe('Managing Identities', () => {
             await testHarness.agent.identity.manage({ portableIdentity: await socialIdentity.export() });
 
             // Verify the Identities were ALSO stored in the Identity Agent's tenant.
-            const storedIdentities = await testHarness.agent.identity.list();
+            const storedIdentities = await testHarness.agent.identity.listMetadata();
             expect(storedIdentities).to.have.length(3);
 
             // Verify the DIDs were only stored in the new Identity's tenant.


### PR DESCRIPTION
While working with restoring a a synced agent, I ran into an issue where the Identity API's `list` method requires both the messages from the agent's DID and the Identity itself, however that Identity may not have been registered to sync (yet or ever).

This doesn't solve the issue entirely, however I did notice that most times when listing the identities, you first want the metadata which gives you what you need to then `get` the `BearerIdentity`.

I've replaced `list` with `listMetadata` in this PR and updated the usage in `@web5/api`.

In a subsequent PR(s?) I will address the underlying issue associated with syncing an agent, or potentially refactoring the Identity API completely, however I wanted to put in this low-effort PR to unblock a path in a sane way.