### PR TITLE
Agent resolver refreshes did store and cache

### DIFF
--- a/.changeset/brave-cameras-reply.md
+++ b/.changeset/brave-cameras-reply.md
@@ -1,0 +1,9 @@
+---
+"@web5/agent": minor
+"@web5/dids": minor
+"@web5/identity-agent": minor
+"@web5/proxy-agent": minor
+"@web5/user-agent": minor
+---
+
+Ability to Update a DID

--- a/packages/agent/src/agent-did-resolver-cache.ts
+++ b/packages/agent/src/agent-did-resolver-cache.ts
@@ -72,7 +72,7 @@ export class AgentDidResolverCache extends DidResolverCacheLevel implements DidR
               } catch(error: any) {
                 // if the error is not due to no changes detected, log the error
                 if (error.message && !error.message.includes('No changes detected, update aborted')) {
-                  console.error(`Error updating DID: ${error.message}`);
+                  logger.error(`Error updating DID: ${error.message}`);
                 }
               }
             }

--- a/packages/agent/src/agent-did-resolver-cache.ts
+++ b/packages/agent/src/agent-did-resolver-cache.ts
@@ -70,7 +70,7 @@ export class AgentDidResolverCache extends DidResolverCacheLevel implements DidR
               } catch(error: any) {
                 // if the error is not due to no changes detected, log the error
                 if (error.message && !error.message.includes('No changes detected, update aborted')) {
-                  console.log(`Error updating DID: ${error.message}`);
+                  console.error(`Error updating DID: ${error.message}`);
                 }
               }
             }

--- a/packages/agent/src/agent-did-resolver-cache.ts
+++ b/packages/agent/src/agent-did-resolver-cache.ts
@@ -1,5 +1,6 @@
 import { DidResolutionResult, DidResolverCache, DidResolverCacheLevel, DidResolverCacheLevelParams } from '@web5/dids';
 import { Web5PlatformAgent } from './types/agent.js';
