### PR TITLE
`web5/api` changeset

### DIFF
--- a/.changeset/nine-moose-rhyme.md
+++ b/.changeset/nine-moose-rhyme.md
@@ -1,0 +1,5 @@
+---
+"@web5/api": minor
+---
+
+Identity information exclusively stored using Agent's DID as a tenant


### PR DESCRIPTION
Adding a `minor` changeset for `@web5/api` as the agent version causes backward compatibility issues.