### PR TITLE
Enable event-stream by default for DwnApi.

### DIFF
--- a/.changeset/rotten-lions-flash.md
+++ b/.changeset/rotten-lions-flash.md
@@ -1,0 +1,5 @@
+---
+"@web5/api": patch
+---
+
+Enable EventStream from agent.

--- a/.changeset/rude-socks-pay.md
+++ b/.changeset/rude-socks-pay.md
@@ -1,0 +1,8 @@
+---
+"@web5/agent": patch
+"@web5/identity-agent": patch
+"@web5/proxy-agent": patch
+"@web5/user-agent": patch
+---
+
+Enable EventEmitterStream

--- a/packages/agent/src/dwn-api.ts
+++ b/packages/agent/src/dwn-api.ts
@@ -7,6 +7,7 @@ import {
   DwnConfig,
   DwnInterfaceName,
   DwnMethodName,
+  EventEmitterStream,
   EventLogLevel,
   GenericMessage,
   Message,
@@ -155,6 +156,8 @@ export class AgentDwnApi {
     }));
 
     resumableTaskStore ??= new ResumableTaskStoreLevel({ location: `${dataPath}/DWN_RESUMABLETASKSTORE` });
+
+    eventStream ??= new EventEmitterStream();
 
     return await Dwn.create({ dataStore, didResolver, eventLog, eventStream, messageStore, tenantGate, resumableTaskStore });
   }


### PR DESCRIPTION
For local subscriptions the EventEmitterStream was not being set when instantiating the DwnApi.