+import { logger } from '@web5/common';
 
 
 /**

--- a/packages/agent/src/agent-did-resolver-cache.ts
+++ b/packages/agent/src/agent-did-resolver-cache.ts
@@ -64,9 +64,10 @@ export class AgentDidResolverCache extends DidResolverCacheLevel implements DidR
                 metadata : result.didDocumentMetadata,
               };
 
-              // this will throw an error if the DID is not managed by the agent, or there is no difference between the stored and resolved DID
               try {
-                await this.agent.did.update({ portableDid, tenant: this.agent.agentDid.uri });
+                // this will throw an error if the DID is not managed by the agent, or there is no difference between the stored and resolved DID
+                // We don't publish the DID in this case, as it was received by the resolver.
+                await this.agent.did.update({ portableDid, tenant: this.agent.agentDid.uri, publish: false });
               } catch(error: any) {
                 // if the error is not due to no changes detected, log the error
                 if (error.message && !error.message.includes('No changes detected, update aborted')) {

--- a/packages/agent/src/did-api.ts
+++ b/packages/agent/src/did-api.ts
@@ -264,7 +264,7 @@ export class AgentDidApi<TKeyManager extends AgentKeyManager = AgentKeyManager> 
   }): Promise<BearerDid> {
 
     // Check if the DID exists in the store.
-    const existingDid = await this.get({ didUri: portableDid.uri, tenant });
+    const existingDid = await this.get({ didUri: portableDid.uri, tenant: tenant ?? portableDid.uri });
     if (!existingDid) {
       throw new Error(`AgentDidApi: Could not update, DID not found: ${portableDid.uri}`);
     }

--- a/packages/agent/src/did-api.ts
+++ b/packages/agent/src/did-api.ts
@@ -11,7 +11,7 @@ import type {
   DidResolverCache,
 } from '@web5/dids';
 
-import { BearerDid, Did, UniversalResolver } from '@web5/dids';
+import { BearerDid, Did, DidDht, UniversalResolver } from '@web5/dids';
 
 import type { AgentDataStore } from './store-data.js';
 import type { AgentKeyManager } from './types/key-manager.js';
@@ -19,6 +19,7 @@ import type { ResponseStatus, Web5PlatformAgent } from './types/agent.js';
 
 import { InMemoryDidStore } from './store-did.js';
 import { AgentDidResolverCache } from './agent-did-resolver-cache.js';
+import { canonicalize } from '@web5/crypto';
 
 export enum DidInterface {
   Create  = 'Create',
@@ -254,6 +255,59 @@ export class AgentDidApi<TKeyManager extends AgentKeyManager = AgentKeyManager> 
     const verificationMethod = await didMethod.getSigningMethod({ didDocument, methodId });
 
     return verificationMethod;
+  }
+
+  public async update({ tenant, portableDid, publish = true }: {
+    tenant?: string;
+    portableDid: PortableDid;
+    publish?: boolean;
+  }): Promise<BearerDid> {
+
+    // Check if the DID exists in the store.
+    const existingDid = await this.get({ didUri: portableDid.uri, tenant });
+    if (!existingDid) {
+      throw new Error(`AgentDidApi: Could not update, DID not found: ${portableDid.uri}`);
+    }
+
+    // If the document has not changed, abort the update.
+    if (canonicalize(portableDid.document) === canonicalize(existingDid.document)) {
+      throw new Error('AgentDidApi: No changes detected, update aborted');
+    }
+
+    // If private keys are present in the PortableDid, import the key material into the Agent's key
+    // manager. Validate that the key material for every verification method in the DID document is
+    // present in the key manager.
+    const bearerDid = await BearerDid.import({ keyManager: this.agent.keyManager, portableDid });
+
+    // Only the DID URI, document, and metadata are stored in the Agent's DID store.
+    const { uri, document, metadata } = bearerDid;
+    const portableDidWithoutKeys: PortableDid = { uri, document, metadata };
+
+    // pre-populate the resolution cache with the document and metadata
+    await this.cache.set(uri, { didDocument: document, didResolutionMetadata: { }, didDocumentMetadata: metadata });
+
+    // Store the DID in the agent's DID store.
+    // Unless an existing `tenant` is specified, a record that includes the DID's URI, document,
+    // and metadata will be stored under a new tenant controlled by the imported DID.
+    await this._store.set({
+      id             : portableDidWithoutKeys.uri,
+      data           : portableDidWithoutKeys,
+      agent          : this.agent,
+      tenant         : tenant ?? portableDidWithoutKeys.uri,
+      updateExisting : true,
+      useCache       : true
+    });
+
+    if (publish) {
+      const parsedDid = Did.parse(bearerDid.uri);
+      // currently only supporting DHT as a publishable method.
+      // TODO: abstract this into the didMethod class so that other publishable methods can be supported.
+      if (parsedDid && parsedDid.method === 'dht') {
+        await DidDht.publish({ did: bearerDid });
+      }
+    }
+
+    return bearerDid;
   }
 
   public async import({ portableDid, tenant }: {

--- a/packages/agent/src/local-key-manager.ts
+++ b/packages/agent/src/local-key-manager.ts
@@ -423,6 +423,7 @@ export class LocalKeyManager implements AgentKeyManager {
     // Compute the key URI for the key.
     const keyUri = await this.getKeyUri({ key: privateKey });
 
+    // Store the key in the key store.
     await this._keyStore.set({
       id                : keyUri,
       data              : privateKey,

--- a/packages/agent/src/local-key-manager.ts
+++ b/packages/agent/src/local-key-manager.ts
@@ -423,17 +423,13 @@ export class LocalKeyManager implements AgentKeyManager {
     // Compute the key URI for the key.
     const keyUri = await this.getKeyUri({ key: privateKey });
 
-    const existingKey = await this._keyStore.get({ id: keyUri, agent: this.agent, useCache: true });
-    if (!existingKey) {
-      // Store the key if it does not already exist in the key store.
-      await this._keyStore.set({
-        id                : keyUri,
-        data              : privateKey,
-        agent             : this.agent,
-        preventDuplicates : true,
-        useCache          : true
-      });
-    }
+    await this._keyStore.set({
+      id                : keyUri,
+      data              : privateKey,
+      agent             : this.agent,
+      preventDuplicates : true,
+      useCache          : true
+    });
 
     return keyUri;
   }

--- a/packages/agent/src/local-key-manager.ts
+++ b/packages/agent/src/local-key-manager.ts
@@ -423,14 +423,17 @@ export class LocalKeyManager implements AgentKeyManager {
     // Compute the key URI for the key.
     const keyUri = await this.getKeyUri({ key: privateKey });
 
-    // Store the key in the key store.
-    await this._keyStore.set({
-      id                : keyUri,
-      data              : privateKey,
-      agent             : this.agent,
-      preventDuplicates : true,
-      useCache          : true
-    });
+    const existingKey = await this._keyStore.get({ id: keyUri, agent: this.agent, useCache: true });
+    if (!existingKey) {
+      // Store the key if it does not already exist in the key store.
+      await this._keyStore.set({
+        id                : keyUri,
+        data              : privateKey,
+        agent             : this.agent,
+        preventDuplicates : true,
+        useCache          : true
+      });
+    }
 
     return keyUri;
   }

--- a/packages/agent/src/store-data.ts
+++ b/packages/agent/src/store-data.ts
@@ -7,7 +7,7 @@ import type { Web5PlatformAgent } from './types/agent.js';
 
 import { TENANT_SEPARATOR } from './utils-internal.js';
 import { getDataStoreTenant } from './utils-internal.js';
-import { DwnInterface } from './types/dwn.js';
+import { DwnInterface, DwnMessageParams } from './types/dwn.js';
 import { ProtocolDefinition } from '@tbd54566975/dwn-sdk-js';
 
 export type DataStoreTenantParams = {
@@ -26,6 +26,7 @@ export type DataStoreSetParams<TStoreObject> = DataStoreTenantParams & {
   id: string;
   data: TStoreObject;
   preventDuplicates?: boolean;
+  updateExisting?: boolean;
   useCache?: boolean;
 }
 
@@ -137,7 +138,7 @@ export class DwnDataStore<TStoreObject extends Record<string, any> = Jwk> implem
     return storedRecords;
   }
 
-  public async set({ id, data, tenant, agent, preventDuplicates = true, useCache = false }:
+  public async set({ id, data, tenant, agent, preventDuplicates = true, updateExisting = false, useCache = false }:
     DataStoreSetParams<TStoreObject>
   ): Promise<void> {
     // Determine the tenant identifier (DID) for the set operation.
@@ -146,14 +147,25 @@ export class DwnDataStore<TStoreObject extends Record<string, any> = Jwk> implem
     // initialize the storage protocol if not already done
     await this.initialize({ tenant: tenantDid, agent });
 
-    // If enabled, check if a record with the given `id` is already present in the store.
-    if (preventDuplicates) {
+    const messageParams: DwnMessageParams[DwnInterface.RecordsWrite] = { ...this._recordProperties };
+
+    if (updateExisting) {
+      // Look up the DWN record ID of the object in the store with the given `id`.
+      const matchingRecordId = await this.lookupRecordId({ id, tenantDid, agent });
+      if (!matchingRecordId) {
+        throw new Error(`${this.name}: Update failed due to missing entry for: ${id}`);
+      }
+
+      // set the recordId in the messageParams to update the existing record
+      messageParams.recordId = matchingRecordId;
+    } else if (preventDuplicates) {
       // Look up the DWN record ID of the object in the store with the given `id`.
       const matchingRecordId = await this.lookupRecordId({ id, tenantDid, agent });
       if (matchingRecordId) {
         throw new Error(`${this.name}: Import failed due to duplicate entry for: ${id}`);
       }
     }
+
 
     // Convert the store object to a byte array, which will be the data payload of the DWN record.
     const dataBytes = Convert.object(data).toUint8Array();
@@ -340,12 +352,19 @@ export class InMemoryDataStore<TStoreObject extends Record<string, any> = Jwk> i
     return result;
   }
 
-  public async set({ id, data, tenant, agent, preventDuplicates }: DataStoreSetParams<TStoreObject>): Promise<void> {
+  public async set({ id, data, tenant, agent, preventDuplicates, updateExisting }: DataStoreSetParams<TStoreObject>): Promise<void> {
     // Determine the tenant identifier (DID) for the set operation.
     const tenantDid = await getDataStoreTenant({ agent, tenant, didUri: id });
 
     // If enabled, check if a record with the given `id` is already present in the store.
-    if (preventDuplicates) {
+    if (updateExisting) {
+      // Look up the DWN record ID of the object in the store with the given `id`.
+      if (!this.store.has(`${tenantDid}${TENANT_SEPARATOR}${id}`)) {
+        throw new Error(`${this.name}: Update failed due to missing entry for: ${id}`);
+      }
+
+      // set the recordId in the messageParams to update the existing record
+    } else if (preventDuplicates) {
       const duplicateFound = this.store.has(`${tenantDid}${TENANT_SEPARATOR}${id}`);
       if (duplicateFound) {
         throw new Error(`${this.name}: Import failed due to duplicate entry for: ${id}`);

--- a/packages/agent/tests/agent-did-resolver-cach.spec.ts
+++ b/packages/agent/tests/agent-did-resolver-cach.spec.ts
@@ -5,7 +5,6 @@ import { TestAgent } from './utils/test-agent.js';
 import sinon from 'sinon';
 import { expect } from 'chai';
 import { BearerDid, DidJwk } from '@web5/dids';
-import { BearerIdentity } from '../src/bearer-identity.js';
 
 describe('AgentDidResolverCache',  () => {
   let resolverCache: AgentDidResolverCache;
@@ -81,7 +80,7 @@ describe('AgentDidResolverCache',  () => {
 
     const getStub = sinon.stub(resolverCache['cache'], 'get').resolves(JSON.stringify({ ttlMillis: Date.now() - 1000, value: { didDocument: { id: did.uri } } }));
     const resolveSpy = sinon.spy(testHarness.agent.did, 'resolve').withArgs(did.uri);
-    const nextTickSpy = sinon.stub(resolverCache['cache'], 'nextTick').resolves();
+    sinon.stub(resolverCache['cache'], 'nextTick').resolves();
     const didApiStub = sinon.stub(testHarness.agent.did, 'get');
     const updateSpy = sinon.stub(testHarness.agent.did, 'update').resolves();
     didApiStub.withArgs({ didUri: did.uri, tenant: testHarness.agent.agentDid.uri }).resolves(new BearerDid({
@@ -104,7 +103,7 @@ describe('AgentDidResolverCache',  () => {
 
     const getStub = sinon.stub(resolverCache['cache'], 'get').resolves(JSON.stringify({ ttlMillis: Date.now() - 1000, value: { didDocument: { id: did.uri } } }));
     const resolveSpy = sinon.spy(testHarness.agent.did, 'resolve').withArgs(did.uri);
-    const nextTickSpy = sinon.stub(resolverCache['cache'], 'nextTick').resolves();
+    sinon.stub(resolverCache['cache'], 'nextTick').resolves();
     const didApiStub = sinon.stub(testHarness.agent.did, 'get');
     const updateSpy = sinon.stub(testHarness.agent.did, 'update').rejects(new Error('Some Error'));
     const consoleErrorSpy = sinon.stub(console, 'error');
@@ -137,7 +136,7 @@ describe('AgentDidResolverCache',  () => {
 
   it('throws if the error is anything other than a notFound error', async () => {
     const did = testHarness.agent.agentDid.uri;
-    const getStub = sinon.stub(resolverCache['cache'], 'get').rejects(new Error('Some Error'));
+    sinon.stub(resolverCache['cache'], 'get').rejects(new Error('Some Error'));
 
     try {
       await resolverCache.get(did);

--- a/packages/agent/tests/agent-did-resolver-cach.spec.ts
+++ b/packages/agent/tests/agent-did-resolver-cach.spec.ts
@@ -5,6 +5,7 @@ import { TestAgent } from './utils/test-agent.js';
 import sinon from 'sinon';
 import { expect } from 'chai';
 import { BearerDid, DidJwk } from '@web5/dids';
+import { logger } from '@web5/common';
 
 describe('AgentDidResolverCache',  () => {
   let resolverCache: AgentDidResolverCache;
@@ -106,7 +107,7 @@ describe('AgentDidResolverCache',  () => {
     sinon.stub(resolverCache['cache'], 'nextTick').resolves();
     const didApiStub = sinon.stub(testHarness.agent.did, 'get');
     const updateSpy = sinon.stub(testHarness.agent.did, 'update').rejects(new Error('Some Error'));
-    const consoleErrorSpy = sinon.stub(console, 'error');
+    const consoleErrorSpy = sinon.stub(logger, 'error');
     didApiStub.withArgs({ didUri: did.uri, tenant: testHarness.agent.agentDid.uri }).resolves(new BearerDid({
       uri        : did.uri,
       document   : { id: did.uri },

--- a/packages/agent/tests/agent-did-resolver-cach.spec.ts
+++ b/packages/agent/tests/agent-did-resolver-cach.spec.ts
@@ -61,11 +61,10 @@ describe('AgentDidResolverCache',  () => {
   });
 
   it('should not call resolve if the DID is not the agent DID or exists as an identity in the agent', async () => {
-    const did = await DidJwk.create({});
+    const did = await DidJwk.create();
     const getStub = sinon.stub(resolverCache['cache'], 'get').resolves(JSON.stringify({ ttlMillis: Date.now() - 1000, value: { didDocument: { id: did.uri } } }));
-    const resolveSpy = sinon.spy(testHarness.agent.did, 'resolve');
+    const resolveSpy = sinon.spy(testHarness.agent.did, 'resolve').withArgs(did.uri);
     const nextTickSpy = sinon.stub(resolverCache['cache'], 'nextTick').resolves();
-    sinon.stub(testHarness.agent.identity, 'get').resolves(undefined);
 
     await resolverCache.get(did.uri),
 

--- a/packages/agent/tests/agent-did-resolver-cach.spec.ts
+++ b/packages/agent/tests/agent-did-resolver-cach.spec.ts
@@ -4,7 +4,7 @@ import { TestAgent } from './utils/test-agent.js';
 
 import sinon from 'sinon';
 import { expect } from 'chai';
-import { DidJwk } from '@web5/dids';
+import { BearerDid, DidJwk } from '@web5/dids';
 import { BearerIdentity } from '../src/bearer-identity.js';
 
 describe('AgentDidResolverCache',  () => {
@@ -76,21 +76,52 @@ describe('AgentDidResolverCache',  () => {
     expect(nextTickSpy.callCount).to.equal(1);
   });
 
-  it('should resolve if the DID is managed by the agent', async () => {
-    const did = await DidJwk.create({});
+  it('should resolve and update if the DID is managed by the agent', async () => {
+    const did = await DidJwk.create();
+
     const getStub = sinon.stub(resolverCache['cache'], 'get').resolves(JSON.stringify({ ttlMillis: Date.now() - 1000, value: { didDocument: { id: did.uri } } }));
-    const resolveSpy = sinon.spy(testHarness.agent.did, 'resolve');
+    const resolveSpy = sinon.spy(testHarness.agent.did, 'resolve').withArgs(did.uri);
     const nextTickSpy = sinon.stub(resolverCache['cache'], 'nextTick').resolves();
-    sinon.stub(testHarness.agent.identity, 'get').resolves(new BearerIdentity({
-      metadata: { name: 'Some Name', uri: did.uri, tenant: did.uri },
-      did,
+    const didApiStub = sinon.stub(testHarness.agent.did, 'get');
+    const updateSpy = sinon.stub(testHarness.agent.did, 'update').resolves();
+    didApiStub.withArgs({ didUri: did.uri, tenant: testHarness.agent.agentDid.uri }).resolves(new BearerDid({
+      uri        : did.uri,
+      document   : { id: did.uri },
+      metadata   : { },
+      keyManager : testHarness.agent.keyManager
     }));
 
     await resolverCache.get(did.uri),
 
     // get should be called once, and we also resolve the DId as it's returned by the identity.get method
-    expect(getStub.callCount).to.equal(1);
-    expect(resolveSpy.callCount).to.equal(1);
+    expect(getStub.callCount).to.equal(1, 'get');
+    expect(resolveSpy.callCount).to.equal(1, 'resolve');
+    expect(updateSpy.callCount).to.equal(1, 'update');
+  });
+
+  it('should log an error if an update is attempted and fails', async () => {
+    const did = await DidJwk.create();
+
+    const getStub = sinon.stub(resolverCache['cache'], 'get').resolves(JSON.stringify({ ttlMillis: Date.now() - 1000, value: { didDocument: { id: did.uri } } }));
+    const resolveSpy = sinon.spy(testHarness.agent.did, 'resolve').withArgs(did.uri);
+    const nextTickSpy = sinon.stub(resolverCache['cache'], 'nextTick').resolves();
+    const didApiStub = sinon.stub(testHarness.agent.did, 'get');
+    const updateSpy = sinon.stub(testHarness.agent.did, 'update').rejects(new Error('Some Error'));
+    const consoleErrorSpy = sinon.stub(console, 'error');
+    didApiStub.withArgs({ didUri: did.uri, tenant: testHarness.agent.agentDid.uri }).resolves(new BearerDid({
+      uri        : did.uri,
+      document   : { id: did.uri },
+      metadata   : { },
+      keyManager : testHarness.agent.keyManager
+    }));
+
+    await resolverCache.get(did.uri),
+
+    // get should be called once, and we also resolve the DId as it's returned by the identity.get method
+    expect(getStub.callCount).to.equal(1, 'get');
+    expect(resolveSpy.callCount).to.equal(1, 'resolve');
+    expect(updateSpy.callCount).to.equal(1, 'update');
+    expect(consoleErrorSpy.callCount).to.equal(1, 'console.error');
   });
 
   it('does not cache notFound records', async () => {

--- a/packages/agent/tests/local-key-manager.spec.ts
+++ b/packages/agent/tests/local-key-manager.spec.ts
@@ -120,32 +120,6 @@ describe('LocalKeyManager', () => {
           expect(importedKey).to.exist;
           expect(importedKey).to.deep.equal(key);
         });
-
-        it('does not attempt to import a key that is already in the key store', async () => {
-          // scenario: a key already exists within your key store, you attempt to import it again
-          // the method should not throw an error, but should also not attempt to store the key again
-
-          const storeSetSpy = sinon.spy(testHarness.agent.keyManager['_keyStore'], 'set');
-
-          // generate a key within the key manager
-          const keyUri = await testHarness.agent.keyManager.generateKey({ algorithm: 'secp256k1' });
-          expect(storeSetSpy.callCount).to.equal(1);
-
-          // export the key
-          const exportedKey = await testHarness.agent.keyManager.exportKey({ keyUri });
-
-          // reset the spy count
-          storeSetSpy.resetHistory();
-
-          // attempt to import the same key, will not fail
-          await testHarness.agent.keyManager.importKey({ key: exportedKey });
-          expect(storeSetSpy.callCount).to.equal(0); //
-
-          // sanity import a key generated outside the key manager
-          const key = await Ed25519.generateKey();
-          await testHarness.agent.keyManager.importKey({ key });
-          expect(storeSetSpy.callCount).to.equal(1);
-        });
       });
 
       describe('exportKey()', () => {

--- a/packages/agent/tests/local-key-manager.spec.ts
+++ b/packages/agent/tests/local-key-manager.spec.ts
@@ -1,9 +1,10 @@
 import type { Jwk } from '@web5/crypto';
 import type { BearerDid } from '@web5/dids';
 
+import sinon from 'sinon';
 import { expect } from 'chai';
 import { Convert } from '@web5/common';
-import { CryptoUtils } from '@web5/crypto';
+import { CryptoUtils, Ed25519 } from '@web5/crypto';
 
 import type { Web5PlatformAgent } from '../src/types/agent.js';
 
@@ -103,6 +104,47 @@ describe('LocalKeyManager', () => {
           // Validate the results.
           expect(ciphertext).to.be.instanceOf(Uint8Array);
           expect(ciphertext.byteLength).to.equal(plaintext.byteLength + tagLength / 8);
+        });
+      });
+
+      describe('importKey()', () => {
+        it('imports a key and returns a key URI', async () => {
+          // generate a key and import it
+          const key = await Ed25519.generateKey();
+          const keyUri = await testHarness.agent.keyManager.importKey({ key });
+
+          // fetch the key using the keyUri
+          const importedKey = await testHarness.agent.keyManager.exportKey({ keyUri });
+
+          // validate the key
+          expect(importedKey).to.exist;
+          expect(importedKey).to.deep.equal(key);
+        });
+
+        it('does not attempt to import a key that is already in the key store', async () => {
+          // scenario: a key already exists within your key store, you attempt to import it again
+          // the method should not throw an error, but should also not attempt to store the key again
+
+          const storeSetSpy = sinon.spy(testHarness.agent.keyManager['_keyStore'], 'set');
+
+          // generate a key within the key manager
+          const keyUri = await testHarness.agent.keyManager.generateKey({ algorithm: 'secp256k1' });
+          expect(storeSetSpy.callCount).to.equal(1);
+
+          // export the key
+          const exportedKey = await testHarness.agent.keyManager.exportKey({ keyUri });
+
+          // reset the spy count
+          storeSetSpy.resetHistory();
+
+          // attempt to import the same key, will not fail
+          await testHarness.agent.keyManager.importKey({ key: exportedKey });
+          expect(storeSetSpy.callCount).to.equal(0); //
+
+          // sanity import a key generated outside the key manager
+          const key = await Ed25519.generateKey();
+          await testHarness.agent.keyManager.importKey({ key });
+          expect(storeSetSpy.callCount).to.equal(1);
         });
       });
 

--- a/packages/agent/tests/store-data.spec.ts
+++ b/packages/agent/tests/store-data.spec.ts
@@ -702,6 +702,58 @@ describe('AgentDataStore', () => {
             expect(error.message).to.include('Failed to install protocol: 500 - Internal Server Error');
           }
         });
+
+        describe('updateExisting', () => {
+          it('updates an existing record', async () => {
+            // Create and import a DID.
+            let bearerDid = await DidJwk.create();
+            const importedDid = await testHarness.agent.did.import({
+              portableDid : await bearerDid.export(),
+              tenant      : testHarness.agent.agentDid.uri
+            });
+
+            const portableDid = await importedDid.export();
+
+            // update did document's service
+            const updatedDid = {
+              ...portableDid,
+              document: {
+                ...portableDid.document,
+                service: [{ id: 'test-service', type: 'test-type', serviceEndpoint: 'test-endpoint' }]
+              }
+            };
+
+            // Update the DID in the store.
+            await testStore.set({
+              id             : importedDid.uri,
+              data           : updatedDid,
+              agent          : testHarness.agent,
+              updateExisting : true,
+              tenant         : testHarness.agent.agentDid.uri
+            });
+
+            // Verify the DID is in the store.
+            const storedDid = await testStore.get({ id: importedDid.uri, agent: testHarness.agent, tenant: testHarness.agent.agentDid.uri });
+            expect(storedDid!.uri).to.equal(updatedDid.uri);
+            expect(storedDid!.document).to.deep.equal(updatedDid.document);
+          });
+
+          it('throws an error if the record does not exist', async () => {
+            const did = await DidJwk.create();
+            const portableDid = await did.export();
+            try {
+              await testStore.set({
+                id             : portableDid.uri,
+                data           : portableDid,
+                agent          : testHarness.agent,
+                updateExisting : true
+              });
+              expect.fail('Expected an error to be thrown');
+            } catch (error: any) {
+              expect(error.message).to.include(`${TestStore.name}: Update failed due to missing entry for: ${portableDid.uri}`);
+            }
+          });
+        });
       });
     });
   });

--- a/packages/dids/src/bearer-did.ts
+++ b/packages/dids/src/bearer-did.ts
@@ -240,6 +240,7 @@ export class BearerDid {
     keyManager?: CryptoApi & KeyImporterExporter<KmsImportKeyParams, KeyIdentifier, KmsExportKeyParams>;
     portableDid: PortableDid;
   }): Promise<BearerDid> {
+
     // Get all verification methods from the given DID document, including embedded methods.
     const verificationMethods = getVerificationMethods({ didDocument: portableDid.document });
 
@@ -250,7 +251,13 @@ export class BearerDid {
 
     // If given, import the private key material into the key manager.
     for (let key of portableDid.privateKeys ?? []) {
-      await keyManager.importKey({ key });
+
+      // confirm th key does not already exist before importing it to avoid failures from the key manager
+      const keyUri = await keyManager.getKeyUri({ key });
+      const keyExists = await keyManager.getPublicKey({ keyUri }).then(() => true).catch(() => false);
+      if (!keyExists) {
+        await keyManager.importKey({ key });
+      }
     }
 
     // Validate that the key material for every verification method in the DID document is present

--- a/packages/dids/tests/bearer-did.spec.ts
+++ b/packages/dids/tests/bearer-did.spec.ts
@@ -447,5 +447,23 @@ describe('BearerDid', () => {
         expect(error.message).to.include('Key not found');
       }
     });
+
+    it('does not attempt to import a key that is already in the key manager', async () => {
+
+      // create a key manager
+      const keyManager = new LocalKeyManager();
+
+      // Import one of the private keys into the key manager
+      const privateKey = portableDid.privateKeys![0];
+      await keyManager.importKey({ key: privateKey });
+
+      // spy on the importKey method
+      const importKeySpy = sinon.spy(keyManager, 'importKey');
+
+      // attempt to import the BearerDid with the key manager
+      const did = await BearerDid.import({ portableDid, keyManager });
+      expect(did.uri).to.equal(portableDid.uri);
+      expect(importKeySpy.calledOnce).to.be.false;
+    });
   });
 });


### PR DESCRIPTION
This PR adds `update` functionality to `DidApi` which will store an updated did document and (optionally) publish the updated document if the did is a `did:dht` method, the resolution cache is pre-populated with the updated document.

Additionally the `AgentDidResolverCache` now updates the DID Store with any newly resolved DID to make sure the locate store is in sync wit the resolved DID.

The `BearerDid` import method now checks if a key already exists in the key manager before attempting to import it when importing an `portableDid`.