### PR TITLE
add prerequisites for expansion of connect flow

### DIFF
--- a/.changeset/chilled-paws-stare.md
+++ b/.changeset/chilled-paws-stare.md
@@ -1,0 +1,29 @@
+---
+"@web5/agent": patch
+---
+
+security enhancements: use separate DIDs for signing, encryption, verification of web5 connect
+feature enhancements: prepare code for the option of exporting the DWA's DID to a wallet
+
+breaking changes for wallet authors.
+
+web5 connect's `getAuthRequest()` now returns an object which include both the authRequest and a DID:
+
+```ts
+{
+  authRequest: Web5ConnectAuthRequest;
+  clientEcdhDid: DidResolutionResult;
+}
+```
+
+web5 connect's `submitAuthResponse()` now requires that the did received from `getAuthRequest()` is passed in to the method at position 4:
+
+```ts
+async function submitAuthResponse(
+  selectedDid: string,
+  authRequest: Web5ConnectAuthRequest,
+  randomPin: string,
+  clientEcdhDid: DidResolutionResult,
+  agent: Web5Agent
+) { ... }
+```

--- a/.changeset/weak-shirts-draw.md
+++ b/.changeset/weak-shirts-draw.md
@@ -1,0 +1,5 @@
+---
+"@web5/api": patch
+---
+
+added enhancements and optionality in preparation for export connect

--- a/packages/agent/src/connect.ts
+++ b/packages/agent/src/connect.ts
@@ -138,7 +138,6 @@ async function initClient({
     baseURL  : connectServerUrl,
     endpoint : 'callback',
   });
