### PR TITLE
Currently sync interval stops if there is a failure, instead log failure and wait for the interval

### DIFF
--- a/.changeset/lucky-dots-clap.md
+++ b/.changeset/lucky-dots-clap.md
@@ -1,0 +1,8 @@
+---
+"@web5/agent": patch
+"@web5/identity-agent": patch
+"@web5/proxy-agent": patch
+"@web5/user-agent": patch
+---
+
+Prevent SyncEngine from stopping completely during a sync failure, next interval will try again.


### PR DESCRIPTION
This PR fixes the issue where a sync interval would stop completely if any error occurred during sync.

This will now catch the error and log it, continuing to attempt sync the next interval.
Additionally, enqueueing operations for each DID/Remote will not wait for each one to complete sequentially and instead take advantage of `Promise.allSettled`. Which also will not fail if a single peer of the array fails and instead log the error.  