### PR TITLE
Add ability to update the Identity Metadata name field.

### DIFF
--- a/.changeset/shy-grapes-juggle.md
+++ b/.changeset/shy-grapes-juggle.md
@@ -1,0 +1,8 @@
+---
+"@web5/agent": patch
+"@web5/identity-agent": patch
+"@web5/proxy-agent": patch
+"@web5/user-agent": patch
+---
+
+Add ability to update the Identity Metadata name field.

--- a/packages/agent/src/identity-api.ts
+++ b/packages/agent/src/identity-api.ts
@@ -270,6 +270,40 @@ export class AgentIdentityApi<TKeyManager extends AgentKeyManager = AgentKeyMana
     await this.agent.did.update({ portableDid, tenant: this.agent.agentDid.uri });
   }
 
+  public async getMetadataName({ didUri }: { didUri: string }): Promise<string> {
+    const identity = await this.get({ didUri });
+    if (!identity) {
+      throw new Error(`AgentIdentityApi: Failed to retrieve metadata name due to Identity not found: ${didUri}`);
+    }
+
+    return identity.metadata.name;
+  }
+
+  public async setMetadataName({ didUri, name }: { didUri: string; name: string }): Promise<void> {
+    if (!name) {
+      throw new Error('AgentIdentityApi: Failed to set metadata name due to missing name value.');
+    }
+
+    const identity = await this.get({ didUri });
+    if (!identity) {
+      throw new Error(`AgentIdentityApi: Failed to set metadata name due to Identity not found: ${didUri}`);
+    }
+
+    if (identity.metadata.name === name) {
+      throw new Error('AgentIdentityApi: Metadata name is already set to the provided value.');
+    }
+
+    // Update the name in the Identity's metadata and store it
+    await this._store.set({
+      id             : identity.did.uri,
+      data           : { ...identity.metadata, name },
+      agent          : this.agent,
+      tenant         : identity.metadata.tenant,
+      updateExisting : true,
+      useCache       : true
+    });
+  }
+
   /**
    * Returns the connected Identity, if one is available.
    *

--- a/packages/agent/src/identity-api.ts
+++ b/packages/agent/src/identity-api.ts
@@ -270,15 +270,6 @@ export class AgentIdentityApi<TKeyManager extends AgentKeyManager = AgentKeyMana
     await this.agent.did.update({ portableDid, tenant: this.agent.agentDid.uri });
   }
 
-  public async getMetadataName({ didUri }: { didUri: string }): Promise<string> {
-    const identity = await this.get({ didUri });
-    if (!identity) {
-      throw new Error(`AgentIdentityApi: Failed to retrieve metadata name due to Identity not found: ${didUri}`);
-    }
-
-    return identity.metadata.name;
-  }
-
   public async setMetadataName({ didUri, name }: { didUri: string; name: string }): Promise<void> {
     if (!name) {
       throw new Error('AgentIdentityApi: Failed to set metadata name due to missing name value.');
@@ -290,7 +281,7 @@ export class AgentIdentityApi<TKeyManager extends AgentKeyManager = AgentKeyMana
     }
 
     if (identity.metadata.name === name) {
-      throw new Error('AgentIdentityApi: Metadata name is already set to the provided value.');
+      throw new Error('AgentIdentityApi: No changes detected.');
     }
 
     // Update the name in the Identity's metadata and store it

--- a/packages/agent/src/identity-api.ts
+++ b/packages/agent/src/identity-api.ts
@@ -270,6 +270,14 @@ export class AgentIdentityApi<TKeyManager extends AgentKeyManager = AgentKeyMana
     await this.agent.did.update({ portableDid, tenant: this.agent.agentDid.uri });
   }
 
+  /**
+   * Updates the Identity's metadata name field.
+   *
+   * @param didUri - The DID URI of the Identity to update.
+   * @param name - The new name to set for the Identity.
+   *
+   * @throws An error if the Identity is not found, name is not provided, or no changes are detected.
+   */
   public async setMetadataName({ didUri, name }: { didUri: string; name: string }): Promise<void> {
     if (!name) {
       throw new Error('AgentIdentityApi: Failed to set metadata name due to missing name value.');


### PR DESCRIPTION
This PR exposes the ability to update the `name` field within the Identity's Metadata.

The reasoning behind exposing the specific field vs allowing the entire object to be updated is to prevent some pretty bad foot-guns.

For more context:
```typescript
export interface IdentityMetadata {
  name: string;
  tenant: string;
  uri: string;
  connectedDid?: string;
}
```

The `uri` field should always be the DID's URI, so this should remain unchanged.
The `tenant` field is set to the Agent's DID, changing this would be a foot-gun and might render the identity un-readable.
The `connectedDid` field is used to denote whether a DID is a delegated/connected DID and which DID it is acting on behalf of (the connectedDID).

Since none of these other values should be changed, we expose a method to update a single field.