-  console.log('after callback endpoint');
 
   // build the PAR request
   const request = await Oidc.createAuthRequest({
@@ -168,7 +167,6 @@ async function initClient({
     kid : clientEcdhDid.document.verificationMethod![0].id,
     encryptionKey,
   });
-  console.log('after requestobjecjtwe');
 
   // Convert the encrypted Request Object to URLSearchParams for form encoding.
   const formEncodedRequest = new URLSearchParams({
@@ -187,7 +185,6 @@ async function initClient({
       'Content-Type': 'application/x-www-form-urlencoded',
     },
   });
-  console.log('after par');
 
   if (!parResponse.ok) {
     throw new Error(`${parResponse.status}: ${parResponse.statusText}`);
@@ -204,7 +201,6 @@ async function initClient({
     'encryption_key',
     Convert.uint8Array(encryptionKey).toBase64Url()
   );
-  console.log('after generatedwalleturi');
 
   // call user's callback so they can send the URI to the wallet as they see fit
   onWalletUriReady(generatedWalletUri.toString());

--- a/packages/agent/src/connect.ts
+++ b/packages/agent/src/connect.ts
@@ -1,10 +1,11 @@
-
 import type { PushedAuthResponse } from './oidc.js';
-import type { DwnPermissionScope, DwnProtocolDefinition, Web5Agent, Web5ConnectAuthResponse } from './index.js';
+import type {
+  DwnPermissionScope,
+  DwnProtocolDefinition,
+  Web5ConnectAuthResponse,
+} from './index.js';
 
-import {
-  Oidc,
-} from './oidc.js';
+import { Oidc } from './oidc.js';
 import { pollWithTtl } from './utils.js';
 
 import { Convert, logger } from '@web5/common';
@@ -13,134 +14,15 @@ import { DidJwk } from '@web5/dids';
 import { DwnInterfaceName, DwnMethodName } from '@tbd54566975/dwn-sdk-js';
 
 /**
- * Initiates the wallet connect process. Used when a client wants to obtain
- * a did from a provider.
- */
-async function initClient({
-  displayName,
-  connectServerUrl,
-  walletUri,
-  permissionRequests,
-  onWalletUriReady,
-  validatePin,
-}: WalletConnectOptions) {
-  // ephemeral client did for ECDH, signing, verification
-  // TODO: use separate keys for ECDH vs. sign/verify. could maybe use secp256k1.
-  const clientDid = await DidJwk.create();
-
-  // TODO: properly implement PKCE. this implementation is lacking server side validations and more.
-  // https://github.com/TBD54566975/web5-js/issues/829
-  // Derive the code challenge based on the code verifier
-  // const { codeChallengeBytes, codeChallengeBase64Url } =
-  //   await Oidc.generateCodeChallenge();
-  const encryptionKey = CryptoUtils.randomBytes(32);
-
-  // build callback URL to pass into the auth request
-  const callbackEndpoint = Oidc.buildOidcUrl({
-    baseURL  : connectServerUrl,
-    endpoint : 'callback',
-  });
-
-  // build the PAR request
-  const request = await Oidc.createAuthRequest({
-    client_id          : clientDid.uri,
-    scope              : 'openid did:jwk',
-    redirect_uri       : callbackEndpoint,
-    // custom properties:
-    // code_challenge        : codeChallengeBase64Url,
-    // code_challenge_method : 'S256',
-    permissionRequests : permissionRequests,
-    displayName,
-  });
-
-  // Sign the Request Object using the Client DID's signing key.
-  const requestJwt = await Oidc.signJwt({
-    did  : clientDid,
-    data : request,
-  });
-
-  if (!requestJwt) {
-    throw new Error('Unable to sign requestObject');
-  }
-  // Encrypt the Request Object JWT using the code challenge.
-  const requestObjectJwe = await Oidc.encryptAuthRequest({
-    jwt: requestJwt,
-    encryptionKey,
-  });
-
-  // Convert the encrypted Request Object to URLSearchParams for form encoding.
-  const formEncodedRequest = new URLSearchParams({
-    request: requestObjectJwe,
-  });
-
-  const pushedAuthorizationRequestEndpoint = Oidc.buildOidcUrl({
-    baseURL  : connectServerUrl,
-    endpoint : 'pushedAuthorizationRequest',
-  });
-
-  const parResponse = await fetch(pushedAuthorizationRequestEndpoint, {
-    body    : formEncodedRequest,
-    method  : 'POST',
-    headers : {
-      'Content-Type': 'application/x-www-form-urlencoded',
-    },
-  });
-
-  if (!parResponse.ok) {
-    throw new Error(`${parResponse.status}: ${parResponse.statusText}`);
-  }
-
-  const parData: PushedAuthResponse = await parResponse.json();
-
-  // a deeplink to a web5 compatible wallet. if the wallet scans this link it should receive
-  // a route to its web5 connect provider flow and the params of where to fetch the auth request.
-  logger.log(`Wallet URI: ${walletUri}`);
-  const generatedWalletUri = new URL(walletUri);
-  generatedWalletUri.searchParams.set('request_uri', parData.request_uri);
-  generatedWalletUri.searchParams.set(
-    'encryption_key',
-    Convert.uint8Array(encryptionKey).toBase64Url()
-  );
-
-  // call user's callback so they can send the URI to the wallet as they see fit
-  onWalletUriReady(generatedWalletUri.toString());
-
-  const tokenUrl = Oidc.buildOidcUrl({
-    baseURL    : connectServerUrl,
-    endpoint   : 'token',
-    tokenParam : request.state,
-  });
-
-  // subscribe to receiving a response from the wallet with default TTL. receive ciphertext of {@link Web5ConnectAuthResponse}
-  const authResponse = await pollWithTtl(() => fetch(tokenUrl));
-
-  if (authResponse) {
-    const jwe = await authResponse?.text();
-
-    // get the pin from the user and use it as AAD to decrypt
-    const pin = await validatePin();
-    const jwt = await Oidc.decryptAuthResponse(clientDid, jwe, pin);
-    const verifiedAuthResponse = (await Oidc.verifyJwt({
-      jwt,
-    })) as Web5ConnectAuthResponse;
-
-    return {
-      delegateGrants      : verifiedAuthResponse.delegateGrants,
-      delegatePortableDid : verifiedAuthResponse.delegatePortableDid,
-      connectedDid        : verifiedAuthResponse.iss,
-    };
-  }
-}
-
-/**
- * Initiates the wallet connect process. Used when a client wants to obtain
- * a did from a provider.
+ * Settings provided by users who wish to allow their DWA to connect to a wallet
+ * and either transfer their DID to that wallet (when `exported: true`)
+ * or transfer a DID from their wallet (without `exported: true`).
  */
 export type WalletConnectOptions = {
-  /** The user friendly name of the client/app to be displayed when prompting end-user with permission requests. */
+  /** The user friendly name of the app to be displayed when prompting end-user with permission requests. */
   displayName: string;
 
-  /** The URL of the intermediary server which relays messages between the client and provider. */
+  /** The URL of the intermediary server which relays messages between the client and provider */
   connectServerUrl: string;
 
   /**
@@ -152,10 +34,16 @@ export type WalletConnectOptions = {
 
   /**
    * The protocols of permissions requested, along with the definition and
-   * permission scopes for each protocol. The key is the protocol URL and
-   * the value is an object with the protocol definition and the permission scopes.
+   * permission scopes for each protocol.
+   * If `exported` is true these will be created automatically.
    */
-  permissionRequests: ConnectPermissionRequest[];
+  permissionRequests: ConnectUserPermissionRequest[];
+
+  /**
+   * Can be set to true if the DWA wants to transfer its identity to the wallet
+   * instead of get an identity from the wallet
+   */
+  exported?: boolean;
 
   /**
    * The Web5 API provides a URI to the wallet based on the `walletUri` plus a query params payload valid for 5 minutes.
@@ -178,9 +66,7 @@ export type WalletConnectOptions = {
   validatePin: () => Promise<string>;
 };
 
-/**
- * The protocols of permissions requested, along with the definition and permission scopes for each protocol.
- */
+/** Used by the WalletConnect protocol to provision a Wallet for the exact permissions its needs */
 export type ConnectPermissionRequest = {
   /**
    * The definition of the protocol the permissions are being requested for.
@@ -192,29 +78,187 @@ export type ConnectPermissionRequest = {
   permissionScopes: DwnPermissionScope[];
 };
 
-/**
- * Shorthand for the types of permissions that can be requested.
- */
-export type Permission = 'write' | 'read' | 'delete' | 'query' | 'subscribe' | 'configure';
+/** Convenience object passed in by users and normalized to the internally used {@link ConnectPermissionRequest}  */
+export type ConnectUserPermissionRequest = Omit<
+  ConnectPermissionRequest,
+  'permissionScopes'
+> & {
+  /**
+   * Used to create a {@link DwnPermissionScope} for each option provided in this param.
+   * If undefined defaults to requesting all permissions.
+   * `configure` is not included by default, as this gives the application a lot of control over the protocol.
+   */
+  permissions?: Permission[];
+};
+
+/** Shorthand for the types of permissions that can be requested. */
+type Permission =
+  | 'write'
+  | 'read'
+  | 'delete'
+  | 'query'
+  | 'subscribe'
+  | 'configure';
 
 /**
- * The options for creating a permission request for a given protocol.
+ * Called by the DWA. In this workflow the wallet provisions a DID to the DWA.
+ * The DWA will have access to the data of the DID and be able to act as that DID.
  */
-export type ProtocolPermissionOptions = {
+async function initClient({
+  displayName,
+  connectServerUrl,
+  walletUri,
+  permissionRequests,
+  onWalletUriReady,
+  validatePin,
+}: WalletConnectOptions) {
+  const normalizedPermissionRequests = permissionRequests.map(
+    ({ protocolDefinition, permissions }) =>
+      WalletConnect.createPermissionRequestForProtocol({
+        definition  : protocolDefinition,
+        permissions : permissions ?? [
+          'read',
+          'write',
+          'delete',
+          'query',
+          'subscribe',
+        ],
+      })
+  );
+
+  // ephemeral did used for signing, verification
+  const clientSigningDid = await DidJwk.create();
+
+  // ephemeral did used for ECDH only
+  const clientEcdhDid = await DidJwk.create();
+
+  // TODO: properly implement PKCE. this implementation is lacking server side validations and more.
+  // https://github.com/TBD54566975/web5-js/issues/829
+  // Derive the code challenge based on the code verifier
+  // const { codeChallengeBytes, codeChallengeBase64Url } =
+  //   await Oidc.generateCodeChallenge();
+  const encryptionKey = CryptoUtils.randomBytes(32);
+
+  // build callback URL to pass into the auth request
+  const callbackEndpoint = Oidc.buildOidcUrl({
+    baseURL  : connectServerUrl,
+    endpoint : 'callback',
+  });
+  console.log('after callback endpoint');
+
+  // build the PAR request
+  const request = await Oidc.createAuthRequest({
+    client_id          : clientSigningDid.uri,
+    scope              : 'openid did:jwk',
+    redirect_uri       : callbackEndpoint,
+    client_name        : displayName,
+    // code_challenge        : codeChallengeBase64Url,
+    // code_challenge_method : 'S256',
+    // custom properties:
+    permissionRequests : normalizedPermissionRequests,
+  });
+
+  // Sign the Request Object using the Client DID's signing key.
+  const requestJwt = await Oidc.signJwt({
+    did  : clientSigningDid,
+    data : request,
+  });
+
+  if (!requestJwt) {
+    throw new Error('Unable to sign requestObject');
+  }
+
+  // Encrypt with symmetric randomBytes and tell counterparty about the future ecdh pub did kid
+  const requestObjectJwe = await Oidc.encryptAuthRequest({
+    jwt : requestJwt,
+    kid : clientEcdhDid.document.verificationMethod![0].id,
+    encryptionKey,
+  });
+  console.log('after requestobjecjtwe');
+
+  // Convert the encrypted Request Object to URLSearchParams for form encoding.
+  const formEncodedRequest = new URLSearchParams({
+    request: requestObjectJwe,
+  });
+
+  const pushedAuthorizationRequestEndpoint = Oidc.buildOidcUrl({
+    baseURL  : connectServerUrl,
+    endpoint : 'pushedAuthorizationRequest',
+  });
+
+  const parResponse = await fetch(pushedAuthorizationRequestEndpoint, {
+    body    : formEncodedRequest,
+    method  : 'POST',
+    headers : {
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+  });
+  console.log('after par');
+
+  if (!parResponse.ok) {
+    throw new Error(`${parResponse.status}: ${parResponse.statusText}`);
+  }
+
+  const parData: PushedAuthResponse = await parResponse.json();
+
+  // a deeplink to a web5 compatible wallet. if the wallet scans this link it should receive
+  // a route to its web5 connect provider flow and the params of where to fetch the auth request.
+  logger.log(`Wallet URI: ${walletUri}`);
+  const generatedWalletUri = new URL(walletUri);
+  generatedWalletUri.searchParams.set('request_uri', parData.request_uri);
+  generatedWalletUri.searchParams.set(
+    'encryption_key',
+    Convert.uint8Array(encryptionKey).toBase64Url()
+  );
+  console.log('after generatedwalleturi');
+
+  // call user's callback so they can send the URI to the wallet as they see fit
+  onWalletUriReady(generatedWalletUri.toString());
+
+  const tokenUrl = Oidc.buildOidcUrl({
+    baseURL    : connectServerUrl,
+    endpoint   : 'token',
+    tokenParam : request.state,
+  });
+
+  // subscribe to receiving a response from the wallet with default TTL. receive ciphertext of {@link Web5ConnectAuthResponse}
+  const authResponse = await pollWithTtl(() => fetch(tokenUrl));
+
+  if (authResponse) {
+    const jwe = await authResponse?.text();
+
+    // get the pin from the user and use it as AAD to decrypt
+    const pin = await validatePin();
+    const jwt = await Oidc.decryptWithPin(clientEcdhDid, jwe, pin);
+    const verifiedAuthResponse = (await Oidc.verifyJwt({
+      jwt,
+    })) as Web5ConnectAuthResponse;
+
+    // TODO: export insertion point
+
+    return {
+      delegateGrants      : verifiedAuthResponse.delegateGrants,
+      delegatePortableDid : verifiedAuthResponse.delegatePortableDid,
+      connectedDid        : verifiedAuthResponse.iss,
+    };
+  }
+}
+
+/**
+ * An internal utility that simplifies the API for permission requests by allowing
+ * users to pass simple strings (any of {@link Permission}) and will create the
+ * appropriate {@link DwnPermissionScope} for each string provided.
+ */
+function createPermissionRequestForProtocol({
+  definition,
+  permissions,
+}: {
   /** The protocol definition for the protocol being requested */
   definition: DwnProtocolDefinition;
 
   /** The permissions being requested for the protocol */
   permissions: Permission[];
-};
-
-/**
- * Creates a set of Dwn Permission Scopes to request for a given protocol.
- *
- * If no permissions are provided, the default is to request all relevant record permissions (write, read, delete, query, subscribe).
- * 'configure' is not included by default, as this gives the application a lot of control over the protocol.
- */
-function createPermissionRequestForProtocol({ definition, permissions }: ProtocolPermissionOptions): ConnectPermissionRequest {
+}) {
   const requests: DwnPermissionScope[] = [];
 
   // Add the ability to query for the specific protocol
@@ -225,19 +269,23 @@ function createPermissionRequestForProtocol({ definition, permissions }: Protoco
   });
 
   // In order to enable sync, we must request permissions for `MessagesQuery`, `MessagesRead` and `MessagesSubscribe`
-  requests.push({
-    protocol  : definition.protocol,
-    interface : DwnInterfaceName.Messages,
-    method    : DwnMethodName.Read,
-  }, {
-    protocol  : definition.protocol,
-    interface : DwnInterfaceName.Messages,
-    method    : DwnMethodName.Query,
-  }, {
-    protocol  : definition.protocol,
-    interface : DwnInterfaceName.Messages,
-    method    : DwnMethodName.Subscribe,
-  });
+  requests.push(
+    {
+      protocol  : definition.protocol,
+      interface : DwnInterfaceName.Messages,
+      method    : DwnMethodName.Read,
+    },
+    {
+      protocol  : definition.protocol,
+      interface : DwnInterfaceName.Messages,
+      method    : DwnMethodName.Query,
+    },
+    {
+      protocol  : definition.protocol,
+      interface : DwnInterfaceName.Messages,
+      method    : DwnMethodName.Subscribe,
+    }
+  );
 
   // We also request any additional permissions the user has requested for this protocol
   for (const permission of permissions) {
@@ -293,4 +341,7 @@ function createPermissionRequestForProtocol({ definition, permissions }: Protoco
   };
 }
 
-export const WalletConnect = { initClient, createPermissionRequestForProtocol };
+export const WalletConnect = {
+  initClient,
+  createPermissionRequestForProtocol,
+};

--- a/packages/agent/src/connect.ts
+++ b/packages/agent/src/connect.ts
@@ -249,13 +249,7 @@ function createPermissionRequestForProtocol({
   /** The permissions being requested for the protocol. Defaults to all. */
   permissions?: Permission[];
 }) {
-  permissions ??= [
-    'read',
-    'write',
-    'delete',
-    'query',
-    'subscribe',
-  ];
+  permissions ??= ['read', 'write', 'delete', 'query', 'subscribe'];
 
   const requests: DwnPermissionScope[] = [];
 

--- a/packages/agent/src/connect.ts
+++ b/packages/agent/src/connect.ts
@@ -115,14 +115,8 @@ async function initClient({
   const normalizedPermissionRequests = permissionRequests.map(
     ({ protocolDefinition, permissions }) =>
       WalletConnect.createPermissionRequestForProtocol({
-        definition  : protocolDefinition,
-        permissions : permissions ?? [
-          'read',
-          'write',
-          'delete',
-          'query',
-          'subscribe',
-        ],
+        definition: protocolDefinition,
+        permissions,
       })
   );
 
@@ -256,9 +250,17 @@ function createPermissionRequestForProtocol({
   /** The protocol definition for the protocol being requested */
   definition: DwnProtocolDefinition;
 
-  /** The permissions being requested for the protocol */
-  permissions: Permission[];
+  /** The permissions being requested for the protocol. Defaults to all. */
+  permissions?: Permission[];
 }) {
+  permissions ??= [
+    'read',
+    'write',
+    'delete',
+    'query',
+    'subscribe',
+  ];
+
   const requests: DwnPermissionScope[] = [];
 
   // Add the ability to query for the specific protocol

--- a/packages/agent/src/oidc.ts
+++ b/packages/agent/src/oidc.ts
@@ -7,12 +7,18 @@ import {
   Sha256,
   X25519,
   CryptoUtils,
+  JweHeaderParams,
 } from '@web5/crypto';
 import { concatenateUrl } from './utils.js';
 import { xchacha20poly1305 } from '@noble/ciphers/chacha';
 import type { ConnectPermissionRequest } from './connect.js';
-import { DidDocument, DidJwk, PortableDid, type BearerDid } from '@web5/dids';
-import { DwnDataEncodedRecordsWriteMessage, DwnInterface, DwnPermissionScope, DwnProtocolDefinition } from './types/dwn.js';
+import { DidDocument, DidJwk, DidResolutionResult, PortableDid, type BearerDid } from '@web5/dids';
+import {
+  DwnDataEncodedRecordsWriteMessage,
+  DwnInterface,
+  DwnPermissionScope,
+  DwnProtocolDefinition,
+} from './types/dwn.js';
 import { AgentPermissionsApi } from './permissions-api.js';
 import type { Web5Agent } from './types/agent.js';
 import { isRecordPermissionScope } from './dwn-api.js';
@@ -51,6 +57,9 @@ export type PushedAuthResponse = {
 export type SIOPv2AuthRequest = {
   /** The DID of the client (RP) */
   client_id: string;
+
+  /** The user friendly name of the client (RP) */
+  client_name?: string;
 
   /** The scope of the access request (e.g., `openid profile`). */
   scope: string;
@@ -128,11 +137,10 @@ export type SIOPv2AuthRequest = {
  * The contents of this are inserted into a JWT inside of the {@link PushedAuthRequest}.
  */
 export type Web5ConnectAuthRequest = {
-  /** The user friendly name of the client/app to be displayed when prompting end-user with permission requests. */
-  displayName: string;
-
   /** PermissionGrants that are to be sent to the provider */
-  permissionRequests: ConnectPermissionRequest[];
+  permissionRequests?: ConnectPermissionRequest[];
+  /** Instead of receiving a DID from the wallet the DWA will export its DID to the wallet  */
+  exported?: boolean;
 } & SIOPv2AuthRequest;
 
 /** The fields for an OIDC SIOPv2 Auth Repsonse */
@@ -171,12 +179,20 @@ export type Web5ConnectAuthResponse = {
  * 2. `authorize`: provider gets the {@link Web5ConnectAuthRequest} JWT that was stored by the PAR
  * 3. `callback`: provider sends {@link Web5ConnectAuthResponse} to this endpoint
  * 4. `token`: client gets {@link Web5ConnectAuthResponse} from this endpoint
+ * 5. `export`: (if `exported` is true) client will POST a {@link PortableDid}
+ * 6. `retrieve`: (if `exported` is true) wallet will GET the {@link PortableDid}
+ * 7. `export-token`: (if `exported` is true) wallet will POST the grants in order to finalize the flow.
+ * 8. `retrieve-token`: (if `exported` is true) client will GET the grants in order to finalize the flow.
  */
 type OidcEndpoint =
   | 'pushedAuthorizationRequest'
   | 'authorize'
   | 'callback'
-  | 'token';
+  | 'token'
+  | 'export'
+  | 'retrieve'
+  | 'export-token'
+  | 'retrieve-token';
 
 /**
  * Gets the correct OIDC endpoint out of the {@link OidcEndpoint} options provided.
@@ -213,13 +229,16 @@ function buildOidcUrl({
     /** 3. provider sends {@link Web5ConnectAuthResponse} */
     case 'callback':
       return concatenateUrl(baseURL, `callback`);
-    /**  4. client gets {@link Web5ConnectAuthResponse */
+    /**  4. client gets {@link Web5ConnectAuthResponse} */
     case 'token':
       if (!tokenParam)
         throw new Error(
           `tokenParam must be providied when building a token URL`
         );
       return concatenateUrl(baseURL, `token/${tokenParam}.jwt`);
+    /** 5. (if `exported` is true) client will POST a {@link PortableDid} for import to the wallet. */
+    case 'export':
+      return concatenateUrl(baseURL, `export`);
     // TODO: metadata endpoints?
     default:
       throw new Error(`No matches for endpoint specified: ${endpoint}`);
@@ -245,7 +264,7 @@ async function generateCodeChallenge() {
 async function createAuthRequest(
   options: RequireOnly<
     Web5ConnectAuthRequest,
-    'client_id' | 'scope' | 'redirect_uri' | 'permissionRequests' | 'displayName'
+    'client_id' | 'scope' | 'redirect_uri'
   >
 ) {
   // Generate a random state value to associate the authorization request with the response.
@@ -272,15 +291,18 @@ async function createAuthRequest(
 async function encryptAuthRequest({
   jwt,
   encryptionKey,
+  kid
 }: {
   jwt: string;
   encryptionKey: Uint8Array;
+  kid: string;
 }) {
-  const protectedHeader = {
+  const protectedHeader: JweHeaderParams = {
     alg : 'dir',
     cty : 'JWT',
     enc : 'XC20P',
     typ : 'JWT',
+    kid
   };
   const nonce = CryptoUtils.randomBytes(24);
   const additionalData = Convert.object(protectedHeader).toUint8Array();
@@ -400,6 +422,7 @@ async function verifyJwt({ jwt }: { jwt: string }) {
 }
 
 /**
+ * Called by the wallet first to get the authRequest.
  * Fetches the {@Web5ConnectAuthRequest} from the authorize endpoint and decrypts it
  * using the encryption key passed via QR code.
  */
@@ -414,7 +437,12 @@ const getAuthRequest = async (request_uri: string, encryption_key: string) => {
     jwt,
   })) as Web5ConnectAuthRequest;
 
-  return web5ConnectAuthRequest;
+  // get the pub DID that represents the client in ECDH and deriving a shared key
+  const header = Convert.base64Url(jwe.split('.')[0]).toObject() as JweHeaderParams;
+
+  const clientEcdhDid = await DidJwk.resolve(header.kid!.split('#')[0]);
+
+  return { authRequest: web5ConnectAuthRequest, clientEcdhDid };
 };
 
 /** Take the encrypted JWE, decrypt using the code challenge and return a JWT string which will need to be verified */
@@ -436,6 +464,7 @@ function decryptAuthRequest({
   const encryptionKeyBytes = Convert.base64Url(encryption_key).toUint8Array();
   const protectedHeader = Convert.base64Url(protectedHeaderB64U).toUint8Array();
   const additionalData = protectedHeader;
+  const additionalDataObj = Convert.base64Url(protectedHeaderB64U).toObject();
   const nonce = Convert.base64Url(nonceB64U).toUint8Array();
   const ciphertext = Convert.base64Url(ciphertextB64U).toUint8Array();
   const authenticationTag = Convert.base64Url(
@@ -457,17 +486,8 @@ function decryptAuthRequest({
 /**
  * The client uses to decrypt the jwe obtained from the auth server which contains
  * the {@link Web5ConnectAuthResponse} that was sent by the provider to the auth server.
- *
- * @async
- * @param {BearerDid} clientDid - The did that was initially used by the client for ECDH at connect init.
- * @param {string} jwe - The encrypted data as a jwe.
- * @param {string} pin - The pin that was obtained from the user.
  */
-async function decryptAuthResponse(
-  clientDid: BearerDid,
-  jwe: string,
-  pin: string
-) {
+async function decryptWithPin(clientDid: BearerDid, jwe: string, pin: string) {
   const [
     protectedHeaderB64U,
     ,
@@ -478,12 +498,18 @@ async function decryptAuthResponse(
 
   // get the delegatedid public key from the header
   const header = Convert.base64Url(protectedHeaderB64U).toObject() as Jwk;
-  const delegateResolvedDid = await DidJwk.resolve(header.kid!.split('#')[0]);
+
+  // get ECDH pub did kid for provider encrypted jwe
+  const jweProviderEcdhDidKid = await DidJwk.resolve(header.kid!.split('#')[0]);
+
+  if (!jweProviderEcdhDidKid.didDocument) {
+    throw new Error('Could not resolve provider\'s didd document for shared key derivation');
+  }
 
   // derive ECDH shared key using the provider's public key and our clientDid private key
   const sharedKey = await Oidc.deriveSharedKey(
     clientDid,
-    delegateResolvedDid.didDocument!
+    jweProviderEcdhDidKid.didDocument
   );
 
   // add the pin to the AAD
@@ -557,26 +583,30 @@ async function deriveSharedKey(
 /**
  * Encrypts the auth response jwt. Requires a randomPin is added to the AAD of the
  * encryption algorithm in order to prevent man in the middle and eavesdropping attacks.
- * The keyid of the delegate did is used to pass the public key to the client in order
+ * The keyid of the encrypting did is used to pass the public key to the client in order
  * for the client to derive the shared ECDH private key.
  */
-function encryptAuthResponse({
+function encryptWithPin({
   jwt,
   encryptionKey,
-  delegateDidKeyId,
+  pubDidKid,
   randomPin,
 }: {
+  /** JWT of data to encrypt */
   jwt: string;
+  /** the ECDH did priv key */
   encryptionKey: Uint8Array;
-  delegateDidKeyId: string;
+  /** the DID URI of the encrypting DID, NOT the shared key */
+  pubDidKid: string;
+  /** cryptographically secure pin */
   randomPin: string;
 }) {
-  const protectedHeader = {
+  const protectedHeader: JweHeaderParams = {
     alg : 'dir',
     cty : 'JWT',
     enc : 'XC20P',
     typ : 'JWT',
-    kid : delegateDidKeyId,
+    kid : pubDidKid,
   };
   const nonce = CryptoUtils.randomBytes(24);
   const additionalData = Convert.object({
@@ -626,12 +656,11 @@ async function createPermissionGrants(
   selectedDid: string,
   delegateBearerDid: BearerDid,
   agent: Web5Agent,
-  scopes: DwnPermissionScope[],
+  scopes: DwnPermissionScope[]
 ) {
   const permissionsApi = new AgentPermissionsApi({ agent });
 
   // TODO: cleanup all grants if one fails by deleting them from the DWN: https://github.com/TBD54566975/web5-js/issues/849
-  logger.log(`Creating permission grants for ${scopes.length} scopes given...`);
   const permissionGrants = await Promise.all(
     scopes.map((scope) => {
       // check if the scope is a records permission scope, or a protocol configure scope, if so it should use a delegated permission.
@@ -698,7 +727,7 @@ async function prepareProtocol(
     messageParams : { filter: { protocol: protocolDefinition.protocol } },
   });
 
-  if ( queryMessage.reply.status.code !== 200) {
+  if (queryMessage.reply.status.code !== 200) {
     // if the query failed, throw an error
     throw new Error(
       `Could not fetch protocol: ${queryMessage.reply.status.detail}`
@@ -724,9 +753,8 @@ async function prepareProtocol(
       author      : selectedDid,
       target      : selectedDid,
       messageType : DwnInterface.ProtocolsConfigure,
-      rawMessage  : configureMessage
+      rawMessage  : configureMessage,
     });
-
   } else {
     logger.log(`Protocol already exists: ${protocolDefinition.protocol}`);
 
@@ -758,85 +786,100 @@ async function submitAuthResponse(
   selectedDid: string,
   authRequest: Web5ConnectAuthRequest,
   randomPin: string,
+  clientEcdhDid: DidResolutionResult,
   agent: Web5Agent
 ) {
+  // ephemeral provider did for signing
+  const providerSigningDid = await DidJwk.create();
+
+  // ephemeral provider did for ECDH
+  const providerEcdhDid = await DidJwk.create();
+
+  // delegate did for persistent use
+  // not used for signing or encryption during wallet connect
   const delegateBearerDid = await DidJwk.create();
   const delegatePortableDid = await delegateBearerDid.export();
 
   // TODO: roll back permissions and protocol configurations if an error occurs. Need a way to delete protocols to achieve this.
-  const delegateGrantPromises = authRequest.permissionRequests.map(
-    async (permissionRequest) => {
-      const { protocolDefinition, permissionScopes } = permissionRequest;
+  if (authRequest.permissionRequests) {
+    const delegateGrantPromises = authRequest.permissionRequests.map(
+      async (permissionRequest) => {
+        const { protocolDefinition, permissionScopes } = permissionRequest;
 
-      // We validate that all permission scopes match the protocol uri of the protocol definition they are provided with.
-      const grantsMatchProtocolUri = permissionScopes.every(scope => 'protocol' in scope && scope.protocol === protocolDefinition.protocol);
-      if (!grantsMatchProtocolUri) {
-        throw new Error('All permission scopes must match the protocol uri they are provided with.');
+        // We validate that all permission scopes match the protocol uri of the protocol definition they are provided with.
+        const grantsMatchProtocolUri = permissionScopes.every(
+          (scope) =>
+            'protocol' in scope &&
+            scope.protocol === protocolDefinition.protocol
+        );
+        if (!grantsMatchProtocolUri) {
+          throw new Error(
+            'All permission scopes must match the protocol uri they are provided with.'
+          );
+        }
+
+        await prepareProtocol(selectedDid, agent, protocolDefinition);
+
+        const permissionGrants = await Oidc.createPermissionGrants(
+          selectedDid,
+          delegateBearerDid,
+          agent,
+          permissionScopes
+        );
+
+        return permissionGrants;
       }
+    );
 
-      await prepareProtocol(selectedDid, agent, protocolDefinition);
+    const delegateGrants = (await Promise.all(delegateGrantPromises)).flat();
+    const responseObject = await Oidc.createResponseObject({
+      //* the IDP's did that was selected to be connected
+      iss   : selectedDid,
+      //* the client's new identity
+      sub   : delegateBearerDid.uri,
+      //* the client's temporary ephemeral did used for connect
+      aud   : authRequest.client_id,
+      //* the nonce of the original auth request
+      nonce : authRequest.nonce,
+      delegateGrants,
+      delegatePortableDid,
+    });
 
-      const permissionGrants = await Oidc.createPermissionGrants(
-        selectedDid,
-        delegateBearerDid,
-        agent,
-        permissionScopes
-      );
+    // Sign using the signing key
+    const responseObjectJwt = await Oidc.signJwt({
+      did  : providerSigningDid,
+      data : responseObject,
+    });
 
-      return permissionGrants;
+    if (!clientEcdhDid.didDocument?.verificationMethod?.[0].id) {
+      throw new Error('Unable to resolve the encryption DID used by the client for ECDH');
     }
-  );
 
-  const delegateGrants = (await Promise.all(delegateGrantPromises)).flat();
+    const sharedKey = await Oidc.deriveSharedKey(
+      providerEcdhDid,
+      clientEcdhDid?.didDocument
+    );
 
-  logger.log('Generating auth response object...');
-  const responseObject = await Oidc.createResponseObject({
-    //* the IDP's did that was selected to be connected
-    iss   : selectedDid,
-    //* the client's new identity
-    sub   : delegateBearerDid.uri,
-    //* the client's temporary ephemeral did used for connect
-    aud   : authRequest.client_id,
-    //* the nonce of the original auth request
-    nonce : authRequest.nonce,
-    delegateGrants,
-    delegatePortableDid,
-  });
+    const encryptedResponse = Oidc.encryptWithPin({
+      jwt           : responseObjectJwt,
+      encryptionKey : sharedKey,
+      pubDidKid     : providerEcdhDid.document.verificationMethod![0].id,
+      randomPin,
+    });
 
-  // Sign the Response Object using the ephemeral DID's signing key.
-  logger.log('Signing auth response object...');
-  const responseObjectJwt = await Oidc.signJwt({
-    did  : delegateBearerDid,
-    data : responseObject,
-  });
-  const clientDid = await DidJwk.resolve(authRequest.client_id);
+    const formEncodedRequest = new URLSearchParams({
+      id_token : encryptedResponse,
+      state    : authRequest.state,
+    }).toString();
 
-  const sharedKey = await Oidc.deriveSharedKey(
-    delegateBearerDid,
-    clientDid?.didDocument!
-  );
-
-  logger.log('Encrypting auth response object...');
-  const encryptedResponse = Oidc.encryptAuthResponse({
-    jwt              : responseObjectJwt!,
-    encryptionKey    : sharedKey,
-    delegateDidKeyId : delegateBearerDid.document.verificationMethod![0].id,
-    randomPin,
-  });
-
-  const formEncodedRequest = new URLSearchParams({
-    id_token : encryptedResponse,
-    state    : authRequest.state,
-  }).toString();
-
-  logger.log(`Sending auth response object to Web5 Connect server: ${authRequest.redirect_uri}`);
-  await fetch(authRequest.redirect_uri, {
-    body    : formEncodedRequest,
-    method  : 'POST',
-    headers : {
-      'Content-Type': 'application/x-www-form-urlencoded',
-    },
-  });
+    await fetch(authRequest.redirect_uri, {
+      body    : formEncodedRequest,
+      method  : 'POST',
+      headers : {
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+    });
+  }
 }
 
 export const Oidc = {
@@ -846,8 +889,8 @@ export const Oidc = {
   decryptAuthRequest,
   createPermissionGrants,
   createResponseObject,
-  encryptAuthResponse,
-  decryptAuthResponse,
+  encryptWithPin,
+  decryptWithPin,
   deriveSharedKey,
   signJwt,
   verifyJwt,

--- a/packages/agent/src/oidc.ts
+++ b/packages/agent/src/oidc.ts
@@ -511,7 +511,7 @@ async function decryptWithPin(clientDid: BearerDid, jwe: string, pin: string) {
 
   if (!jweProviderEcdhDidKid.didDocument) {
     throw new Error(
-      'Could not resolve provider\'s didd document for shared key derivation'
+      'Could not resolve provider\'s DID document for shared key derivation'
     );
   }
 

--- a/packages/agent/src/oidc.ts
+++ b/packages/agent/src/oidc.ts
@@ -464,7 +464,6 @@ function decryptAuthRequest({
   const encryptionKeyBytes = Convert.base64Url(encryption_key).toUint8Array();
   const protectedHeader = Convert.base64Url(protectedHeaderB64U).toUint8Array();
   const additionalData = protectedHeader;
-  const additionalDataObj = Convert.base64Url(protectedHeaderB64U).toObject();
   const nonce = Convert.base64Url(nonceB64U).toUint8Array();
   const ciphertext = Convert.base64Url(ciphertextB64U).toUint8Array();
   const authenticationTag = Convert.base64Url(

--- a/packages/agent/src/oidc.ts
+++ b/packages/agent/src/oidc.ts
@@ -12,7 +12,13 @@ import {
 import { concatenateUrl } from './utils.js';
 import { xchacha20poly1305 } from '@noble/ciphers/chacha';
 import type { ConnectPermissionRequest } from './connect.js';
-import { DidDocument, DidJwk, DidResolutionResult, PortableDid, type BearerDid } from '@web5/dids';
+import {
+  DidDocument,
+  DidJwk,
+  DidResolutionResult,
+  PortableDid,
+  type BearerDid,
+} from '@web5/dids';
 import {
   DwnDataEncodedRecordsWriteMessage,
   DwnInterface,
@@ -291,7 +297,7 @@ async function createAuthRequest(
 async function encryptAuthRequest({
   jwt,
   encryptionKey,
-  kid
+  kid,
 }: {
   jwt: string;
   encryptionKey: Uint8Array;
@@ -302,7 +308,7 @@ async function encryptAuthRequest({
     cty : 'JWT',
     enc : 'XC20P',
     typ : 'JWT',
-    kid
+    kid,
   };
   const nonce = CryptoUtils.randomBytes(24);
   const additionalData = Convert.object(protectedHeader).toUint8Array();
@@ -438,7 +444,9 @@ const getAuthRequest = async (request_uri: string, encryption_key: string) => {
   })) as Web5ConnectAuthRequest;
 
   // get the pub DID that represents the client in ECDH and deriving a shared key
-  const header = Convert.base64Url(jwe.split('.')[0]).toObject() as JweHeaderParams;
+  const header = Convert.base64Url(
+    jwe.split('.')[0]
+  ).toObject() as JweHeaderParams;
 
   const clientEcdhDid = await DidJwk.resolve(header.kid!.split('#')[0]);
 
@@ -502,7 +510,9 @@ async function decryptWithPin(clientDid: BearerDid, jwe: string, pin: string) {
   const jweProviderEcdhDidKid = await DidJwk.resolve(header.kid!.split('#')[0]);
 
   if (!jweProviderEcdhDidKid.didDocument) {
-    throw new Error('Could not resolve provider\'s didd document for shared key derivation');
+    throw new Error(
+      'Could not resolve provider\'s didd document for shared key derivation'
+    );
   }
 
   // derive ECDH shared key using the provider's public key and our clientDid private key
@@ -638,7 +648,10 @@ function shouldUseDelegatePermission(scope: DwnPermissionScope): boolean {
   // In the future only methods that modify state will be delegated and the rest will be normal permissions
   if (isRecordPermissionScope(scope)) {
     return true;
-  } else if (scope.interface === DwnInterfaceName.Protocols && scope.method === DwnMethodName.Configure) {
+  } else if (
+    scope.interface === DwnInterfaceName.Protocols &&
+    scope.method === DwnMethodName.Configure
+  ) {
     // ProtocolConfigure messages are also delegated, as they modify state
     return true;
   }
@@ -675,7 +688,9 @@ async function createPermissionGrants(
     })
   );
 
-  logger.log(`Sending ${permissionGrants.length} permission grants to remote DWN...`);
+  logger.log(
+    `Sending ${permissionGrants.length} permission grants to remote DWN...`
+  );
   const messagePromises = permissionGrants.map(async (grant) => {
     // Quirk: we have to pull out encodedData out of the message the schema validator doesn't want it there
     const { encodedData, ...rawMessage } = grant.message;
@@ -718,7 +733,6 @@ async function prepareProtocol(
   agent: Web5Agent,
   protocolDefinition: DwnProtocolDefinition
 ): Promise<void> {
-
   const queryMessage = await agent.processDwnRequest({
     author        : selectedDid,
     messageType   : DwnInterface.ProtocolsQuery,
@@ -731,16 +745,22 @@ async function prepareProtocol(
     throw new Error(
       `Could not fetch protocol: ${queryMessage.reply.status.detail}`
     );
-  } else if (queryMessage.reply.entries === undefined || queryMessage.reply.entries.length === 0) {
-    logger.log(`Protocol does not exist, creating: ${protocolDefinition.protocol}`);
+  } else if (
+    queryMessage.reply.entries === undefined ||
+    queryMessage.reply.entries.length === 0
+  ) {
+    logger.log(
+      `Protocol does not exist, creating: ${protocolDefinition.protocol}`
+    );
 
     // send the protocol definition to the remote DWN first, if it passes we can process it locally
-    const { reply: sendReply, message: configureMessage } = await agent.sendDwnRequest({
-      author        : selectedDid,
-      target        : selectedDid,
-      messageType   : DwnInterface.ProtocolsConfigure,
-      messageParams : { definition: protocolDefinition },
-    });
+    const { reply: sendReply, message: configureMessage } =
+      await agent.sendDwnRequest({
+        author        : selectedDid,
+        target        : selectedDid,
+        messageType   : DwnInterface.ProtocolsConfigure,
+        messageParams : { definition: protocolDefinition },
+      });
 
     // check if the message was sent successfully, if the remote returns 409 the message may have come through already via sync
     if (sendReply.status.code !== 202 && sendReply.status.code !== 409) {
@@ -851,7 +871,9 @@ async function submitAuthResponse(
     });
 
     if (!clientEcdhDid.didDocument?.verificationMethod?.[0].id) {
-      throw new Error('Unable to resolve the encryption DID used by the client for ECDH');
+      throw new Error(
+        'Unable to resolve the encryption DID used by the client for ECDH'
+      );
     }
 
     const sharedKey = await Oidc.deriveSharedKey(

--- a/packages/agent/src/oidc.ts
+++ b/packages/agent/src/oidc.ts
@@ -673,6 +673,7 @@ async function createPermissionGrants(
   const permissionsApi = new AgentPermissionsApi({ agent });
 
   // TODO: cleanup all grants if one fails by deleting them from the DWN: https://github.com/TBD54566975/web5-js/issues/849
+  logger.log(`Creating permission grants for ${scopes.length} scopes given...`);
   const permissionGrants = await Promise.all(
     scopes.map((scope) => {
       // check if the scope is a records permission scope, or a protocol configure scope, if so it should use a delegated permission.
@@ -864,7 +865,7 @@ async function submitAuthResponse(
       delegatePortableDid,
     });
 
-    // Sign using the signing key
+    logger.log('Signing auth response object...');
     const responseObjectJwt = await Oidc.signJwt({
       did  : providerSigningDid,
       data : responseObject,
@@ -881,6 +882,7 @@ async function submitAuthResponse(
       clientEcdhDid?.didDocument
     );
 
+    logger.log('Encrypting auth response object...');
     const encryptedResponse = Oidc.encryptWithPin({
       jwt           : responseObjectJwt,
       encryptionKey : sharedKey,
@@ -893,6 +895,9 @@ async function submitAuthResponse(
       state    : authRequest.state,
     }).toString();
 
+    logger.log(
+      `Sending auth response object to Web5 Connect server: ${authRequest.redirect_uri}`
+    );
     await fetch(authRequest.redirect_uri, {
       body    : formEncodedRequest,
       method  : 'POST',

--- a/packages/api/src/web5.ts
+++ b/packages/api/src/web5.ts
@@ -270,7 +270,6 @@ export class Web5 {
         // TODO: In the future, implement a way to re-connect an already connected identity and apply additional grants/protocols
         identity = connectedIdentity;
       } else if (isWalletConnect) {
-        console.log('IN walletConnect (non export) case');
         if (sync === 'off') {
           // Currently we require sync to be enabled when using WalletConnect
           // This is to ensure a connected app is not in a disjointed state from any other clients/app using the connectedDid
@@ -294,7 +293,6 @@ export class Web5 {
               tenant : agent.agentDid.uri,
             }
           }});
-          console.log('does have an identity');
 
           // Attempts to process the connected grants to be used by the delegateDID
           // If the process fails, we want to clean up the identity
@@ -309,7 +307,6 @@ export class Web5 {
       } else if (isWalletExportedConnect) {
         throw new Error('Exported connect will be implemented in a separate PR');
       } else {
-        console.log('IN else case');
         // No connected identity found and no connectOptions provided, use local Identities
         // Query the Agent's DWN tenant for identity records.
         const identities = await userAgent.identity.list();

--- a/packages/api/src/web5.ts
+++ b/packages/api/src/web5.ts
@@ -280,11 +280,8 @@ export class Web5 {
         // Since we are connecting a new identity, we will want to register sync for the connectedDid
         registerSync = true;
 
-        // No connected identity found and connectOptions are provided, attempt to import a delegated DID from an external wallet
         try {
-          console.log('before initclient');
           const { delegatePortableDid, connectedDid, delegateGrants } = await WalletConnect.initClient(walletConnectOptions);
-          console.log('after initclient');
 
           // Import the delegated DID as an Identity in the User Agent.
           // Setting the connectedDID in the metadata applies a relationship between the signer identity and the one it is impersonating.
@@ -310,25 +307,7 @@ export class Web5 {
           throw new Error(`Failed to connect to wallet: ${error.message}`);
         }
       } else if (isWalletExportedConnect) {
-        console.log('IN EXPORT case');
-        if (sync === 'off') {
-          // sync must be enabled when using WalletConnect to ensure a connected app
-          // is not in a disjointed state from any other clients using the connectedDid
-          throw new Error('Sync must not be disabled when using WalletConnect');
-        }
-
-        // Since we are connecting a new identity, we will want to register sync for the connectedDid
-        registerSync = true;
-
-        try {
-          // TODO: do the exported connect
-        } catch (error:any) {
-          // clean up the DID and Identity if import fails and throw
-          // TODO: Implement the ability to purge all of our messages as a tenant
-          await this.cleanUpIdentity({ identity, userAgent });
-          throw new Error(`Failed to connect to wallet: ${error.message}`);
-        }
-      // else connecting to a locally held DID
+        throw new Error('Exported connect will be implemented in a separate PR');
       } else {
         console.log('IN else case');
         // No connected identity found and no connectOptions provided, use local Identities

--- a/packages/api/tests/web5.spec.ts
+++ b/packages/api/tests/web5.spec.ts
@@ -798,12 +798,7 @@ describe('web5 api', () => {
 
         sinon.stub(Web5UserAgent, 'create').resolves(testHarness.agent as Web5UserAgent);
 
-        // spy on the WalletConnect createPermissionRequestForProtocol method
-        const requestPermissionsSpy = sinon.spy(WalletConnect, 'createPermissionRequestForProtocol');
-
-        // We throw and spy on the initClient method to avoid the actual WalletConnect initialization
-        // but to still be able to spy on the passed parameters
-        sinon.stub(WalletConnect, 'initClient').throws('Error');
+        const createPermissionRequestForProtocolSpy = sinon.spy(WalletConnect, 'createPermissionRequestForProtocol');
 
         // stub the cleanUpIdentity method to avoid actual cleanup
         sinon.stub(Web5 as any, 'cleanUpIdentity').resolves();
@@ -837,12 +832,11 @@ describe('web5 api', () => {
 
           expect.fail('Should have thrown an error');
         } catch(error: any) {
-          // we expect an error because we stubbed the initClient method to throw it
-          expect(error.message).to.include('Sinon-provided Error');
+          // we expect an error because we aren't testing the whole e2e flow
+          expect(error.message).to.include('Failed to connect to wallet');
 
-          // The `createPermissionRequestForProtocol` method should have been called once for the provided protocol
-          expect(requestPermissionsSpy.callCount).to.equal(1);
-          const call = requestPermissionsSpy.getCall(0);
+          expect(createPermissionRequestForProtocolSpy.callCount).to.equal(1);
+          const call = createPermissionRequestForProtocolSpy.getCall(0);
 
           // since no explicit permissions were provided, all permissions should be requested
           expect(call.args[0].permissions).to.have.members([
@@ -857,10 +851,6 @@ describe('web5 api', () => {
 
         // spy on the WalletConnect createPermissionRequestForProtocol method
         const requestPermissionsSpy = sinon.spy(WalletConnect, 'createPermissionRequestForProtocol');
-
-        // We throw and spy on the initClient method to avoid the actual WalletConnect initialization
-        // but to still be able to spy on the passed parameters
-        sinon.stub(WalletConnect, 'initClient').throws('Error');
 
         // stub the cleanUpIdentity method to avoid actual cleanup
         sinon.stub(Web5 as any, 'cleanUpIdentity').resolves();
@@ -912,8 +902,8 @@ describe('web5 api', () => {
 
           expect.fail('Should have thrown an error');
         } catch(error: any) {
-          // we expect an error because we stubbed the initClient method to throw it
-          expect(error.message).to.include('Sinon-provided Error');
+          // we expect an error because we aren't testing the whole e2e flow
+          expect(error.message).to.include('Failed to connect to wallet');
 
           // The `createPermissionRequestForProtocol` method should have been called once for each provided request
           expect(requestPermissionsSpy.callCount).to.equal(2);

--- a/packages/api/tests/web5.spec.ts
+++ b/packages/api/tests/web5.spec.ts
@@ -795,7 +795,6 @@ describe('web5 api', () => {
       });
 
       it('should request all permissions for a protocol if no specific permissions are provided', async () => {
-
         sinon.stub(Web5UserAgent, 'create').resolves(testHarness.agent as Web5UserAgent);
 
         const createPermissionRequestForProtocolSpy = sinon.spy(WalletConnect, 'createPermissionRequestForProtocol');
@@ -818,7 +817,6 @@ describe('web5 api', () => {
         };
 
         try {
-
           await Web5.connect({
             walletConnectOptions: {
               displayName        : 'Sample App',
@@ -836,21 +834,23 @@ describe('web5 api', () => {
           expect(error.message).to.include('Failed to connect to wallet');
 
           expect(createPermissionRequestForProtocolSpy.callCount).to.equal(1);
-          const call = createPermissionRequestForProtocolSpy.getCall(0);
+          const result = createPermissionRequestForProtocolSpy.getCall(0).returnValue;
 
-          // since no explicit permissions were provided, all permissions should be requested
-          expect(call.args[0].permissions).to.have.members([
-            'read', 'write', 'delete', 'query', 'subscribe'
+          // Check if all permissions are included in the result
+          expect(result.permissionScopes).to.deep.include.members([
+            { protocol: protocolDefinition.protocol, interface: DwnInterfaceName.Records, method: DwnMethodName.Read },
+            { protocol: protocolDefinition.protocol, interface: DwnInterfaceName.Records, method: DwnMethodName.Write },
+            { protocol: protocolDefinition.protocol, interface: DwnInterfaceName.Records, method: DwnMethodName.Delete },
+            { protocol: protocolDefinition.protocol, interface: DwnInterfaceName.Records, method: DwnMethodName.Query },
+            { protocol: protocolDefinition.protocol, interface: DwnInterfaceName.Records, method: DwnMethodName.Subscribe }
           ]);
         }
       });
 
       it('should only request the specified permissions for a protocol', async () => {
-
         sinon.stub(Web5UserAgent, 'create').resolves(testHarness.agent as Web5UserAgent);
 
-        // spy on the WalletConnect createPermissionRequestForProtocol method
-        const requestPermissionsSpy = sinon.spy(WalletConnect, 'createPermissionRequestForProtocol');
+        const createPermissionRequestForProtocolSpy = sinon.spy(WalletConnect, 'createPermissionRequestForProtocol');
 
         // stub the cleanUpIdentity method to avoid actual cleanup
         sinon.stub(Web5 as any, 'cleanUpIdentity').resolves();
@@ -883,9 +883,7 @@ describe('web5 api', () => {
           }
         };
 
-
         try {
-
           await Web5.connect({
             walletConnectOptions: {
               displayName        : 'Sample App',
@@ -894,8 +892,8 @@ describe('web5 api', () => {
               validatePin        : async () => { return '1234'; },
               onWalletUriReady   : (_walletUri: string) => {},
               permissionRequests : [
-                { protocolDefinition: protocol1Definition }, // no permissions provided, expect all permissions to be requested
-                { protocolDefinition: protocol2Definition, permissions: ['read', 'write'] } // only read and write permissions provided
+                { protocolDefinition: protocol1Definition },
+                { protocolDefinition: protocol2Definition, permissions: ['read', 'write'] }
               ]
             }
           });
@@ -905,20 +903,28 @@ describe('web5 api', () => {
           // we expect an error because we aren't testing the whole e2e flow
           expect(error.message).to.include('Failed to connect to wallet');
 
-          // The `createPermissionRequestForProtocol` method should have been called once for each provided request
-          expect(requestPermissionsSpy.callCount).to.equal(2);
-          const call1 = requestPermissionsSpy.getCall(0);
+          expect(createPermissionRequestForProtocolSpy.callCount).to.equal(2);
+          const result1 = createPermissionRequestForProtocolSpy.getCall(0).returnValue;
+          const result2 = createPermissionRequestForProtocolSpy.getCall(1).returnValue;
 
-          // since no explicit permissions were provided for the first protocol, all permissions should be requested
-          expect(call1.args[0].permissions).to.have.members([
-            'read', 'write', 'delete', 'query', 'subscribe'
+          // Check if all permissions are included for the first protocol
+          expect(result1.permissionScopes).to.deep.include.members([
+            { protocol: protocol1Definition.protocol, interface: DwnInterfaceName.Records, method: DwnMethodName.Read },
+            { protocol: protocol1Definition.protocol, interface: DwnInterfaceName.Records, method: DwnMethodName.Write },
+            { protocol: protocol1Definition.protocol, interface: DwnInterfaceName.Records, method: DwnMethodName.Delete },
+            { protocol: protocol1Definition.protocol, interface: DwnInterfaceName.Records, method: DwnMethodName.Query },
+            { protocol: protocol1Definition.protocol, interface: DwnInterfaceName.Records, method: DwnMethodName.Subscribe }
           ]);
 
-          const call2 = requestPermissionsSpy.getCall(1);
-
-          // only the provided permissions should be requested for the second protocol
-          expect(call2.args[0].permissions).to.have.members([
-            'read', 'write'
+          // Check if only read and write permissions are included for the second protocol
+          expect(result2.permissionScopes).to.deep.include.members([
+            { protocol: protocol2Definition.protocol, interface: DwnInterfaceName.Records, method: DwnMethodName.Read },
+            { protocol: protocol2Definition.protocol, interface: DwnInterfaceName.Records, method: DwnMethodName.Write }
+          ]);
+          expect(result2.permissionScopes).to.not.deep.include.members([
+            { protocol: protocol2Definition.protocol, interface: DwnInterfaceName.Records, method: DwnMethodName.Delete },
+            { protocol: protocol2Definition.protocol, interface: DwnInterfaceName.Records, method: DwnMethodName.Query },
+            { protocol: protocol2Definition.protocol, interface: DwnInterfaceName.Records, method: DwnMethodName.Subscribe }
           ]);
         }
       });


### PR DESCRIPTION
### Context

The web5 connect flow previously relied on the delegateDid in order to encrypt, sign + verify and move the workflow from step to step.

While this worked for an MVP implementation to get the release out the door, it had a number of issues. The same DID should not have been used for sign/verify as is used for encryption and that same DID should also not be used for persistent delegation.

The code was implemented with TODOs knowing that this would need to be enhanced but the enhancements were slated as security enhancements only. 

When the "export" flow was proposed it turned out that this code would need to be fixed immediately. In the export flow the delegation is only transferred at the end of the connect flow. This means that you therefore cannot rely on the delegation for the creation of shared encryption keys. 

Therefore fixing this security issue became a priority and a prerequisite for the "export" flow.

### Implementation

1. Here I have implemented the suggested fixes by creating separate DIDs for signing and verification, encryption, and delegation. 
2. I have also mapped out the export flow, which will come in a separate PR.
3. I cleaned up some comments 
4. I deduped the connect types, which I was able to simplify significantly.
5. I moved the `permissions` helper into the `initClient` method to reduce the amount of boilerplate going on in the `Web5` class

### Breaking changes for wallet authors.

web5 connect's `getAuthRequest()` now returns an object which include both the authRequest and a DID:

```ts
{
  authRequest: Web5ConnectAuthRequest;
  clientEcdhDid: DidResolutionResult;
}
```

web5 connect's `submitAuthResponse()` now requires that the did received from `getAuthRequest()` is passed in to the method at position 4:

```ts
async function submitAuthResponse(
  selectedDid: string,
  authRequest: Web5ConnectAuthRequest,
  randomPin: string,
  clientEcdhDid: DidResolutionResult,
  agent: Web5Agent
) { ... }